### PR TITLE
Use option-menu for navigation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,3 +42,4 @@ kaleido
 websockets
 plotly
 pyvis
+streamlit-option-menu

--- a/ui.py
+++ b/ui.py
@@ -1,5 +1,6 @@
 import os
 import streamlit as st  # ensure Streamlit is imported early
+from streamlit_option_menu import option_menu
 
 # STRICTLY A SOCIAL MEDIA PLATFORM
 # Intellectual Property & Artistic Inspiration
@@ -916,7 +917,22 @@ def main() -> None:
         return
 
     render_main_ui()
-    choice = st.sidebar.selectbox("Page", page_files)
+
+    icon_map = {
+        "agents": "robot",
+        "social": "people",
+        "validation": "check-circle",
+        "voting": "check-square",
+    }
+
+    with st.sidebar:
+        choice = option_menu(
+            "Navigation",
+            page_files,
+            icons=[icon_map.get(p, "file") for p in page_files],
+            menu_icon="list",
+            default_index=0,
+        )
 
     try:
         module = import_module(f"transcendental_resonance_frontend.pages.{choice}")


### PR DESCRIPTION
## Summary
- add streamlit-option-menu to dependencies
- swap selectbox for option menu navigation with icons

## Testing
- `pytest -q transcendental_resonance_frontend/tests` *(fails: 27 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68891c56074083209c700e50b4077762