### PR TITLE
Improve Streamlit UI theme

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -9,12 +9,13 @@ from importlib import util
 from pathlib import Path
 
 ROOT_TESTS_CONFTST = Path(__file__).resolve().parent / "tests" / "conftest.py"
-spec = util.spec_from_file_location("root_tests_conftest", ROOT_TESTS_CONFTST)
-_module = util.module_from_spec(spec)
-assert spec.loader is not None
-sys.modules[spec.name] = _module
-spec.loader.exec_module(_module)
+if ROOT_TESTS_CONFTST.exists():
+    spec = util.spec_from_file_location("root_tests_conftest", ROOT_TESTS_CONFTST)
+    _module = util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = _module
+    spec.loader.exec_module(_module)
 
-globals().update(
-    {name: getattr(_module, name) for name in dir(_module) if not name.startswith("_")}
-)
+    globals().update(
+        {name: getattr(_module, name) for name in dir(_module) if not name.startswith("_")}
+    )

--- a/streamlit_helpers.py
+++ b/streamlit_helpers.py
@@ -42,17 +42,27 @@ def header(title: str, *, layout: str = "centered") -> None:
 
 
 def apply_theme(theme: str) -> None:
-    """Apply light or dark theme styles based on ``theme``."""
+    """Apply light, dark or modern theme styles based on ``theme``."""
     if theme == "dark":
         css = """
             <style>
-            body, .stApp { background-color: #1e1e1e; color: #f0f0f0; }
+            @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap');
+            body, .stApp { background-color: #1e1e1e; color: #f0f0f0; font-family: 'Inter', sans-serif; }
+            </style>
+        """
+    elif theme == "modern":
+        css = """
+            <style>
+            @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap');
+            body, .stApp { background-color: #f5f5f5; color: #333333; font-family: 'Inter', sans-serif; }
+            .stButton > button { background-color: #0a66c2; color: #ffffff; border-radius: 6px; }
             </style>
         """
     else:
         css = """
             <style>
-            body, .stApp { background-color: #ffffff; color: #000000; }
+            @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap');
+            body, .stApp { background-color: #ffffff; color: #000000; font-family: 'Inter', sans-serif; }
             </style>
         """
     st.markdown(css, unsafe_allow_html=True)
@@ -62,12 +72,10 @@ def theme_selector(label: str = "Theme") -> str:
     """Render a radio selector for the app theme and return the choice."""
     if "theme" not in st.session_state:
         st.session_state["theme"] = "light"
-    choice = st.radio(
-        label,
-        ["Light", "Dark"],
-        index=(1 if st.session_state["theme"] == "dark" else 0),
-        horizontal=True,
-    )
+    themes = ["Light", "Dark", "Modern"]
+    current = st.session_state["theme"].capitalize()
+    idx = themes.index(current) if current in themes else 0
+    choice = st.radio(label, themes, index=idx, horizontal=True)
     st.session_state["theme"] = choice.lower()
     apply_theme(st.session_state["theme"])
     return st.session_state["theme"]

--- a/ui.py
+++ b/ui.py
@@ -61,7 +61,13 @@ from streamlit_helpers import (
     theme_selector,
 )
 from api_key_input import render_api_key_ui, render_simulation_stubs
-from ui_utils import load_rfc_entries, parse_summary, summarize_text, render_main_ui
+from ui_utils import (
+    load_rfc_entries,
+    parse_summary,
+    summarize_text,
+    render_main_ui,
+    render_landing_page,
+)
 
 
 def _run_async(coro):
@@ -888,6 +894,10 @@ def main() -> None:
     from importlib import import_module
 
     st.set_page_config(page_title="superNova_2177", layout="wide")
+
+    if "theme" not in st.session_state:
+        st.session_state["theme"] = "modern"
+    apply_theme(st.session_state["theme"])
 
     # Unified health check using query params or PATH_INFO
     params = st.query_params

--- a/ui_utils.py
+++ b/ui_utils.py
@@ -5,6 +5,7 @@
 
 from pathlib import Path
 import streamlit as st
+from streamlit_helpers import header, centered_container
 
 
 def summarize_text(text: str, max_len: int = 150) -> str:
@@ -50,8 +51,22 @@ def load_rfc_entries(rfc_dir: Path):
 
 def render_main_ui() -> None:
     """Render a minimal placeholder for the Streamlit dashboard."""
-    st.title("superNova_2177")
-    st.write("UI initialization complete.")
+    header("superNova_2177 Dashboard", layout="wide")
+    with centered_container():
+        st.write("Select a page from the sidebar to begin.")
+
+
+def render_landing_page() -> None:
+    """Render a simple landing page shown when no pages are available."""
+    header("superNova_2177", layout="wide")
+    with centered_container():
+        st.markdown(
+            "<h2 style='text-align:center;'>Welcome to the modern interface.</h2>",
+            unsafe_allow_html=True,
+        )
+        st.write(
+            "Use the navigation sidebar to explore validations, social feeds and voting tools."
+        )
 
 
 __all__ = [
@@ -59,4 +74,5 @@ __all__ = [
     "parse_summary",
     "load_rfc_entries",
     "render_main_ui",
+    "render_landing_page",
 ]


### PR DESCRIPTION
## Summary
- modernize UI helpers with a new "modern" theme and selector
- add a simple landing page and refresh main layout helpers
- default UI to the modern theme
- make root conftest optional if tests are missing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: frontend_bridge)*

------
https://chatgpt.com/codex/tasks/task_e_68891bce0e84832083c56c7e58e3418d