### PR TITLE
Add st-aggrid requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -47,3 +47,4 @@ plotly
 pyvis
 streamlit-option-menu
 streamlit-aggrid
+st-aggrid


### PR DESCRIPTION
## Summary
- add missing `st-aggrid` to requirements

## Testing
- `pytest -q` *(fails: FileNotFoundError for /workspace/streamlit-test/tests/conftest.py)*

------
https://chatgpt.com/codex/tasks/task_e_688920b6f4d8832087056a0b3faff57e