### PR TITLE
Refine button styling and alerts

### DIFF
--- a/streamlit_helpers.py
+++ b/streamlit_helpers.py
@@ -15,21 +15,26 @@ from typing import Literal
 import streamlit as st
 
 
-def alert(message: str, level: Literal["warning", "error", "info"] = "info") -> None:
+def alert(
+    message: str,
+    level: Literal["warning", "error", "info"] = "info",
+    *,
+    show_icon: bool = True,
+) -> None:
     """Display a minimally intrusive alert box."""
     icons = {"warning": "\u26A0", "error": "\u274C", "info": "\u2139"}
     colors = {
-        "warning": ("#2c2b24", "#997a00"),
-        "error": ("#352626", "#cc0000"),
-        "info": ("#1f2d3d", "#1e88e5"),
+        "warning": ("#fff7e6", "#f0ad4e"),
+        "error": ("#fdecea", "#f44336"),
+        "info": ("#e8f4fd", "#1e88e5"),
     }
     bg_color, border_color = colors.get(level, colors["info"])
-    icon = icons.get(level, "")
+    icon_html = f"<span class='icon'>{icons.get(level, '')}</span>" if show_icon else ""
     st.markdown(
         f"<div class='custom-alert' style='border-left:4px solid {border_color};"
         f"background-color:{bg_color};padding:0.5em;border-radius:4px;"
         f"margin-bottom:1em;display:flex;align-items:center;gap:0.5rem;'>"
-        f"<span class='icon'>{icon}</span>{html.escape(message)}</div>",
+        f"{icon_html}{html.escape(message)}</div>",
         unsafe_allow_html=True,
     )
 

--- a/ui.py
+++ b/ui.py
@@ -59,6 +59,9 @@ from streamlit_helpers import (
     header,
     theme_selector,
 )
+
+# Accent color used for button styling
+ACCENT_COLOR = "#4f8bf9"
 from api_key_input import render_api_key_ui, render_simulation_stubs
 from ui_utils import load_rfc_entries, parse_summary, summarize_text, render_main_ui
 
@@ -833,6 +836,20 @@ def main() -> None:
     from importlib import import_module
 
     st.set_page_config(page_title="superNova_2177", layout="wide")
+
+    # Inject global button styles
+    st.markdown(
+        f"""
+        <style>
+        .stButton>button {{
+            border-radius: 6px;
+            background-color: {ACCENT_COLOR};
+            color: white;
+        }}
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
 
     # Unified health check using query params or PATH_INFO
     params = st.query_params


### PR DESCRIPTION
## Summary
- globally style Streamlit buttons with a blue accent
- soften alert colors and make icons optional

## Testing
- `pytest -q` *(fails: FileNotFoundError for tests/conftest.py)*

------
https://chatgpt.com/codex/tasks/task_e_6889216275a88320bb73f79849e4f568