### PR TITLE
Add UI spinners and success toasts

### DIFF
--- a/social_tabs.py
+++ b/social_tabs.py
@@ -27,8 +27,10 @@ def render_social_tab() -> None:
         return
     username = st.text_input("Username")
     if st.button("Follow/Unfollow") and username:
-        try:
-            result = _run_async(dispatch_route("follow_user", {"username": username}))
-            st.json(result)
-        except Exception as exc:  # pragma: no cover - UI feedback
-            alert(f"Operation failed: {exc}", "error")
+        with st.spinner("Working on it..."):
+            try:
+                result = _run_async(dispatch_route("follow_user", {"username": username}))
+                st.json(result)
+                st.toast("Success!")
+            except Exception as exc:  # pragma: no cover - UI feedback
+                alert(f"Operation failed: {exc}", "error")

--- a/ui.py
+++ b/ui.py
@@ -637,24 +637,28 @@ def render_validation_ui() -> None:
                 if st.button("Run Audit") and hid:
                     if dispatch_route and SessionLocal:
                         with SessionLocal() as db:
-                            try:
-                                result = _run_async(
-                                    dispatch_route(
-                                        "trigger_full_audit",
-                                        {"hypothesis_id": hid},
-                                        db=db,
+                            with st.spinner("Working on it..."):
+                                try:
+                                    result = _run_async(
+                                        dispatch_route(
+                                            "trigger_full_audit",
+                                            {"hypothesis_id": hid},
+                                            db=db,
+                                        )
                                     )
-                                )
-                                st.json(result)
-                            except Exception as exc:
-                                st.error(f"Audit failed: {exc}")
+                                    st.json(result)
+                                    st.toast("Success!")
+                                except Exception as exc:
+                                    st.error(f"Audit failed: {exc}")
                     elif run_full_audit and SessionLocal:
                         with SessionLocal() as db:
-                            try:
-                                result = run_full_audit(hid, db)
-                                st.json(result)
-                            except Exception as exc:
-                                st.error(f"Audit failed: {exc}")
+                            with st.spinner("Working on it..."):
+                                try:
+                                    result = run_full_audit(hid, db)
+                                    st.json(result)
+                                    st.toast("Success!")
+                                except Exception as exc:
+                                    st.error(f"Audit failed: {exc}")
                     else:
                         st.info("Audit functionality unavailable")
 


### PR DESCRIPTION
## Summary
- show loading spinner and success toast when following users
- add spinner and success toast to audit run action

## Testing
- `pytest -q` *(fails: FileNotFoundError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_688921656f4c8320ac0f470e9f6d1e98