### PR TITLE
Add spinner and toast for long actions

### DIFF
--- a/social_tabs.py
+++ b/social_tabs.py
@@ -27,8 +27,12 @@ def render_social_tab() -> None:
         return
     username = st.text_input("Username")
     if st.button("Follow/Unfollow") and username:
-        try:
-            result = _run_async(dispatch_route("follow_user", {"username": username}))
-            st.json(result)
-        except Exception as exc:  # pragma: no cover - UI feedback
-            alert(f"Operation failed: {exc}", "error")
+        with st.spinner("Working on it..."):
+            try:
+                result = _run_async(
+                    dispatch_route("follow_user", {"username": username})
+                )
+                st.json(result)
+                st.toast("Success!")
+            except Exception as exc:  # pragma: no cover - UI feedback
+                alert(f"Operation failed: {exc}", "error")


### PR DESCRIPTION
## Summary
- wrap social follow/unfollow action in a spinner block
- show toast on follow/unfollow success
- wrap audit, event processing, flow execution and agent run actions with spinner
- show success toast after these long-running actions

## Testing
- `pytest -q` *(fails: FileNotFoundError for tests/conftest.py)*

------
https://chatgpt.com/codex/tasks/task_e_6889209269ec8320b58b8c8eb4156024