### PR TITLE
Add card layout and custom theme

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -2,8 +2,8 @@
 # Intellectual Property & Artistic Inspiration
 # Legal & Ethical Safeguards
 [theme]
-primaryColor="#1E88E5"
-backgroundColor="#0E1117"
-secondaryBackgroundColor="#262730"
-textColor="#FAFAFA"
+primaryColor="#2A7AE2"
+backgroundColor="#F3F4F6"
+secondaryBackgroundColor="#FFFFFF"
+textColor="#111827"
 font="sans serif"

--- a/app.py
+++ b/app.py
@@ -1,2 +1,8 @@
 import streamlit as st
+from streamlit_helpers import inject_global_styles
+
+inject_global_styles()
+
+st.markdown("<div class='card'>", unsafe_allow_html=True)
 st.title("It Works!")
+st.markdown("</div>", unsafe_allow_html=True)

--- a/streamlit_helpers.py
+++ b/streamlit_helpers.py
@@ -70,11 +70,22 @@ def inject_global_styles() -> None:
     st.markdown(
         """
         <style>
+        body, .stApp {
+            background-color: #F3F4F6;
+        }
         .custom-container {
             padding: 1rem;
             border-radius: 8px;
-            border: 1px solid rgba(255,255,255,0.1);
-            box-shadow: 0 2px 4px rgba(0,0,0,0.4);
+            border: 1px solid rgba(0, 0, 0, 0.05);
+            box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+            margin-bottom: 1rem;
+        }
+        .card {
+            background-color: #FFFFFF;
+            padding: 1rem;
+            border: 1px solid rgba(0, 0, 0, 0.1);
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
             margin-bottom: 1rem;
         }
         .stButton>button {border-radius:6px;}


### PR DESCRIPTION
## Summary
- define a professional color palette in `.streamlit/config.toml`
- inject global styles with card component and contrasting page background
- use the new card style in `app.py`

## Testing
- `pytest -q` *(fails: FileNotFoundError for tests/conftest.py)*

------
https://chatgpt.com/codex/tasks/task_e_688927a15f708320bd01acc87502b210