### PR TITLE
Add card layout theme with CSS

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -2,8 +2,8 @@
 # Intellectual Property & Artistic Inspiration
 # Legal & Ethical Safeguards
 [theme]
-primaryColor="#1E88E5"
-backgroundColor="#0E1117"
-secondaryBackgroundColor="#262730"
-textColor="#FAFAFA"
+primaryColor="#4A90E2"
+backgroundColor="#F0F2F6"
+secondaryBackgroundColor="#FFFFFF"
+textColor="#333333"
 font="sans serif"

--- a/app.py
+++ b/app.py
@@ -1,2 +1,29 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
 import streamlit as st
+
+st.set_page_config(page_title="Card Layout Demo")
+
+st.markdown(
+    """
+    <style>
+    body {
+        background-color: #F0F2F6;
+    }
+    .card {
+        background-color: #FFFFFF;
+        padding: 1rem;
+        border: 1px solid #E1E1E1;
+        border-radius: 8px;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    }
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
+
 st.title("It Works!")
+
+st.markdown('<div class="card">This is a card with custom styling.</div>', unsafe_allow_html=True)


### PR DESCRIPTION
## Summary
- tweak theme colors and font in `.streamlit/config.toml`
- inject global CSS for `.card` component in `app.py`
- demo a card in the Streamlit app

## Testing
- `pytest -q` *(fails: FileNotFoundError for tests)*
- `mypy` *(fails: invalid package name)*

------
https://chatgpt.com/codex/tasks/task_e_688927a15f708320bd01acc87502b210