### PR TITLE
Redesign proposals tab layout

### DIFF
--- a/voting_ui.py
+++ b/voting_ui.py
@@ -44,34 +44,52 @@ def render_proposals_tab() -> None:
             "warning",
         )
         return
-    with st.container():
-        st.markdown(BOX_CSS + "<div class='tab-box'>", unsafe_allow_html=True)
-        if st.button("Refresh Proposals"):
-            with st.spinner("Working on it..."):
-                try:
-                    res = _run_async(dispatch_route("list_proposals", {}))
-                    st.session_state["proposals_cache"] = res.get("proposals", [])
-                    st.toast("Success!")
-                except Exception as exc:
-                    alert(f"Failed to load proposals: {exc}", "error")
 
-    proposals = st.session_state.get("proposals_cache", [])
-    if proposals:
-        simple = [
-            {
-                "id": p.get("id"),
-                "title": p.get("title"),
-                "status": p.get("status"),
-                "deadline": p.get("voting_deadline"),
-            }
-            for p in proposals
-        ]
-        df = pd.DataFrame(simple)
-        gb = GridOptionsBuilder.from_dataframe(df)
-        gb.configure_default_column(filter=True, sortable=True, resizable=True)
-        AgGrid(df, gridOptions=gb.build(), theme="streamlit", fit_columns_on_grid_load=True)
+    st.markdown(
+        BOX_CSS
+        + """
+        <style>
+        .app-container { padding: 1rem; }
+        .card {
+            background: #fff;
+            border-radius: 8px;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        .card input,
+        .card textarea,
+        .card select {
+            border-radius: 8px;
+            padding: 0.5rem;
+        }
+        .button-primary > button {
+            background-color: #1DA1F2;
+            color: #fff;
+            border-radius: 8px;
+        }
+        .ag-theme-streamlit .ag-header,
+        .ag-theme-streamlit .ag-header-viewport {
+            background-color: #1DA1F2 !important;
+        }
+        .ag-theme-streamlit .ag-header-cell-label {
+            color: #fff;
+            font-weight: bold;
+        }
+        .ag-grid-container {
+            max-height: 400px;
+            overflow-y: auto;
+        }
+        </style>
+        <div class='app-container'>
+        """,
+        unsafe_allow_html=True,
+    )
 
-    with st.container():
+    col1, col2 = st.columns([1, 1])
+
+    with col1:
+        st.markdown("<div class='card'>", unsafe_allow_html=True)
         with st.form("create_proposal_form"):
             st.write("Create Proposal")
             title = st.text_input("Title")
@@ -79,7 +97,62 @@ def render_proposals_tab() -> None:
             author_id = st.number_input("Author ID", value=1, step=1)
             group_id = st.text_input("Group ID")
             voting_deadline = st.date_input("Voting Deadline")
+            st.markdown("<div class='button-primary'>", unsafe_allow_html=True)
             submitted = st.form_submit_button("Create")
+            st.markdown("</div>", unsafe_allow_html=True)
+        st.markdown("</div>", unsafe_allow_html=True)
+
+    with col2:
+        st.markdown("<div class='card'>", unsafe_allow_html=True)
+        st.markdown("<div class='button-primary'>", unsafe_allow_html=True)
+        if st.button("Refresh Proposals", key="refresh_proposals"):
+            with st.spinner("Working on it..."):
+                try:
+                    res = _run_async(dispatch_route("list_proposals", {}))
+                    st.session_state["proposals_cache"] = res.get("proposals", [])
+                    st.toast("Success!")
+                except Exception as exc:
+                    alert(f"Failed to load proposals: {exc}", "error")
+        st.markdown("</div>", unsafe_allow_html=True)
+
+        proposals = st.session_state.get("proposals_cache", [])
+        if proposals:
+            simple = [
+                {
+                    "id": p.get("id"),
+                    "title": p.get("title"),
+                    "status": p.get("status"),
+                    "deadline": p.get("voting_deadline"),
+                }
+                for p in proposals
+            ]
+            df = pd.DataFrame(simple)
+            gb = GridOptionsBuilder.from_dataframe(df)
+            gb.configure_default_column(filter=True, sortable=True, resizable=True)
+            st.markdown("<div class='ag-grid-container'>", unsafe_allow_html=True)
+            AgGrid(
+                df,
+                gridOptions=gb.build(),
+                theme="streamlit",
+                fit_columns_on_grid_load=True,
+            )
+            st.markdown("</div>", unsafe_allow_html=True)
+
+        with st.form("vote_proposal_form"):
+            st.write("Vote on Proposal")
+            ids = [p.get("id") for p in proposals]
+            prop_id = (
+                st.selectbox("Proposal", ids)
+                if ids
+                else st.number_input("Proposal ID", value=1, step=1)
+            )
+            harmonizer_id = st.number_input(
+                "Harmonizer ID", value=1, step=1, key="harmonizer_id_vote"
+            )
+            vote_choice = st.selectbox("Vote", ["yes", "no", "abstain"])
+            vote_sub = st.form_submit_button("Submit Vote")
+        st.markdown("</div>", unsafe_allow_html=True)
+
     if submitted:
         payload = {
             "title": title,
@@ -96,20 +169,6 @@ def render_proposals_tab() -> None:
             except Exception as exc:
                 alert(f"Create failed: {exc}", "error")
 
-    with st.container():
-        with st.form("vote_proposal_form"):
-            st.write("Vote on Proposal")
-            ids = [p.get("id") for p in proposals]
-            prop_id = (
-                st.selectbox("Proposal", ids)
-                if ids
-                else st.number_input("Proposal ID", value=1, step=1)
-            )
-            harmonizer_id = st.number_input(
-                "Harmonizer ID", value=1, step=1, key="harmonizer_id_vote"
-            )
-            vote_choice = st.selectbox("Vote", ["yes", "no", "abstain"])
-            vote_sub = st.form_submit_button("Submit Vote")
     if vote_sub:
         payload = {
             "proposal_id": prop_id,
@@ -123,7 +182,8 @@ def render_proposals_tab() -> None:
                 st.toast("Success!")
             except Exception as exc:
                 alert(f"Vote failed: {exc}", "error")
-        st.markdown("</div>", unsafe_allow_html=True)
+
+    st.markdown("</div>", unsafe_allow_html=True)
 
 
 def render_governance_tab() -> None:
@@ -150,7 +210,9 @@ def render_governance_tab() -> None:
         df = pd.DataFrame(votes)
         gb = GridOptionsBuilder.from_dataframe(df)
         gb.configure_default_column(filter=True, sortable=True, resizable=True)
-        AgGrid(df, gridOptions=gb.build(), theme="streamlit", fit_columns_on_grid_load=True)
+        AgGrid(
+            df, gridOptions=gb.build(), theme="streamlit", fit_columns_on_grid_load=True
+        )
 
     with st.container():
         with st.form("record_vote_form"):
@@ -231,6 +293,7 @@ def render_agent_ops_tab() -> None:
                 alert(f"Step failed: {exc}", "error")
         st.markdown("</div>", unsafe_allow_html=True)
 
+
 def render_logs_tab() -> None:
     """Provide simple audit trace explanation."""
     if dispatch_route is None:
@@ -250,7 +313,9 @@ def render_logs_tab() -> None:
             else:
                 with st.spinner("Working on it..."):
                     try:
-                        res = _run_async(dispatch_route("explain_audit", {"trace": trace}))
+                        res = _run_async(
+                            dispatch_route("explain_audit", {"trace": trace})
+                        )
                         st.text_area("Explanation", value=res, height=150)
                         st.toast("Success!")
                     except Exception as exc:
@@ -261,12 +326,14 @@ def render_logs_tab() -> None:
 def render_voting_tab() -> None:
     """High level tab combining proposal and vote management."""
     inject_global_styles()
-    sub1, sub2, sub3, sub4 = st.tabs([
-        "Proposal Hub",
-        "Governance",
-        "Agent Ops",
-        "Logs",
-    ])
+    sub1, sub2, sub3, sub4 = st.tabs(
+        [
+            "Proposal Hub",
+            "Governance",
+            "Agent Ops",
+            "Logs",
+        ]
+    )
     with sub1:
         render_proposals_tab()
     with sub2:


### PR DESCRIPTION
## Summary
- revamp `render_proposals_tab` with two-column layout
- introduce modern card-based UI with styled buttons
- make proposal table responsive with custom header style

## Testing
- `python -m py_compile voting_ui.py`
- `black voting_ui.py`
- `pytest -q` *(fails: FileNotFoundError in tests setup)*
- `mypy` *(fails: not a valid Python package name)*

------
https://chatgpt.com/codex/tasks/task_e_68892e04a0f883208b2fec8b17f5aedb