### PR TITLE
Add styled proposal UI

### DIFF
--- a/voting_ui.py
+++ b/voting_ui.py
@@ -44,8 +44,61 @@ def render_proposals_tab() -> None:
             "warning",
         )
         return
-    with st.container():
-        st.markdown(BOX_CSS + "<div class='tab-box'>", unsafe_allow_html=True)
+
+    # inject styling for the modern layout
+    st.markdown(
+        BOX_CSS
+        + """
+        <style>
+            .app-container {padding: 1rem;}
+            .card {
+                background-color: #ffffff;
+                border-radius: 8px;
+                padding: 1rem;
+                box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+                margin-bottom: 1rem;
+            }
+            .card input,
+            .card textarea,
+            .card select {
+                border-radius: 8px;
+                padding: 0.5rem;
+            }
+            .button-primary {
+                background-color: #1DA1F2;
+                color: #fff;
+                border: none;
+                border-radius: 8px;
+                padding: 0.5rem 1rem;
+            }
+            .ag-header {background-color: #1DA1F2 !important;}
+            .ag-header-cell-label {font-weight: bold; color: #ffffff;}
+            .ag-root-wrapper {max-height: 400px !important; overflow: auto;}
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+
+    st.markdown("<div class='app-container'>", unsafe_allow_html=True)
+
+    left_col, right_col = st.columns([1, 1])
+
+    # left column - create proposal form
+    with left_col:
+        st.markdown("<div class='card'>", unsafe_allow_html=True)
+        with st.form("create_proposal_form"):
+            st.write("Create Proposal")
+            title = st.text_input("Title")
+            description = st.text_area("Description")
+            author_id = st.number_input("Author ID", value=1, step=1)
+            group_id = st.text_input("Group ID")
+            voting_deadline = st.date_input("Voting Deadline")
+            submitted = st.form_submit_button("Create")
+        st.markdown("</div>", unsafe_allow_html=True)
+
+    # right column - refresh, table, vote form
+    with right_col:
+        st.markdown("<div class='card'>", unsafe_allow_html=True)
         if st.button("Refresh Proposals"):
             with st.spinner("Working on it..."):
                 try:
@@ -55,31 +108,42 @@ def render_proposals_tab() -> None:
                 except Exception as exc:
                     alert(f"Failed to load proposals: {exc}", "error")
 
-    proposals = st.session_state.get("proposals_cache", [])
-    if proposals:
-        simple = [
-            {
-                "id": p.get("id"),
-                "title": p.get("title"),
-                "status": p.get("status"),
-                "deadline": p.get("voting_deadline"),
-            }
-            for p in proposals
-        ]
-        df = pd.DataFrame(simple)
-        gb = GridOptionsBuilder.from_dataframe(df)
-        gb.configure_default_column(filter=True, sortable=True, resizable=True)
-        AgGrid(df, gridOptions=gb.build(), theme="streamlit", fit_columns_on_grid_load=True)
+        proposals = st.session_state.get("proposals_cache", [])
+        if proposals:
+            simple = [
+                {
+                    "id": p.get("id"),
+                    "title": p.get("title"),
+                    "status": p.get("status"),
+                    "deadline": p.get("voting_deadline"),
+                }
+                for p in proposals
+            ]
+            df = pd.DataFrame(simple)
+            gb = GridOptionsBuilder.from_dataframe(df)
+            gb.configure_default_column(filter=True, sortable=True, resizable=True)
+            AgGrid(
+                df,
+                gridOptions=gb.build(),
+                theme="streamlit",
+                fit_columns_on_grid_load=True,
+            )
 
-    with st.container():
-        with st.form("create_proposal_form"):
-            st.write("Create Proposal")
-            title = st.text_input("Title")
-            description = st.text_area("Description")
-            author_id = st.number_input("Author ID", value=1, step=1)
-            group_id = st.text_input("Group ID")
-            voting_deadline = st.date_input("Voting Deadline")
-            submitted = st.form_submit_button("Create")
+        with st.form("vote_proposal_form"):
+            st.write("Vote on Proposal")
+            ids = [p.get("id") for p in proposals]
+            prop_id = (
+                st.selectbox("Proposal", ids)
+                if ids
+                else st.number_input("Proposal ID", value=1, step=1)
+            )
+            harmonizer_id = st.number_input(
+                "Harmonizer ID", value=1, step=1, key="harmonizer_id_vote"
+            )
+            vote_choice = st.selectbox("Vote", ["yes", "no", "abstain"])
+            vote_sub = st.form_submit_button("Submit Vote")
+        st.markdown("</div>", unsafe_allow_html=True)
+
     if submitted:
         payload = {
             "title": title,
@@ -96,20 +160,6 @@ def render_proposals_tab() -> None:
             except Exception as exc:
                 alert(f"Create failed: {exc}", "error")
 
-    with st.container():
-        with st.form("vote_proposal_form"):
-            st.write("Vote on Proposal")
-            ids = [p.get("id") for p in proposals]
-            prop_id = (
-                st.selectbox("Proposal", ids)
-                if ids
-                else st.number_input("Proposal ID", value=1, step=1)
-            )
-            harmonizer_id = st.number_input(
-                "Harmonizer ID", value=1, step=1, key="harmonizer_id_vote"
-            )
-            vote_choice = st.selectbox("Vote", ["yes", "no", "abstain"])
-            vote_sub = st.form_submit_button("Submit Vote")
     if vote_sub:
         payload = {
             "proposal_id": prop_id,
@@ -123,7 +173,8 @@ def render_proposals_tab() -> None:
                 st.toast("Success!")
             except Exception as exc:
                 alert(f"Vote failed: {exc}", "error")
-        st.markdown("</div>", unsafe_allow_html=True)
+
+    st.markdown("</div>", unsafe_allow_html=True)
 
 
 def render_governance_tab() -> None:


### PR DESCRIPTION
## Summary
- redesign `render_proposals_tab` with card layout and columns
- add CSS for two-column layout and table styling

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: FileNotFoundError in tests)*
- `mypy .` *(fails: streamlit-test is not a valid Python package name)*

------
https://chatgpt.com/codex/tasks/task_e_68892e077054832081a5709255dedd3b