### PR TITLE
Add basic simulation event capture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ venv/
 
 # Test files
 tests/
+!tests/
+!transcendental_resonance_frontend/tests/
+!tests/conftest.py
 
 # Python cache
 __pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,4 @@
 - Standardized Streamlit default port to **8888**.
 - Added `?healthz=1` query parameter for UI health checks.
 - Removed legacy monkey patch for `/healthz`.
+- Added simulation event form with InfluenceGraph preview.

--- a/README.md
+++ b/README.md
@@ -376,6 +376,10 @@ By default the demo listens on port `8888`. Set `STREAMLIT_PORT` or pass
 Use the sidebar file uploader to select or update your dataset, then click **Run Analysis** to refresh the report.
 Missing packages such as `tqdm` are installed automatically when you run `one_click_install.py` so progress bars work without extra setup.
 
+A small simulation form captures interactions between nodes. Enter a source, target,
+edge type and timestamp to build an in-memory `InfluenceGraph`. The graph preview and
+ancestor/descendant traces update as you submit events.
+
 ### Troubleshooting the UI
 
 - **Missing dependencies**: If the interface fails with `ModuleNotFoundError`, run

--- a/api_key_input.py
+++ b/api_key_input.py
@@ -7,6 +7,11 @@ try:
 except Exception:  # pragma: no cover - streamlit not available
     st = None  # type: ignore
 
+from datetime import datetime
+from typing import Optional
+
+from causal_graph import InfluenceGraph
+
 # Mapping of display name -> (model identifier, session_state key)
 PROVIDERS = {
     "Dummy": ("dummy", None),
@@ -45,11 +50,61 @@ def render_api_key_ui(default: str = "Dummy") -> dict[str, str | None]:
     return {"model": model, "api_key": key_val or st.session_state.get(key_name)}
 
 
+def record_simulation_event(
+    session: dict,
+    source: str,
+    target: str,
+    edge_type: str,
+    timestamp: Optional[str] = None,
+) -> InfluenceGraph:
+    """Store an interaction and return the updated graph."""
+    graph: InfluenceGraph = session.setdefault("simulation_graph", InfluenceGraph())
+    events = session.setdefault("simulation_events", [])
+
+    try:
+        ts = datetime.fromisoformat(timestamp) if timestamp else datetime.utcnow()
+    except Exception:
+        ts = datetime.utcnow()
+
+    graph.add_interaction(source, target, edge_type=edge_type, timestamp=ts)
+    events.append({"source": source, "target": target, "edge_type": edge_type, "timestamp": ts})
+    return graph
+
+
 def render_simulation_stubs() -> None:
-    """Placeholder inputs for upcoming simulation features."""
+    """Interactive form to capture simple simulation events."""
     if st is None:
         return
-    with st.expander("Future Simulation Inputs", expanded=False):
-        st.text("Video upload - coming soon")
-        st.text("Causal event modeling - TODO")
-        st.text("Symbolic voting - TODO")
+
+    st.session_state.setdefault("simulation_graph", InfluenceGraph())
+    st.session_state.setdefault("simulation_events", [])
+
+    with st.expander("Simulation Event Input", expanded=False):
+        with st.form("sim_event_form"):
+            source = st.text_input("Source Node ID")
+            target = st.text_input("Target Node ID")
+            edge_type = st.text_input("Edge Type", value="follow")
+            ts_str = st.text_input("Timestamp (ISO)", value=datetime.utcnow().isoformat())
+            submitted = st.form_submit_button("Add Event")
+        if submitted:
+            record_simulation_event(st.session_state, source, target, edge_type, ts_str)
+            st.success("Event recorded")
+
+        graph: InfluenceGraph = st.session_state["simulation_graph"]
+        if graph.graph.number_of_edges() > 0:
+            try:
+                import networkx as nx  # type: ignore
+                import matplotlib.pyplot as plt  # type: ignore
+
+                fig, ax = plt.subplots()
+                pos = nx.spring_layout(graph.graph)
+                nx.draw_networkx(graph.graph, pos=pos, ax=ax)
+                st.pyplot(fig)
+            except Exception:
+                st.info("Install networkx and matplotlib for graph display")
+
+        trace_id = st.text_input("Trace Node", key="trace_node")
+        if trace_id:
+            st.write("Ancestors", graph.trace_to_ancestors(trace_id, max_depth=3))
+            st.write("Descendants", graph.trace_to_descendants(trace_id, max_depth=3))
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,2 @@
+# Root test fixtures placeholder
+

--- a/transcendental_resonance_frontend/tests/test_simulation_graph.py
+++ b/transcendental_resonance_frontend/tests/test_simulation_graph.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from api_key_input import record_simulation_event
+from causal_graph import InfluenceGraph
+
+
+def test_record_simulation_event_adds_edge():
+    session = {}
+    graph = record_simulation_event(session, "A", "B", "follow", "2024-01-01T00:00:00")
+    assert isinstance(graph, InfluenceGraph)
+    assert graph.graph.has_edge("A", "B")
+    data = graph.get_edge_data("A", "B")
+    assert data["edge_type"] == "follow"
+
+
+def test_record_simulation_event_appends_list():
+    session = {}
+    record_simulation_event(session, "A", "B", "follow", "2024-01-01T00:00:00")
+    record_simulation_event(session, "B", "C", "like", "2024-01-02T00:00:00")
+    graph = session["simulation_graph"]
+    assert graph.graph.number_of_edges() == 2
+    assert len(session["simulation_events"]) == 2
+


### PR DESCRIPTION
## Summary
- add InfluenceGraph event form with visualization and tracing
- record events via `record_simulation_event`
- document the new feature in README and CHANGELOG
- include tests for event recording
- allow tests folder in `.gitignore`

## Testing
- `pytest transcendental_resonance_frontend/tests/test_simulation_graph.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68892e0dc4b48320adcf30b08756879b