### PR TITLE
Fix governance reviewer import

### DIFF
--- a/causal_trigger.py
+++ b/causal_trigger.py
@@ -7,7 +7,10 @@ import json
 from db_models import LogEntry, HypothesisRecord
 from causal_graph import InfluenceGraph
 from audit_explainer import trace_causal_chain
-from governance_reviewer import evaluate_governance_risks, apply_governance_actions
+from governance.governance_reviewer import (
+    evaluate_governance_risks,
+    apply_governance_actions,
+)
 
 logger = logging.getLogger("superNova_2177.trigger")
 logger.propagate = False


### PR DESCRIPTION
## Summary
- fix import path for governance reviewer functions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'frontend_bridge')*

------
https://chatgpt.com/codex/tasks/task_e_68893135188c8320bbb663cb4260fec8