### PR TITLE
Fix governance reviewer import

### DIFF
--- a/causal_trigger.py
+++ b/causal_trigger.py
@@ -7,7 +7,13 @@ import json
 from db_models import LogEntry, HypothesisRecord
 from causal_graph import InfluenceGraph
 from audit_explainer import trace_causal_chain
-from governance_reviewer import evaluate_governance_risks, apply_governance_actions
+# Import from the governance package. The governance utilities live in
+# `governance/governance_reviewer.py`, so we include the package prefix
+# to ensure the module can be resolved when the app runs.
+from governance.governance_reviewer import (
+    evaluate_governance_risks,
+    apply_governance_actions,
+)
 
 logger = logging.getLogger("superNova_2177.trigger")
 logger.propagate = False


### PR DESCRIPTION
## Summary
- ensure the `governance_reviewer` module is imported from the `governance` package

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'nicegui')*

------
https://chatgpt.com/codex/tasks/task_e_688931ef09b483209eeddcb486e88650