### PR TITLE
Fix governance module import

### DIFF
--- a/causal_trigger.py
+++ b/causal_trigger.py
@@ -7,8 +7,7 @@ import json
 from db_models import LogEntry, HypothesisRecord
 from causal_graph import InfluenceGraph
 from audit_explainer import trace_causal_chain
-from governance_reviewer import evaluate_governance_risks, apply_governance_actions
-
+from governance import evaluate_governance_risks, apply_governance_actions
 logger = logging.getLogger("superNova_2177.trigger")
 logger.propagate = False
 

--- a/governance/__init__.py
+++ b/governance/__init__.py
@@ -1,0 +1,4 @@
+# Governance package
+from .governance_reviewer import evaluate_governance_risks, apply_governance_actions
+
+__all__ = ["evaluate_governance_risks", "apply_governance_actions"]


### PR DESCRIPTION
## Summary
- add `governance/__init__.py`
- import governance utilities via the package rather than an undefined module

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: frontend_bridge, external_services)*

------
https://chatgpt.com/codex/tasks/task_e_688931ef09b483209eeddcb486e88650