### PR TITLE
Add resonance music player page

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,8 @@ A small simulation form captures interactions between nodes. Enter a source, tar
 edge type and timestamp to build an in-memory `InfluenceGraph`. The graph preview and
 ancestor/descendant traces update as you submit events.
 
+Use the **Resonance Music** page to generate simple MIDI snippets and view the metrics returned by the `/resonance-summary` endpoint.
+
 ### Troubleshooting the UI
 
 - **Missing dependencies**: If the interface fails with `ModuleNotFoundError`, run

--- a/transcendental_resonance_frontend/pages/__init__.py
+++ b/transcendental_resonance_frontend/pages/__init__.py
@@ -5,4 +5,5 @@ __all__ = [
     "social",
     "voting",
     "agents",
+    "resonance_music",
 ]

--- a/transcendental_resonance_frontend/pages/resonance_music.py
+++ b/transcendental_resonance_frontend/pages/resonance_music.py
@@ -1,0 +1,74 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+"""Resonance music player and summary viewer."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import os
+from typing import Any
+
+import requests
+import streamlit as st
+from streamlit_helpers import alert, centered_container
+
+try:
+    from frontend_bridge import dispatch_route
+except Exception:  # pragma: no cover - optional dependency
+    dispatch_route = None  # type: ignore
+
+BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:8000")
+
+
+def _run_async(coro):
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+    else:
+        if loop.is_running():
+            return asyncio.run_coroutine_threadsafe(coro, loop).result()
+        return loop.run_until_complete(coro)
+
+
+def main() -> None:
+    """Render music generation and summary widgets."""
+
+    st.subheader("Resonance Music")
+    centered_container()
+
+    profile = st.selectbox(
+        "Select resonance profile",
+        ["default", "high_harmony", "high_entropy"],
+    )
+    midi_placeholder = st.empty()
+
+    if st.button("Generate music") and dispatch_route:
+        with st.spinner("Generating..."):
+            try:
+                result = _run_async(
+                    dispatch_route("generate_midi", {"profile": profile})
+                )
+            except Exception as exc:  # pragma: no cover - feedback
+                alert(f"Generation failed: {exc}", "error")
+            else:
+                midi_b64 = (
+                    result.get("midi_base64") if isinstance(result, dict) else None
+                )
+                if midi_b64:
+                    midi_bytes = base64.b64decode(midi_b64)
+                    midi_placeholder.audio(midi_bytes, format="audio/midi")
+                else:
+                    alert("No MIDI data returned", "warning")
+
+    if st.button("Fetch resonance summary"):
+        try:
+            resp = requests.get(f"{BACKEND_URL}/resonance-summary", timeout=5)
+            resp.raise_for_status()
+            data = resp.json()
+            st.json(data.get("metrics", {}))
+            st.write(f"MIDI bytes: {data.get('midi_bytes', 0)}")
+        except Exception as exc:  # pragma: no cover - best effort
+            alert(f"Failed to load summary: {exc}", "error")

--- a/ui.py
+++ b/ui.py
@@ -878,6 +878,7 @@ def main() -> None:
         "Voting": "voting",
         "Agents": "agents",
         "Social": "social",
+        "Resonance Music": "resonance_music",
     }
 
     render_main_ui()
@@ -885,7 +886,7 @@ def main() -> None:
         choice = option_menu(
             menu_title=None,
             options=list(pages.keys()),
-            icons=["check2-square", "graph-up", "robot", "people"],
+            icons=["check2-square", "graph-up", "robot", "people", "music-note"],
             orientation="vertical",
         )
 


### PR DESCRIPTION
## Summary
- add new Streamlit page for resonance music playback
- reference the new page in README
- register the module in UI page index and sidebar

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: failed to find libmagic)*

------
https://chatgpt.com/codex/tasks/task_e_688932e60bac83209de908b072484177