### PR TITLE
Implement moderation dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,6 +479,7 @@ During development, you can also open `/ui/debug_panel` in the NiceGUI
 frontend to interactively invoke these routes. The panel lists every
 registered name with a JSON payload editor and uses `dispatch_route` under
 the hood.
+Moderators can visit `/moderation` to review flagged posts in the new Moderation Dashboard.
  
 ### Frontend Bridge & Social Hooks
 

--- a/transcendental_resonance_frontend/src/pages/__init__.py
+++ b/transcendental_resonance_frontend/src/pages/__init__.py
@@ -27,6 +27,7 @@ __all__ = [
     "validator_graph_page",
     "debug_panel_page",
     "video_chat_page",
+    "moderation_dashboard_page",
 ]
 
 

--- a/transcendental_resonance_frontend/src/pages/moderation_dashboard_page.py
+++ b/transcendental_resonance_frontend/src/pages/moderation_dashboard_page.py
@@ -1,0 +1,72 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+"""Dashboard for reviewing flagged content."""
+
+from __future__ import annotations
+
+from nicegui import ui
+
+from utils.api import TOKEN, api_call, listen_ws
+from utils.layout import page_container, navigation_bar
+from utils.styles import get_theme
+
+from .login_page import login_page
+
+
+@ui.page("/moderation")
+async def moderation_dashboard_page() -> None:
+    """Display flagged content requiring moderation."""
+    if not TOKEN:
+        ui.open(login_page)
+        return
+
+    theme = get_theme()
+    with page_container(theme):
+        if TOKEN:
+            navigation_bar()
+        ui.label("Moderation Dashboard").classes("text-2xl font-bold mb-4").style(
+            f"color: {theme['accent']};"
+        )
+
+        items_column = ui.column().classes("w-full")
+
+        async def refresh_items() -> None:
+            flags = await api_call("GET", "/moderation/flags") or []
+            items_column.clear()
+            if not flags:
+                ui.label("No flagged content.").classes("text-sm opacity-50")
+                return
+            for item in flags:
+                with items_column:
+                    with ui.card().classes("w-full mb-2").style(
+                        "border: 1px solid #333; background: #1e1e1e;"
+                    ):
+                        ui.label(item.get("content", "")).classes("text-sm mb-1")
+                        reason = item.get("reason", "unknown")
+                        ui.label(f"Reason: {reason}").classes("text-xs mb-2")
+                        with ui.row().classes("w-full justify-end"):
+                            for action in ["approve", "reject", "censor", "ban"]:
+                                async def perform(a=action, fid=item.get("id")) -> None:
+                                    await api_call(
+                                        "POST",
+                                        f"/moderation/flags/{fid}",
+                                        {"action": a},
+                                    )
+                                    await refresh_items()
+
+                                ui.button(a.capitalize(), on_click=perform).classes(
+                                    "mr-2"
+                                ).style(
+                                    f"background: {theme['primary']}; color: {theme['text']};"
+                                )
+
+        await refresh_items()
+        ui.timer(15, lambda: ui.run_async(refresh_items()))
+
+        async def handle_event(event: dict) -> None:
+            if event.get("type") == "moderation_flagged":
+                await refresh_items()
+
+        ws_task = listen_ws(handle_event)
+        ui.context.client.on_disconnect(lambda: ws_task.cancel())

--- a/transcendental_resonance_frontend/src/utils/api.py
+++ b/transcendental_resonance_frontend/src/utils/api.py
@@ -298,3 +298,14 @@ async def combined_search(query: str) -> list[Dict[str, Any]]:
             results.append({"type": "event", "label": label, "id": ev.get("id")})
 
     return results
+
+
+async def get_flagged_items() -> list[Dict[str, Any]]:
+    """Return content flagged for moderation."""
+    return await api_call("GET", "/moderation/flags") or []
+
+
+async def perform_moderation_action(flag_id: str, action: str) -> Optional[Dict[str, Any]]:
+    """Send a moderation decision for the given flag."""
+    data = {"action": action}
+    return await api_call("POST", f"/moderation/flags/{flag_id}", data)

--- a/transcendental_resonance_frontend/tests/conftest.py
+++ b/transcendental_resonance_frontend/tests/conftest.py
@@ -4,3 +4,6 @@ from pathlib import Path
 SRC_DIR = Path(__file__).resolve().parents[1] / 'src'
 if str(SRC_DIR) not in sys.path:
     sys.path.insert(0, str(SRC_DIR))
+ROOT_DIR = Path(__file__).resolve().parents[2]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))


### PR DESCRIPTION
## Summary
- add a NiceGUI page for moderators to review flagged posts
- expose helper API calls for moderation actions
- document the new dashboard in the README
- ensure tests add repo root to `sys.path`

## Testing
- `pytest -q` *(fails: API call errors and NiceGUI background task assertions)*
- `mypy transcendental_resonance_frontend/src/utils/api.py` *(fails: streamlit-test is not a valid package name)*

------
https://chatgpt.com/codex/tasks/task_e_688932dadb308320bd6ae88189a53353