### PR TITLE
Improve backend connection UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,15 @@ ancestor/descendant traces update as you submit events.
 
 Use the **Resonance Music** page to generate simple MIDI snippets and view the metrics returned by the `/resonance-summary` endpoint.
 
+The music player talks to the backend API on `http://localhost:8000`. Make sure
+the server is running in another terminal before using the page:
+
+```bash
+uvicorn superNova_2177:app --reload --port 8000
+# or simply
+python superNova_2177.py
+```
+
 ### Troubleshooting the UI
 
 - **Missing dependencies**: If the interface fails with `ModuleNotFoundError`, run


### PR DESCRIPTION
## Summary
- mention how to start the backend API in the README
- show backend online/offline indicator on the Resonance Music page
- replace large error boxes with concise toast+alert messages when backend is unreachable

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'nicegui')*
- `mypy` *(fails: 'streamlit-test' is not a valid Python package name)*

------
https://chatgpt.com/codex/tasks/task_e_6889355d2cbc8320987afa90252c0ae5