### PR TITLE
Add backend health check for Resonance Music page

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -47,3 +47,4 @@ plotly
 pyvis
 streamlit-option-menu
 streamlit-aggrid>=1.1.7
+streamlit-autorefresh


### PR DESCRIPTION
## Summary
- show a green/red status indicator in the Resonance Music Streamlit page
- query `/healthz` via new `backend_online` helper
- alert with a concise message when `/resonance-summary` fails
- refresh the page every few seconds
- include `streamlit-autorefresh` dependency

## Testing
- `pytest transcendental_resonance_frontend/tests/test_music_page.py -q`
- `pytest transcendental_resonance_frontend/tests/test_offline_mode.py -q` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_e_6889373b2634832092fe1c5a22e0f7ad