### PR TITLE
Fix indentation in sidebar block

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -529,9 +529,9 @@ def render_validation_ui(sidebar: "st.delta_generator.DeltaGenerator" | None = N
                 alert("Demo file not found", "warning")
             st.rerun()
 
-secrets = get_st_secrets()
-secret_key = secrets.get("SECRET_KEY")
-database_url = secrets.get("DATABASE_URL")
+    secrets = get_st_secrets()
+    secret_key = secrets.get("SECRET_KEY")
+    database_url = secrets.get("DATABASE_URL")
 
     with sidebar:
         st.header("Environment")


### PR DESCRIPTION
## Summary
- ensure `with sidebar:` block in `render_validation_ui` is indented correctly

## Testing
- `python -m py_compile ui.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'nicegui')*

------
https://chatgpt.com/codex/tasks/task_e_6889385f518883209cec054cb7018096