### PR TITLE
Adapt page modules to container layout

### DIFF
--- a/transcendental_resonance_frontend/agent_ui.py
+++ b/transcendental_resonance_frontend/agent_ui.py
@@ -1,4 +1,7 @@
-# transcendental_resonance_frontend/pages/agent_ui.py
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+"""Agent Insights tab renderer for the Transcendental Resonance frontend."""
 
 import streamlit as st
 

--- a/transcendental_resonance_frontend/pages/agents.py
+++ b/transcendental_resonance_frontend/pages/agents.py
@@ -1,5 +1,16 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
 """Agent insights page."""
+
+import streamlit as st
 from agent_ui import render_agent_insights_tab
 
-def main() -> None:
-    render_agent_insights_tab()
+
+def main(main_container=None) -> None:
+    """Render the Agent Insights page within ``main_container``."""
+    if main_container is None:
+        main_container = st
+
+    with main_container:
+        render_agent_insights_tab(main_container=main_container)

--- a/transcendental_resonance_frontend/pages/resonance_music.py
+++ b/transcendental_resonance_frontend/pages/resonance_music.py
@@ -44,52 +44,55 @@ def _run_async(coro):
         return loop.run_until_complete(coro)
 
 
-def main() -> None:
+def main(main_container=None) -> None:
     """Render music generation and summary widgets."""
 
-    st_autorefresh(interval=5000, key="health-ping")
-    indicator_color = "green" if backend_online() else "red"
-    st.markdown(
-        f"Backend: <span style='color:{indicator_color};font-size:1.2rem;'>\u25CF</span>",
-        unsafe_allow_html=True,
-    )
+    if main_container is None:
+        main_container = st
+    with main_container:
+        st_autorefresh(interval=5000, key="health-ping")
+        indicator_color = "green" if backend_online() else "red"
+        st.markdown(
+            f"Backend: <span style='color:{indicator_color};font-size:1.2rem;'>\u25CF</span>",
+            unsafe_allow_html=True,
+        )
 
-    st.subheader("Resonance Music")
-    centered_container()
+        st.subheader("Resonance Music")
+        centered_container()
 
-    profile = st.selectbox(
-        "Select resonance profile",
-        ["default", "high_harmony", "high_entropy"],
-    )
-    midi_placeholder = st.empty()
+        profile = st.selectbox(
+            "Select resonance profile",
+            ["default", "high_harmony", "high_entropy"],
+        )
+        midi_placeholder = st.empty()
 
-    if st.button("Generate music") and dispatch_route:
-        with st.spinner("Generating..."):
-            try:
-                result = _run_async(
-                    dispatch_route("generate_midi", {"profile": profile})
-                )
-            except Exception as exc:  # pragma: no cover - feedback
-                alert(f"Generation failed: {exc}", "error")
-            else:
-                midi_b64 = (
-                    result.get("midi_base64") if isinstance(result, dict) else None
-                )
-                if midi_b64:
-                    midi_bytes = base64.b64decode(midi_b64)
-                    midi_placeholder.audio(midi_bytes, format="audio/midi")
+        if st.button("Generate music") and dispatch_route:
+            with st.spinner("Generating..."):
+                try:
+                    result = _run_async(
+                        dispatch_route("generate_midi", {"profile": profile})
+                    )
+                except Exception as exc:  # pragma: no cover - feedback
+                    alert(f"Generation failed: {exc}", "error")
                 else:
-                    alert("No MIDI data returned", "warning")
+                    midi_b64 = (
+                        result.get("midi_base64") if isinstance(result, dict) else None
+                    )
+                    if midi_b64:
+                        midi_bytes = base64.b64decode(midi_b64)
+                        midi_placeholder.audio(midi_bytes, format="audio/midi")
+                    else:
+                        alert("No MIDI data returned", "warning")
 
-    if st.button("Fetch resonance summary"):
-        try:
-            resp = requests.get(f"{BACKEND_URL}/resonance-summary", timeout=5)
-            resp.raise_for_status()
-            data = resp.json()
-            st.json(data.get("metrics", {}))
-            st.write(f"MIDI bytes: {data.get('midi_bytes', 0)}")
-        except Exception:  # pragma: no cover - best effort
-            alert(
-                "Backend service unreachable. Please ensure the backend server is running at http://localhost:8000.",
-                "error",
-            )
+        if st.button("Fetch resonance summary"):
+            try:
+                resp = requests.get(f"{BACKEND_URL}/resonance-summary", timeout=5)
+                resp.raise_for_status()
+                data = resp.json()
+                st.json(data.get("metrics", {}))
+                st.write(f"MIDI bytes: {data.get('midi_bytes', 0)}")
+            except Exception:  # pragma: no cover - best effort
+                alert(
+                    "Backend service unreachable. Please ensure the backend server is running at http://localhost:8000.",
+                    "error",
+                )

--- a/transcendental_resonance_frontend/pages/social.py
+++ b/transcendental_resonance_frontend/pages/social.py
@@ -1,5 +1,16 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
 """Friends & Followers page."""
+
+import streamlit as st
 from social_tabs import render_social_tab
 
-def main() -> None:
-    render_social_tab()
+
+def main(main_container=None) -> None:
+    """Render the social page content within ``main_container``."""
+    if main_container is None:
+        main_container = st
+
+    with main_container:
+        render_social_tab()

--- a/transcendental_resonance_frontend/pages/validation.py
+++ b/transcendental_resonance_frontend/pages/validation.py
@@ -1,5 +1,16 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
 """Validation analysis page."""
+
+import streamlit as st
 from ui import render_validation_ui
 
-def main() -> None:
-    render_validation_ui()
+
+def main(main_container=None) -> None:
+    """Render the validation UI within ``main_container``."""
+    if main_container is None:
+        main_container = st
+
+    with main_container:
+        render_validation_ui()

--- a/transcendental_resonance_frontend/pages/voting.py
+++ b/transcendental_resonance_frontend/pages/voting.py
@@ -1,5 +1,16 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
 """Governance and voting page."""
+
+import streamlit as st
 from voting_ui import render_voting_tab
 
-def main() -> None:
-    render_voting_tab()
+
+def main(main_container=None) -> None:
+    """Render the Governance and Voting page inside ``main_container``."""
+    if main_container is None:
+        main_container = st
+
+    with main_container:
+        render_voting_tab()


### PR DESCRIPTION
## Summary
- update agents, social, validation, voting, resonance_music page modules to accept a container
- wrap their Streamlit elements in `with main_container:` blocks
- add standard disclaimer lines to each updated file
- clarify agent_ui module and include disclaimers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'nicegui')*

------
https://chatgpt.com/codex/tasks/task_e_6889390101a08320bb265a949bd89cc2