### PR TITLE
Add health check route

### DIFF
--- a/docs/routes.md
+++ b/docs/routes.md
@@ -55,3 +55,9 @@ and follow `disclaimers.LEGAL_ETHICAL_SAFEGUARDS` for community use.
 |`create_proposal`|Create a new proposal.|
 |`list_proposals`|List existing proposals.|
 |`vote_proposal`|Vote on a proposal.|
+
+## system
+
+| Route | Description |
+|-------|-------------|
+|`healthz`|Health check endpoint.|

--- a/superNova_2177.py
+++ b/superNova_2177.py
@@ -2706,6 +2706,12 @@ def get_system_status(
     }
 
 
+@app.get("/healthz", tags=["System"])
+def healthz():
+    """Simple health check endpoint."""
+    return {"status": "ok"}
+
+
 @app.get("/universe/info", tags=["System"])
 def universe_info() -> Dict[str, str]:
     """Return details about the current database configuration."""


### PR DESCRIPTION
## Summary
- add `/healthz` endpoint to `superNova_2177` for a simple health check
- document the new route under a new "system" section in `docs/routes.md`

## Testing
- `pytest -q` *(fails: 13 failed, 46 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68893739c29883208827dc1e37309697