### PR TITLE
Add realtime updates to moderation page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,4 @@
 - Added `?healthz=1` query parameter for UI health checks.
 - Removed legacy monkey patch for `/healthz`.
 - Added simulation event form with InfluenceGraph preview.
+- Added moderation page with real-time flag updates.

--- a/transcendental_resonance_frontend/src/main.py
+++ b/transcendental_resonance_frontend/src/main.py
@@ -33,6 +33,7 @@ from .pages import (
     validator_graph_page,
     debug_panel_page,
     video_chat_page,
+    moderation_page,
 )  # register all pages
 from .utils.api import (
     api_call,

--- a/transcendental_resonance_frontend/src/pages/__init__.py
+++ b/transcendental_resonance_frontend/src/pages/__init__.py
@@ -27,6 +27,7 @@ __all__ = [
     "validator_graph_page",
     "debug_panel_page",
     "video_chat_page",
+    "moderation_page",
 ]
 
 

--- a/transcendental_resonance_frontend/src/pages/moderation_page.py
+++ b/transcendental_resonance_frontend/src/pages/moderation_page.py
@@ -1,0 +1,53 @@
+"""Content moderation panel for reviewing flagged posts."""
+
+from nicegui import ui
+
+from utils.api import TOKEN, api_call, listen_ws
+from utils.layout import page_container, navigation_bar
+from utils.styles import get_theme
+
+from .login_page import login_page
+
+
+@ui.page('/moderation')
+async def moderation_page() -> None:
+    """Display flagged content for review with live updates."""
+    if not TOKEN:
+        ui.open(login_page)
+        return
+
+    THEME = get_theme()
+    with page_container(THEME):
+        if TOKEN:
+            navigation_bar()
+        ui.label('Moderation').classes('text-2xl font-bold mb-4').style(
+            f'color: {THEME["accent"]};'
+        )
+
+        flags_column = ui.column().classes('w-full')
+
+        async def refresh_flags() -> None:
+            """Reload the list of flagged content."""
+            flags = await api_call('GET', '/moderation/flags') or []
+            flags_column.clear()
+            if not flags:
+                ui.label('No flagged content').classes('text-sm')
+                return
+            for flag in flags:
+                with flags_column:
+                    with ui.card().classes('w-full mb-2').style(
+                        'border: 1px solid #333; background: #1e1e1e;'
+                    ):
+                        ui.label(flag.get('summary', 'Flagged Item')).classes('text-sm font-bold')
+                        if reason := flag.get('reason'):
+                            ui.label(reason).classes('text-sm')
+
+        await refresh_flags()
+        ui.timer(15, lambda: ui.run_async(refresh_flags()))
+
+        async def handle_event(event: dict) -> None:
+            if event.get('type') in {'flagged', 'moderation_flagged'}:
+                await refresh_flags()
+
+        ws_task = listen_ws(handle_event)
+        ui.context.client.on_disconnect(lambda: ws_task.cancel())


### PR DESCRIPTION
## Summary
- add new `moderation_page` for reviewing flagged content
- register moderation page in page loader and main app
- note moderation page in CHANGELOG

## Testing
- `pip install nicegui sqlalchemy requests python-dateutil networkx`
- `PYTHONPATH=$PWD pytest -q` *(fails: 12 failed, 47 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68893497ec388320b6c2231be9c68353