### PR TITLE
Add basic moderation API

### DIFF
--- a/db_models.py
+++ b/db_models.py
@@ -629,6 +629,18 @@ class TokenListing(Base):
 MarketplaceListing = TokenListing
 
 
+class FlaggedItem(Base):
+    """Content flagged for moderation review."""
+
+    __tablename__ = "flagged_items"
+
+    id = Column(Integer, primary_key=True, index=True)
+    content = Column(Text, nullable=False)
+    reason = Column(String, nullable=False)
+    status = Column(String, default="pending", index=True)
+    created_at = Column(DateTime, default=datetime.datetime.utcnow)
+
+
 def init_db() -> None:
     """Create all tables defined in this module."""
     Base.metadata.create_all(bind=engine)

--- a/moderation_router.py
+++ b/moderation_router.py
@@ -1,0 +1,95 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+"""Moderation endpoints for reviewing flagged content."""
+
+from __future__ import annotations
+
+from typing import List
+import datetime
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from superNova_2177 import get_db
+from db_models import FlaggedItem, Harmonizer
+
+router = APIRouter(prefix="/api/moderation", tags=["Moderation"])
+
+
+class FlaggedItemCreate(BaseModel):
+    content: str
+    reason: str
+
+
+class FlaggedItemOut(FlaggedItemCreate):
+    id: int
+    status: str
+    created_at: datetime.datetime
+
+    class Config:
+        from_attributes = True
+
+
+class FlaggedItemUpdate(BaseModel):
+    status: str
+
+
+def _get_item(item_id: int, db: Session) -> FlaggedItem:
+    item = db.query(FlaggedItem).filter(FlaggedItem.id == item_id).first()
+    if not item:
+        raise HTTPException(status_code=404, detail="Item not found")
+    return item
+
+
+def _set_status(item: FlaggedItem, status_value: str, db: Session) -> FlaggedItem:
+    item.status = status_value
+    db.commit()
+    db.refresh(item)
+    return item
+
+
+@router.get("/queue", response_model=List[FlaggedItemOut])
+def get_queue(db: Session = Depends(get_db)):
+    return db.query(FlaggedItem).filter(FlaggedItem.status == "pending").all()
+
+
+@router.post("/", response_model=FlaggedItemOut, status_code=status.HTTP_201_CREATED)
+def flag_content(item: FlaggedItemCreate, db: Session = Depends(get_db)):
+    flagged = FlaggedItem(content=item.content, reason=item.reason)
+    db.add(flagged)
+    db.commit()
+    db.refresh(flagged)
+    return flagged
+
+
+@router.put("/{item_id}", response_model=FlaggedItemOut)
+def update_item(item_id: int, update: FlaggedItemUpdate, db: Session = Depends(get_db)):
+    item = _get_item(item_id, db)
+    return _set_status(item, update.status, db)
+
+
+@router.post("/{item_id}/approve", response_model=FlaggedItemOut)
+def approve_item(item_id: int, db: Session = Depends(get_db)):
+    item = _get_item(item_id, db)
+    return _set_status(item, "approved", db)
+
+
+@router.post("/{item_id}/reject", response_model=FlaggedItemOut)
+def reject_item(item_id: int, db: Session = Depends(get_db)):
+    item = _get_item(item_id, db)
+    return _set_status(item, "rejected", db)
+
+
+@router.post("/{item_id}/censor", response_model=FlaggedItemOut)
+def censor_item(item_id: int, db: Session = Depends(get_db)):
+    item = _get_item(item_id, db)
+    return _set_status(item, "censored", db)
+
+
+@router.post("/{item_id}/ban_user", response_model=FlaggedItemOut)
+def ban_user_for_item(item_id: int, db: Session = Depends(get_db)):
+    item = _get_item(item_id, db)
+    # Placeholder for actual user ban logic
+    return _set_status(item, "banned", db)

--- a/superNova_2177.py
+++ b/superNova_2177.py
@@ -2470,9 +2470,11 @@ def get_music_generator(
 
 from login_router import router as login_router
 from video_chat_router import router as video_chat_router
+from moderation_router import router as moderation_router
 
 app.include_router(login_router)
 app.include_router(video_chat_router)
+app.include_router(moderation_router)
 
 
 # Endpoints (Full implementation from FastAPI files, enhanced)


### PR DESCRIPTION
## Summary
- add `FlaggedItem` SQLAlchemy model
- create `moderation_router` with endpoints for moderation actions
- include the new router in the main FastAPI app

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'nicegui')*

------
https://chatgpt.com/codex/tasks/task_e_68893496e744832082d20cb35a0e7a75