### PR TITLE
Add backend connectivity indicator

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -47,3 +47,4 @@ plotly
 pyvis
 streamlit-option-menu
 streamlit-aggrid>=1.1.7
+streamlit-autorefresh

--- a/status_indicator.py
+++ b/status_indicator.py
@@ -1,0 +1,36 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+"""Simple connectivity indicator for Streamlit apps."""
+
+from __future__ import annotations
+
+import os
+
+
+import requests
+import streamlit as st
+
+BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:8000")
+
+
+def check_backend(endpoint: str = "/status") -> bool:
+    """Return ``True`` if ``endpoint`` responds successfully."""
+    try:
+        resp = requests.get(f"{BACKEND_URL}{endpoint}", timeout=5)
+        resp.raise_for_status()
+    except Exception:
+        return False
+    return True
+
+
+def render_status_icon(*, endpoint: str = "/status") -> None:
+    """Display a colored dot indicating backend connectivity."""
+    ok = check_backend(endpoint)
+    color = "green" if ok else "red"
+    label = "Online" if ok else "Offline"
+    st.markdown(
+        f"<span style='color:{color};font-size:1.2rem;'>\u25CF</span> {label}",
+        unsafe_allow_html=True,
+    )
+

--- a/transcendental_resonance_frontend/pages/resonance_music.py
+++ b/transcendental_resonance_frontend/pages/resonance_music.py
@@ -13,6 +13,8 @@ from typing import Any
 import requests
 import streamlit as st
 from streamlit_helpers import alert, centered_container
+from streamlit_autorefresh import st_autorefresh
+from status_indicator import render_status_icon
 
 try:
     from frontend_bridge import dispatch_route
@@ -35,9 +37,13 @@ def _run_async(coro):
 
 def main() -> None:
     """Render music generation and summary widgets."""
+    st_autorefresh(interval=30000, key="status_ping")
 
     st.subheader("Resonance Music")
     centered_container()
+
+    with st.sidebar:
+        render_status_icon()
 
     profile = st.selectbox(
         "Select resonance profile",
@@ -72,3 +78,4 @@ def main() -> None:
             st.write(f"MIDI bytes: {data.get('midi_bytes', 0)}")
         except Exception as exc:  # pragma: no cover - best effort
             alert(f"Failed to load summary: {exc}", "error")
+


### PR DESCRIPTION
## Summary
- add `streamlit-autorefresh` dependency for periodic status checks
- provide a new `status_indicator` helper
- display a connectivity indicator on the Resonance Music page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: httpx.ConnectError, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688937317bf88320848aad78808025b4