### PR TITLE
Add resonance music page

### DIFF
--- a/transcendental_resonance_frontend/pages/__init__.py
+++ b/transcendental_resonance_frontend/pages/__init__.py
@@ -5,4 +5,5 @@ __all__ = [
     "social",
     "voting",
     "agents",
+    "resonance_music",
 ]

--- a/transcendental_resonance_frontend/pages/resonance_music.py
+++ b/transcendental_resonance_frontend/pages/resonance_music.py
@@ -1,0 +1,41 @@
+"""Preview resonance metrics as music."""
+
+from __future__ import annotations
+
+import asyncio
+import streamlit as st
+from utils.api import get_resonance_summary
+
+
+def _run_async(coro):
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+    else:
+        if loop.is_running():
+            return asyncio.run_coroutine_threadsafe(coro, loop).result()
+        return loop.run_until_complete(coro)
+
+
+def main() -> None:
+    st.header("Resonance Music")
+    options = ["Solar Echoes", "Quantum Drift", "Ether Pulse"]
+    choice = st.selectbox(
+        "Select a track or resonance profile",
+        options,
+        index=None,
+        placeholder="tracks or resonance profiles",
+    )
+    if not choice:
+        return
+
+    data = _run_async(get_resonance_summary(choice)) or {}
+    metrics = data.get("metrics", {})
+    if metrics:
+        st.subheader("Metrics")
+        st.table({"metric": list(metrics.keys()), "value": list(metrics.values())})
+
+    midi = data.get("midi_bytes")
+    if isinstance(midi, (bytes, bytearray)):
+        st.audio(midi, format="audio/midi")

--- a/transcendental_resonance_frontend/src/utils/api.py
+++ b/transcendental_resonance_frontend/src/utils/api.py
@@ -298,3 +298,9 @@ async def combined_search(query: str) -> list[Dict[str, Any]]:
             results.append({"type": "event", "label": label, "id": ev.get("id")})
 
     return results
+
+
+async def get_resonance_summary(name: str) -> Optional[Dict[str, Any]]:
+    """Return resonance metrics and optional MIDI for ``name``."""
+    params = {"name": name}
+    return await api_call("GET", "/resonance-summary", params)

--- a/ui.py
+++ b/ui.py
@@ -877,6 +877,7 @@ def main() -> None:
         "Validation": "validation",
         "Voting": "voting",
         "Agents": "agents",
+        "Resonance Music": "resonance_music",
         "Social": "social",
     }
 
@@ -885,7 +886,7 @@ def main() -> None:
         choice = option_menu(
             menu_title=None,
             options=list(pages.keys()),
-            icons=["check2-square", "graph-up", "robot", "people"],
+            icons=["check2-square", "graph-up", "robot", "music-note-beamed", "people"],
             orientation="vertical",
         )
 


### PR DESCRIPTION
## Summary
- expose new `get_resonance_summary` helper for `/resonance-summary`
- create `resonance_music` Streamlit page with selectbox and audio preview
- register the page and add it to the sidebar with a music icon

## Testing
- `pytest transcendental_resonance_frontend/tests/test_music_page.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688934d05658832088befcdd651821d0