### PR TITLE
Fix agents page relative import

### DIFF
--- a/transcendental_resonance_frontend/pages/agents.py
+++ b/transcendental_resonance_frontend/pages/agents.py
@@ -1,5 +1,5 @@
 """Agent insights page."""
-from agent_ui import render_agent_insights_tab
+from ..agent_ui import render_agent_insights_tab
 
 def main() -> None:
     render_agent_insights_tab()


### PR DESCRIPTION
## Summary
- fix agents page to import `render_agent_insights_tab` relatively

## Testing
- `pytest transcendental_resonance_frontend/tests/test_events_page.py -q`
- `pytest -q` *(fails: RuntimeError in nicegui context)*

------
https://chatgpt.com/codex/tasks/task_e_68893a879df08320a0ab54dd4e692e98