### PR TITLE
Add Codex-inspired dark theme

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -2,9 +2,9 @@
 # Intellectual Property & Artistic Inspiration
 # Legal & Ethical Safeguards
 [theme]
-# Custom professional palette for the Streamlit app
-primaryColor = "#0A84FF"
-backgroundColor = "#F0F2F6"
-secondaryBackgroundColor = "#FFFFFF"
-textColor = "#333333"
-font = "sans serif"
+# Default Codex-inspired dark palette
+primaryColor = "#19C37D"
+backgroundColor = "#202123"
+secondaryBackgroundColor = "#343541"
+textColor = "#ECECF1"
+font = "monospace"

--- a/docs/codex_theme.md
+++ b/docs/codex_theme.md
@@ -1,0 +1,16 @@
+# Codex Dark Theme
+
+The Codex theme provides a minimalist dark appearance inspired by the ChatGPT interface.
+It is available through `streamlit_helpers.theme_selector()` and sets a monospace
+Iosevka font for a clean layout.
+
+### Usage
+
+```python
+from streamlit_helpers import theme_selector
+
+# Add a radio selector to switch themes
+theme_selector("Theme")
+```
+
+To make Codex the default, update `.streamlit/config.toml` with the included palette.

--- a/streamlit_helpers.py
+++ b/streamlit_helpers.py
@@ -49,8 +49,19 @@ def header(title: str, *, layout: str = "centered") -> None:
 
 
 def apply_theme(theme: str) -> None:
-    """Apply light or dark theme styles based on ``theme``."""
-    if theme == "dark":
+    """Apply light, dark or Codex-inspired theme styles."""
+    if theme == "codex":
+        css = """
+            <style>
+            @import url('https://fonts.googleapis.com/css2?family=Iosevka:wght@400;700&display=swap');
+            body, .stApp {
+                background-color: #202123;
+                color: #ECECF1;
+                font-family: 'Iosevka', monospace;
+            }
+            </style>
+        """
+    elif theme == "dark":
         css = """
             <style>
             body, .stApp { background-color: #1e1e1e; color: #f0f0f0; }
@@ -100,10 +111,13 @@ def theme_selector(label: str = "Theme") -> str:
     """Render a radio selector for the app theme and return the choice."""
     if "theme" not in st.session_state:
         st.session_state["theme"] = "light"
+    options = ["Light", "Dark", "Codex"]
+    current = st.session_state["theme"].capitalize()
+    idx = options.index(current) if current in options else 0
     choice = st.radio(
         label,
-        ["Light", "Dark"],
-        index=(1 if st.session_state["theme"] == "dark" else 0),
+        options,
+        index=idx,
         horizontal=True,
     )
     st.session_state["theme"] = choice.lower()

--- a/transcendental_resonance_frontend/src/utils/styles.py
+++ b/transcendental_resonance_frontend/src/utils/styles.py
@@ -34,6 +34,13 @@ THEMES: Dict[str, Dict[str, str]] = {
         "text": "#F8F8F2",
         "gradient": "linear-gradient(135deg, #FF0080 0%, #00F0FF 100%)",
     },
+    "codex": {
+        "primary": "#19C37D",
+        "accent": "#19C37D",
+        "background": "#202123",
+        "text": "#ECECF1",
+        "gradient": "linear-gradient(135deg, #202123 0%, #343541 100%)",
+    },
     "high_contrast": {
         "primary": "#000000",
         "accent": "#FFFF00",
@@ -79,6 +86,11 @@ def apply_global_styles() -> None:
         font_family = "'Orbitron', sans-serif"
         font_link = (
             "<link href=\"https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap\" rel=\"stylesheet\">"
+        )
+    elif ACTIVE_THEME_NAME == "codex":
+        font_family = "'Iosevka', monospace"
+        font_link = (
+            "<link href=\"https://fonts.googleapis.com/css2?family=Iosevka:wght@400;700&display=swap\" rel=\"stylesheet\">"
         )
 
     ui.add_head_html(


### PR DESCRIPTION
## Summary
- implement new Codex dark palette in config
- extend `apply_theme` and `theme_selector` to support the theme
- integrate Codex palette with NiceGUI styles
- document how to enable the theme

## Testing
- `pytest transcendental_resonance_frontend/tests/test_styles.py::test_set_theme_switches -q`
- `pytest transcendental_resonance_frontend/tests/test_styles.py::test_apply_global_styles_injects_css -q`
- `pytest transcendental_resonance_frontend/tests/test_styles.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688953f5ddf4832092b22c99a04104a2