### PR TITLE
Enhance Streamlit theming with dark mode

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -3,8 +3,8 @@
 # Legal & Ethical Safeguards
 [theme]
 # Custom professional palette for the Streamlit app
-primaryColor = "#0A84FF"
-backgroundColor = "#F0F2F6"
-secondaryBackgroundColor = "#FFFFFF"
-textColor = "#333333"
-font = "sans serif"
+primaryColor = "#4A90E2"
+backgroundColor = "#181818"
+secondaryBackgroundColor = "#242424"
+textColor = "#E8E6E3"
+font = "monospace"

--- a/agent_ui.py
+++ b/agent_ui.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from typing import Any, cast
 
 import streamlit as st
-from streamlit_helpers import inject_global_styles
+from streamlit_helpers import inject_global_styles, theme_selector
 from voting_ui import (
     render_proposals_tab,
     render_governance_tab,
@@ -33,6 +33,7 @@ def render_agent_insights_tab(main_container=None) -> None:
     if main_container is None:
         main_container = st
 
+    theme_selector("Theme")
     inject_global_styles()
     with main_container:
         st.markdown(BOX_CSS + "<div class='tab-box'>", unsafe_allow_html=True)

--- a/streamlit_helpers.py
+++ b/streamlit_helpers.py
@@ -53,13 +53,37 @@ def apply_theme(theme: str) -> None:
     if theme == "dark":
         css = """
             <style>
-            body, .stApp { background-color: #1e1e1e; color: #f0f0f0; }
+            @import url('https://fonts.googleapis.com/css2?family=Iosevka:wght@400;700&display=swap');
+            :root {
+                --background: #181818;
+                --secondary-bg: #242424;
+                --text-color: #e8e6e3;
+                --primary-color: #4a90e2;
+                --font-family: 'Iosevka', monospace;
+            }
+            body, .stApp {
+                background-color: var(--background);
+                color: var(--text-color);
+                font-family: var(--font-family);
+            }
+            a { color: var(--primary-color); }
             </style>
         """
     else:
         css = """
             <style>
-            body, .stApp { background-color: #ffffff; color: #000000; }
+            :root {
+                --background: #F0F2F6;
+                --secondary-bg: #FFFFFF;
+                --text-color: #333333;
+                --primary-color: #0A84FF;
+                --font-family: 'Inter', sans-serif;
+            }
+            body, .stApp {
+                background-color: var(--background);
+                color: var(--text-color);
+                font-family: var(--font-family);
+            }
             </style>
         """
     st.markdown(css, unsafe_allow_html=True)
@@ -71,8 +95,9 @@ def inject_global_styles() -> None:
         """
         <style>
         body, .stApp {
-            background-color: #F0F2F6;
-            font-family: "Inter", sans-serif;
+            background-color: var(--background, #F0F2F6);
+            color: var(--text-color, #333333);
+            font-family: var(--font-family, "Inter", sans-serif);
         }
         .custom-container {
             padding: 1rem;
@@ -80,16 +105,17 @@ def inject_global_styles() -> None:
             border: 1px solid rgba(0,0,0,0.05);
             box-shadow: 0 2px 4px rgba(0,0,0,0.1);
             margin-bottom: 1rem;
+            background-color: var(--secondary-bg, #FFFFFF);
         }
         .card {
-            background-color: #FFFFFF;
+            background-color: var(--secondary-bg, #FFFFFF);
             padding: 1rem;
             border: 1px solid rgba(0,0,0,0.1);
             border-radius: 8px;
             box-shadow: 0 2px 4px rgba(0,0,0,0.1);
             margin-bottom: 1rem;
         }
-        .stButton>button {border-radius:6px;}
+        .stButton>button {border-radius:6px; background-color: var(--primary-color, #0A84FF); color: var(--text-color, #FFFFFF);}
         </style>
         """,
         unsafe_allow_html=True,

--- a/voting_ui.py
+++ b/voting_ui.py
@@ -10,7 +10,7 @@ try:
 except Exception:  # pragma: no cover - optional dependency
     AgGrid = None  # type: ignore
     GridOptionsBuilder = None  # type: ignore
-from streamlit_helpers import alert, inject_global_styles
+from streamlit_helpers import alert, inject_global_styles, theme_selector
 
 try:
     from frontend_bridge import dispatch_route
@@ -364,6 +364,7 @@ def render_voting_tab(main_container=None) -> None:
         main_container = st
 
     with main_container:
+        theme_selector("Theme")
         inject_global_styles()
         sub1, sub2, sub3, sub4 = st.tabs(
             [


### PR DESCRIPTION
## Summary
- refine apply_theme with dark palette variables and Iosevka font
- ensure containers inherit colors from CSS variables
- add Theme selector to voting and agent pages
- default theme colors updated in config.toml

## Testing
- `pip install -r requirements.txt`
- `mypy` *(failed: streamlit-test is not a valid Python package name)*
- `pytest -q` *(failed to collect tests: ModuleNotFoundError: No module named 'nicegui')*

------
https://chatgpt.com/codex/tasks/task_e_688954b896408320afbcb8599174a9fe