### PR TITLE
Update Streamlit theme config

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -2,9 +2,9 @@
 # Intellectual Property & Artistic Inspiration
 # Legal & Ethical Safeguards
 [theme]
-# Custom professional palette for the Streamlit app
-primaryColor = "#4A90E2"
-backgroundColor = "#181818"
-secondaryBackgroundColor = "#242424"
-textColor = "#E8E6E3"
-font = "monospace"
+# Vibrant cyan palette for the Streamlit app
+primaryColor = "#00F0FF"
+backgroundColor = "#001E26"
+secondaryBackgroundColor = "#002B36"
+textColor = "#E0FFFF"
+font = "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"

--- a/docs/codex_theme.md
+++ b/docs/codex_theme.md
@@ -1,8 +1,8 @@
 # Codex Dark Theme
 
 The Codex theme provides a minimalist dark appearance inspired by the ChatGPT interface.
-It is available through `streamlit_helpers.theme_selector()` and sets a monospace
-Iosevka font for a clean layout.
+It is available through `streamlit_helpers.theme_selector()` and sets the
+`Inter` font stack for a clean layout.
 
 ### Usage
 
@@ -13,4 +13,14 @@ from streamlit_helpers import theme_selector
 theme_selector("Theme")
 ```
 
-To make Codex the default, update `.streamlit/config.toml` with the included palette.
+To make Codex the default or apply the vibrant cyan palette, update
+`.streamlit/config.toml` with the new theme variables:
+
+```toml
+[theme]
+primaryColor = "#00F0FF"
+backgroundColor = "#001E26"
+secondaryBackgroundColor = "#002B36"
+textColor = "#E0FFFF"
+font = "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+```


### PR DESCRIPTION
## Summary
- adopt a vibrant cyan palette in `.streamlit/config.toml`
- use Inter font stack
- document updated theme variables in `codex_theme.md`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'nicegui')*

------
https://chatgpt.com/codex/tasks/task_e_6889579d5cf48320aee471bdb88d31e1