### PR TITLE
Add modern layout style demo

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,2 +1,6 @@
 import streamlit as st
-st.title("It Works!")
+from ui_utils import render_modern_layout
+
+
+if __name__ == "__main__":
+    render_modern_layout()

--- a/streamlit_helpers.py
+++ b/streamlit_helpers.py
@@ -96,10 +96,11 @@ def inject_global_styles() -> None:
     st.markdown(
         """
         <style>
+        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap');
         body, .stApp {
             background-color: var(--background, #F0F2F6);
             color: var(--text-color, #333333);
-            font-family: var(--font-family, "Inter", sans-serif);
+            font-family: var(--font-family, 'Inter', sans-serif);
         }
         .custom-container {
             padding: 1rem;
@@ -117,7 +118,15 @@ def inject_global_styles() -> None:
             box-shadow: 0 2px 4px rgba(0,0,0,0.1);
             margin-bottom: 1rem;
         }
-        .stButton>button {border-radius:6px; background-color: var(--primary-color, #0A84FF); color: var(--text-color, #FFFFFF);}
+        .stButton>button {
+            border-radius: 6px;
+            background: linear-gradient(90deg, var(--primary-color, #0A84FF), #2F70FF);
+            color: var(--text-color, #FFFFFF);
+            transition: filter 0.2s ease-in-out;
+        }
+        .stButton>button:hover {
+            filter: brightness(1.1);
+        }
         </style>
         """,
         unsafe_allow_html=True,

--- a/ui_utils.py
+++ b/ui_utils.py
@@ -56,9 +56,20 @@ def render_main_ui() -> None:
     st.write("UI initialization complete.")
 
 
+def render_modern_layout() -> None:
+    """Render a small demo verifying the modern CSS styles."""
+    inject_global_styles()
+    st.markdown(
+        "<div class='custom-container'>Modern layout loaded.</div>",
+        unsafe_allow_html=True,
+    )
+    st.button("Primary Action")
+
+
 __all__ = [
     "summarize_text",
     "parse_summary",
     "load_rfc_entries",
     "render_main_ui",
+    "render_modern_layout",
 ]


### PR DESCRIPTION
## Summary
- update global styles to load Inter from Google fonts
- add gradient button design with hover transitions
- create `render_modern_layout` demo using the new CSS
- call the demo from `app.py`

## Testing
- `pytest -q` *(fails: RuntimeError: The current slot cannot be determined because the slot stack for this task is empty ...)*

------
https://chatgpt.com/codex/tasks/task_e_68895851b95083209cec73d7d031cf80