### PR TITLE
Add mock DB fallback in UI

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -83,12 +83,72 @@ try:
 except Exception:  # pragma: no cover - optional dependency
     dispatch_route = None
 
+DATABASE_AVAILABLE = True
 try:
     from db_models import Harmonizer, SessionLocal, UniverseBranch
 except Exception:  # pragma: no cover - missing ORM
-    SessionLocal = None  # type: ignore
-    Harmonizer = None  # type: ignore
-    UniverseBranch = None  # type: ignore
+    DATABASE_AVAILABLE = False
+
+    class MockHarmonizer:
+        def __init__(self, id: int = 1, username: str = "demo"):
+            self.id = id
+            self.username = username
+
+
+    class UniverseBranch:
+        class timestamp:
+            @staticmethod
+            def desc() -> None:
+                return None
+
+        def __init__(self, id: str, status: str, timestamp: datetime):
+            self.id = id
+            self.status = status
+            self.timestamp = timestamp
+
+
+    class MockQuery(list):
+        def __init__(self, data: list | None = None) -> None:
+            super().__init__(data or [])
+
+        def order_by(self, *_a, **_k) -> "MockQuery":
+            return self
+
+        def limit(self, *_a, **_k) -> "MockQuery":
+            return self
+
+        def all(self) -> list:
+            return list(self)
+
+        def first(self):
+            return self[0] if self else None
+
+
+    class MockSessionLocal:
+        def __enter__(self) -> "MockSessionLocal":
+            return self
+
+        def __exit__(self, *_exc) -> None:
+            pass
+
+        def query(self, model):
+            data = []
+            if model is MockHarmonizer:
+                data = st.session_state.get("mock_data", {}).get("harmonizers", [])
+            elif model is UniverseBranch:
+                data = st.session_state.get("mock_data", {}).get("universe_branches", [])
+            return MockQuery(data)
+
+    Harmonizer = MockHarmonizer  # type: ignore
+    SessionLocal = MockSessionLocal  # type: ignore
+
+    if "mock_data" not in st.session_state:
+        st.session_state["mock_data"] = {
+            "harmonizers": [MockHarmonizer()],
+            "universe_branches": [
+                UniverseBranch("1", "active", datetime.utcnow())
+            ],
+        }
 
 try:
     from introspection.introspection_pipeline import run_full_audit


### PR DESCRIPTION
## Summary
- handle missing database imports in `ui.py`
- mock `SessionLocal`, `Harmonizer`, `UniverseBranch`, and queries when DB is unavailable
- populate simple mock data for offline mode

## Testing
- `pytest -q` *(fails: 13 failed, 46 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68895915f2ac8320b3c056a6d750cc3a