### PR TITLE
Add unique key option for theme selector

### DIFF
--- a/agent_ui.py
+++ b/agent_ui.py
@@ -33,7 +33,7 @@ def render_agent_insights_tab(main_container=None) -> None:
     if main_container is None:
         main_container = st
 
-    theme_selector("Theme")
+    theme_selector("Theme", key_suffix="agent_insights")
     inject_global_styles()
     with main_container:
         st.markdown(BOX_CSS + "<div class='tab-box'>", unsafe_allow_html=True)

--- a/streamlit_helpers.py
+++ b/streamlit_helpers.py
@@ -142,20 +142,35 @@ def inject_global_styles() -> None:
     )
 
 
-def theme_selector(label: str = "Theme") -> str:
-    """Modern theme selector with visual toggle."""
+def theme_selector(label: str = "Theme", *, key_suffix: str | None = None) -> str:
+    """Modern theme selector with visual toggle.
+
+    Parameters
+    ----------
+    label
+        Visible label for the selectbox.
+    key_suffix
+        Optional unique suffix appended to the widget key. If omitted, "default"
+        will be used. The key format becomes ``"theme_selector_{key_suffix}_{id(st)}"``.
+    """
+
+    if key_suffix is None:
+        key_suffix = "default"
+
     if "theme" not in st.session_state:
         st.session_state["theme"] = "dark"
+
+    unique_key = f"theme_selector_{key_suffix}_{id(st)}"
 
     col1, col2 = st.columns([4, 1])
     with col2:
         current_theme = st.session_state.get("theme", "dark")
 
         theme_choice = st.selectbox(
-            "Theme",
+            label,
             ["Light", "Dark"],
             index=1 if current_theme == "dark" else 0,
-            key="theme_select",
+            key=unique_key,
         )
 
         st.session_state["theme"] = theme_choice.lower()

--- a/ui.py
+++ b/ui.py
@@ -676,6 +676,9 @@ def main() -> None:
                 "errors": []
             })
 
+        # Theme selection (unique key)
+        theme_selector("Theme", key_suffix="main")
+
         # Render main UI with error recovery
         try:
             render_validation_ui()


### PR DESCRIPTION
## Summary
- extend `theme_selector` with optional `key_suffix`
- use this unique key in `ui.py` and `agent_ui.py`

## Testing
- `pytest -q` *(fails: httpx.ConnectError, nicegui async context)*
- `mypy hypothesis_meta_evaluator.py causal_trigger.py introspection/introspection_pipeline.py` *(fails: `streamlit-test is not a valid Python package name`)*

------
https://chatgpt.com/codex/tasks/task_e_68895fe002e08320a92ab7951a4ff43f