### PR TITLE
Update mypy usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,9 @@ test:
 	pytest -q
 
 lint:
-	mypy
+	mypy hypothesis_meta_evaluator.py \
+	    causal_trigger.py \
+	    introspection/introspection_pipeline.py
 
 ui:
-        streamlit run ui.py
+	streamlit run ui.py

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ For convenience, the repository includes a `Makefile` with common tasks:
 ```bash
 make install  # set up the environment
 make test     # run tests
-make lint     # run mypy type checks
+make lint     # run mypy type checks on the main modules
 ```
 
 ### Pre-commit Hooks
@@ -601,7 +601,9 @@ You can also run static type checks with `mypy`:
 
 ```bash
 pytest
-mypy .
+mypy hypothesis_meta_evaluator.py \
+     causal_trigger.py \
+     introspection/introspection_pipeline.py
 ```
 
 The provided `Makefile` exposes `make test` and `make lint` wrappers for these commands.

--- a/superNova_2177.py
+++ b/superNova_2177.py
@@ -47,7 +47,9 @@ Contact: https://github.com/BP-H
 # --- Static Analysis & Linting ---
 # black .
 # flake8 .
-# mypy .
+# mypy hypothesis_meta_evaluator.py \
+#      causal_trigger.py \
+#      introspection/introspection_pipeline.py
 # bandit -r .
 
 # ----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- invoke `mypy` on explicit modules in Makefile
- document specific module paths for static type checks
- update example command in superNova_2177.py

## Testing
- `pytest -q` *(fails: httpx.ConnectError, background task assertion, KeyError)*
- `make lint` *(fails: streamlit-test is not a valid Python package name)*

------
https://chatgpt.com/codex/tasks/task_e_68895fe333d4832099f7ea15d70309c0