### PR TITLE
Add developer controls to sidebar

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -671,6 +671,23 @@ def boot_diagnostic_ui():
     run_analysis([], layout="force")
 
 
+def render_dev_controls() -> None:
+    """Display developer utilities in the sidebar."""
+    show = st.sidebar.checkbox("Dev Controls")
+    if not show:
+        return
+
+    if st.sidebar.button("Clear Session"):
+        st.session_state.clear()
+        st.rerun()
+
+    if st.sidebar.button("Print Session Keys"):
+        print(list(st.session_state.keys()))
+
+    if st.sidebar.button("Raise Test Exception"):
+        raise RuntimeError("Test exception")
+
+
 def render_validation_ui(
     sidebar: Optional[st.delta_generator.DeltaGenerator] = None,
     main_container: Optional[st.delta_generator.DeltaGenerator] = None,
@@ -739,6 +756,9 @@ def main() -> None:
             """,
             unsafe_allow_html=True,
         )
+
+        # Optional development controls
+        render_dev_controls()
 
         # Health check endpoint
         params = st.query_params


### PR DESCRIPTION
## Summary
- add `render_dev_controls` for debugging actions
- display dev controls after styling is applied in `main`

## Testing
- `python -m py_compile ui.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'nicegui')*

------
https://chatgpt.com/codex/tasks/task_e_6889654283c48320b7ac8bb1ce9beeb2