### PR TITLE
Streamline UI styling

### DIFF
--- a/docs/codex_theme.md
+++ b/docs/codex_theme.md
@@ -8,8 +8,10 @@ It is available through `streamlit_helpers.theme_selector()` and sets the
 
 ```python
 from streamlit_helpers import theme_selector
+from modern_ui import inject_premium_styles
 
-# Add a radio selector to switch themes
+# Apply premium styles and add a radio selector to switch themes
+inject_premium_styles()
 theme_selector("Theme")
 ```
 

--- a/docs/streamlit_ui_extension_example.md
+++ b/docs/streamlit_ui_extension_example.md
@@ -6,7 +6,9 @@ Import these helpers in your own modules to keep layouts consistent.
 ```python
 import streamlit as st
 from streamlit_helpers import header, theme_selector, centered_container
+from modern_ui import inject_premium_styles
 
+inject_premium_styles()
 header("Custom Page", layout="wide")
 with centered_container():
     theme_selector("Theme")

--- a/modern_ui.py
+++ b/modern_ui.py
@@ -11,21 +11,43 @@ def inject_premium_styles() -> None:
     st.markdown(
         """
         <style>
+        body, .stApp {
+            background-color: var(--background, #F0F2F6);
+            color: var(--text-color, #333333);
+            font-family: var(--font-family, 'Inter', sans-serif);
+        }
         .main .block-container {
             padding-top: 2rem;
             padding-left: 3rem;
             padding-right: 3rem;
             max-width: 1200px;
         }
+        .custom-container {
+            padding: 1rem;
+            border-radius: 8px;
+            border: 1px solid rgba(0,0,0,0.05);
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+            margin-bottom: 1rem;
+            background-color: var(--secondary-bg, #FFFFFF);
+        }
+        .card {
+            background-color: var(--secondary-bg, #FFFFFF);
+            padding: 1rem;
+            border: 1px solid rgba(0,0,0,0.1);
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+            margin-bottom: 1rem;
+        }
         h1, h2, h3, h4, h5, h6 {
             font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif !important;
             font-weight: 600 !important;
             line-height: 1.3 !important;
-            margin-bottom: 1rem !important;
+            margin: 0 0 0.5rem 0 !important;
         }
         p, span, div {
             line-height: 1.6 !important;
             font-family: 'Inter', sans-serif !important;
+            margin-bottom: 0.75rem;
         }
         .stButton > button {
             background: linear-gradient(135deg, #4a90e2 0%, #5ba0f2 100%) !important;
@@ -43,6 +65,7 @@ def inject_premium_styles() -> None:
             transform: translateY(-2px) !important;
             box-shadow: 0 8px 25px rgba(74, 144, 226, 0.6) !important;
             background: linear-gradient(135deg, #5ba0f2 0%, #6bb0ff 100%) !important;
+            filter: brightness(1.1);
         }
         </style>
         """,

--- a/modern_ui_components.py
+++ b/modern_ui_components.py
@@ -7,12 +7,12 @@ from __future__ import annotations
 
 import streamlit as st
 
-from streamlit_helpers import inject_global_styles
+from modern_ui import inject_premium_styles
 
 
 def render_modern_layout() -> None:
     """Apply global styles and base glassmorphism containers."""
-    inject_global_styles()
+    inject_premium_styles()
     st.markdown(
         """
         <style>

--- a/streamlit_helpers.py
+++ b/streamlit_helpers.py
@@ -13,6 +13,7 @@ import html
 from typing import Literal
 
 import streamlit as st
+from modern_ui import inject_premium_styles
 
 
 def alert(
@@ -118,55 +119,8 @@ def apply_theme(theme: str) -> None:
 
 
 def inject_global_styles() -> None:
-    """Inject custom CSS styling for containers, cards and buttons."""
-    st.markdown(
-        """
-        <style>
-        body, .stApp {
-            background-color: var(--background, #F0F2F6);
-            color: var(--text-color, #333333);
-            font-family: var(--font-family, 'Inter', sans-serif);
-        }
-        .custom-container {
-            padding: 1rem;
-            border-radius: 8px;
-            border: 1px solid rgba(0,0,0,0.05);
-            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-            margin-bottom: 1rem;
-            background-color: var(--secondary-bg, #FFFFFF);
-        }
-        .card {
-            background-color: var(--secondary-bg, #FFFFFF);
-            padding: 1rem;
-            border: 1px solid rgba(0,0,0,0.1);
-            border-radius: 8px;
-            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-            margin-bottom: 1rem;
-        }
-        h1, h2, h3, h4, h5, h6 {
-            font-weight: 600;
-            margin: 0 0 0.5rem 0;
-        }
-        p {
-            line-height: 1.6;
-            margin-bottom: 0.75rem;
-        }
-        .stButton>button {
-            border-radius: 6px;
-            background: linear-gradient(90deg, var(--primary-color, #0A84FF), #2F70FF);
-            color: var(--text-color, #FFFFFF);
-            transition: filter 0.2s ease-in-out;
-            padding: 0.4rem 1rem;
-            font-weight: 600;
-            border: none;
-        }
-        .stButton>button:hover {
-            filter: brightness(1.1);
-        }
-        </style>
-        """,
-        unsafe_allow_html=True,
-    )
+    """Deprecated wrapper that forwards to :func:`modern_ui.inject_premium_styles`."""
+    inject_premium_styles()
 
 
 def theme_selector(label: str = "Theme", *, key_suffix: str | None = None) -> str:

--- a/ui.py
+++ b/ui.py
@@ -159,8 +159,6 @@ def render_agent_insights_tab():
     else:
         st.warning("No agents registered")
 
-# Fix theme_selector to handle missing key_suffix parameter
-
 # Add this modern UI code to your ui.py - replace the page loading section
 
 def inject_modern_styles():
@@ -481,18 +479,6 @@ def render_modern_social_page():
 
 # Add this to your main() function after st.set_page_config():
 inject_modern_styles()
-
-def theme_selector(label: str, key_suffix: str = "") -> str:
-    """Render theme selector with unique key."""
-    key = f"theme_selector_{key_suffix}" if key_suffix else "theme_selector"
-    theme = st.selectbox(
-        label,
-        ["light", "dark"],
-        index=0 if st.session_state.get("theme", "light") == "light" else 1,
-        key=key
-    )
-    st.session_state["theme"] = theme
-    return theme
 
 def load_css() -> None:
     """Placeholder for loading custom CSS."""


### PR DESCRIPTION
## Summary
- merge styling logic into `inject_premium_styles`
- use `inject_premium_styles` from `modern_ui_components`
- delegate `inject_global_styles` to the premium injector
- drop duplicate `theme_selector` in `ui.py`
- document usage of the new style injector

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'nicegui')*

------
https://chatgpt.com/codex/tasks/task_e_68897243a75c83209505a3bc37c6959d