### PR TITLE
Refactor sidebar layout

### DIFF
--- a/modern_ui_components.py
+++ b/modern_ui_components.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import streamlit as st
+from typing import Optional
 
 from modern_ui import inject_premium_styles
 
@@ -43,9 +44,14 @@ def render_modern_header(title: str) -> None:
     )
 
 
-def render_modern_sidebar(pages: dict[str, str]) -> str:
-    """Render a sidebar navigation menu and return the selected option."""
-    with st.sidebar:
+def render_modern_sidebar(
+    pages: dict[str, str],
+    container: Optional[st.delta_generator.DeltaGenerator] = None,
+) -> str:
+    """Render a navigation menu within ``container`` and return the selection."""
+    if container is None:
+        container = st
+    with container:
         st.markdown("<div class='glass-card'>", unsafe_allow_html=True)
         choice = st.radio("Navigate", list(pages.keys()))
         st.markdown("</div>", unsafe_allow_html=True)

--- a/transcendental_resonance_frontend/pages/resonance_music.py
+++ b/transcendental_resonance_frontend/pages/resonance_music.py
@@ -33,18 +33,20 @@ def _run_async(coro):
         return loop.run_until_complete(coro)
 
 
-def main(main_container=None) -> None:
+def main(main_container=None, status_container=None) -> None:
     """Render music generation and summary widgets."""
 
     if main_container is None:
         main_container = st
+    if status_container is None:
+        status_container = st
 
     # Auto-refresh for backend health check (global, outside main_container)
     st_autorefresh(interval=30000, key="status_ping")
 
-    # Render global backend status indicator in the sidebar
-    with st.sidebar:
-        render_status_icon(endpoint="/healthz") # Assuming /healthz is the correct health check endpoint
+    # Render global backend status indicator in the provided container
+    with status_container:
+        render_status_icon(endpoint="/healthz")
 
     # Display alert if backend is not reachable (check once per rerun)
     backend_ok = check_backend(endpoint="/healthz") # Use the modular check_backend

--- a/ui.py
+++ b/ui.py
@@ -1109,32 +1109,34 @@ def main() -> None:
             key="main_nav_menu"
         )
 
-        # Main content with sidebar
-        main_col, left_col = st.columns([3, 1])
+        # Main content with 3-column layout
+        left_col, center_col, right_col = st.columns([1, 3, 1])
 
-        with main_col:
+        with center_col:
             # Load page content
             load_page_with_fallback(choice)
-
         with left_col:
             render_status_icon()
 
-            with st.expander("Environment"):
+            with st.expander("Environment Details"):
                 secrets = get_st_secrets()
-                st.write(f"Database URL: {secrets.get('DATABASE_URL', 'not set')}")
-                st.write(f"ENV: {os.getenv('ENV', 'dev')}")
-                st.write(f"Session: {st.session_state['session_start_ts']} UTC")
+                info_text = (
+                    f"DB: {secrets.get('DATABASE_URL', 'not set')} | "
+                    f"ENV: {os.getenv('ENV', 'dev')} | "
+                    f"Session: {st.session_state['session_start_ts']} UTC"
+                )
+                st.info(info_text)
 
-            with st.expander("Settings"):
+            with st.expander("Application Settings"):
                 demo_mode = st.radio("Mode", ["Normal", "Demo"], horizontal=True)
                 theme_selector("Theme")
 
-            with st.expander("File Upload"):
+            with st.expander("Data Management"):
                 uploaded_file = st.file_uploader("Upload JSON", type="json")
                 if st.button("Run Analysis"):
                     st.success("Analysis complete!")
 
-            with st.expander("Agent Controls"):
+            with st.expander("Agent Configuration"):
                 api_info = render_api_key_ui()
                 backend_choice = api_info.get("model", "dummy")
                 api_key = api_info.get("api_key", "") or ""
@@ -1149,7 +1151,7 @@ def main() -> None:
             )
             st.session_state["governance_view"] = governance_view
 
-            with st.expander("Developer Tools"):
+            with st.expander("Simulation Tools"):
                 dev_tabs = st.tabs([
                     "Fork Universe",
                     "Universe State Viewer",


### PR DESCRIPTION
## Summary
- rework modern sidebar to accept a container instead of using `st.sidebar`
- update `resonance_music` to allow injecting a container for status indicator
- replace 2-column layout in `ui.py` with three columns and wrap controls in expanders

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_688977d66a1c8320900933ea91c707b0