### PR TITLE
Connect voting, agent, social and music pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,10 @@ ancestor/descendant traces update as you submit events.
 
 Use the **Resonance Music** page to generate simple MIDI snippets and view the metrics returned by the `/resonance-summary` endpoint.
 
+Additional pages for **Voting**, **Agents**, and **Social** features are
+accessible from the navigation bar. These sections provide early scaffolding
+for governance, AI insights, and community interaction.
+
 ### Starting the Backend
 
 The API must be reachable at [http://localhost:8000](http://localhost:8000). Start it with:

--- a/agent_ui.py
+++ b/agent_ui.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from typing import Any, cast
 
 import streamlit as st
-from streamlit_helpers import inject_global_styles
+from streamlit_helpers import inject_global_styles, theme_selector
 from voting_ui import (
     render_proposals_tab,
     render_governance_tab,

--- a/ui.py
+++ b/ui.py
@@ -479,10 +479,12 @@ def load_page_with_fallback(choice):
     
     try:
         page_module = pages[choice]
-        module_path = f"pages.{page_module}"
+        module_path = f"transcendental_resonance_frontend.pages.{page_module}"
         page_mod = import_module(module_path)
-        
-        if hasattr(page_mod, 'render'):
+
+        if hasattr(page_mod, "main"):
+            page_mod.main()
+        elif hasattr(page_mod, "render"):
             page_mod.render()
         else:
             render_modern_validation_page()
@@ -503,22 +505,26 @@ def load_page_with_fallback(choice):
 def render_modern_voting_page():
     """Modern voting page fallback."""
     st.markdown("# 🗳️ Voting Dashboard")
-    st.info("🚧 Advanced voting features coming soon!")
+    render_voting_tab()
 
 def render_modern_agents_page():
     """Modern agents page fallback."""
     st.markdown("# 🤖 AI Agents")
-    st.info("🚧 Agent management system in development!")
+    render_agent_insights_tab()
 
 def render_modern_music_page():
     """Modern music page fallback."""
     st.markdown("# 🎵 Resonance Music")
-    st.info("🚧 Harmonic resonance features coming soon!")
+    try:
+        from transcendental_resonance_frontend.pages import resonance_music
+        resonance_music.main()
+    except Exception:
+        st.info("🚧 Harmonic resonance features coming soon!")
 
 def render_modern_social_page():
     """Modern social page fallback."""
     st.markdown("# 👥 Social Network")
-    st.info("🚧 Social features in development!")
+    render_social_tab()
 
 # Add this to your main() function after st.set_page_config()
 


### PR DESCRIPTION
## Summary
- hook up additional Streamlit pages through `load_page_with_fallback`
- show voting, agent, music and social components directly from the main UI
- import missing helper in `agent_ui`
- document new navigation pages

## Testing
- `make test` *(fails: 17 failed, 42 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68897d8f31e4832091930c5f1a034291