### PR TITLE
Add integration for voting and agent pages

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -479,46 +479,67 @@ def load_page_with_fallback(choice):
     
     try:
         page_module = pages[choice]
-        module_path = f"pages.{page_module}"
+        module_path = f"transcendental_resonance_frontend.pages.{page_module}"
         page_mod = import_module(module_path)
-        
-        if hasattr(page_mod, 'render'):
+
+        if hasattr(page_mod, "render"):
             page_mod.render()
+        elif hasattr(page_mod, "main"):
+            page_mod.main()
         else:
-            render_modern_validation_page()
+            _render_fallback(choice)
     except ImportError:
-        # Beautiful fallback based on page choice
-        if choice == "Validation":
-            render_modern_validation_page()
-        elif choice == "Voting":
-            render_modern_voting_page()
-        elif choice == "Agents":
-            render_modern_agents_page()
-        elif choice == "Resonance Music":
-            render_modern_music_page()
-        elif choice == "Social":
-            render_modern_social_page()
+        _render_fallback(choice)
     except Exception as exc:
         st.error(f"Error loading page: {exc}")
+
+def _render_fallback(choice: str) -> None:
+    """Render page fallbacks when modules are missing."""
+    if choice == "Validation":
+        render_modern_validation_page()
+    elif choice == "Voting":
+        render_modern_voting_page()
+    elif choice == "Agents":
+        render_modern_agents_page()
+    elif choice == "Resonance Music":
+        render_modern_music_page()
+    elif choice == "Social":
+        render_modern_social_page()
 def render_modern_voting_page():
-    """Modern voting page fallback."""
+    """Modern voting page fallback using ``voting_ui`` widgets."""
     st.markdown("# 🗳️ Voting Dashboard")
-    st.info("🚧 Advanced voting features coming soon!")
+    try:
+        render_voting_tab()
+    except Exception:
+        st.info("🚧 Advanced voting features coming soon!")
 
 def render_modern_agents_page():
-    """Modern agents page fallback."""
+    """Modern agents page fallback using ``agent_ui`` widgets."""
     st.markdown("# 🤖 AI Agents")
-    st.info("🚧 Agent management system in development!")
+    try:
+        render_agent_insights_tab()
+    except Exception:
+        st.info("🚧 Agent management system in development!")
 
 def render_modern_music_page():
-    """Modern music page fallback."""
+    """Modern music page fallback invoking the resonance module if available."""
     st.markdown("# 🎵 Resonance Music")
-    st.info("🚧 Harmonic resonance features coming soon!")
+    try:
+        from transcendental_resonance_frontend.pages import resonance_music
+        if hasattr(resonance_music, "main"):
+            resonance_music.main()
+        else:
+            raise RuntimeError
+    except Exception:
+        st.info("🚧 Harmonic resonance features coming soon!")
 
 def render_modern_social_page():
-    """Modern social page fallback."""
+    """Modern social page fallback using ``social_tabs`` widgets."""
     st.markdown("# 👥 Social Network")
-    st.info("🚧 Social features in development!")
+    try:
+        render_social_tab()
+    except Exception:
+        st.info("🚧 Social features in development!")
 
 # Add this to your main() function after st.set_page_config()
 


### PR DESCRIPTION
## Summary
- scaffold navigation for Voting, Agents, Resonance Music and Social
- hook up optional modules when available and fall back gracefully

## Testing
- `pytest -q` *(fails: test_api_call_offline, test_get_user_recommendations_offline, test_refresh_network_notifies, test_refresh_metrics_notifies, test_refresh_events_notifies, test_feed_post_failure_notification, test_generate_speculative_payload_offline, test_generate_speculative_futures_length, test_set_theme_switches, test_apply_global_styles_injects_css, test_set_accent_overrides_default, test_toggle_high_contrast, test_glow_card_css)*

------
https://chatgpt.com/codex/tasks/task_e_68897d8f31e4832091930c5f1a034291