### PR TITLE
Add render wrappers for frontend pages

### DIFF
--- a/transcendental_resonance_frontend/pages/agents.py
+++ b/transcendental_resonance_frontend/pages/agents.py
@@ -20,5 +20,10 @@ def main():
             st.rerun()
 
 
+def render() -> None:
+    """Wrapper to keep page loading consistent."""
+    main()
+
+
 if __name__ == "__main__":
     main()

--- a/transcendental_resonance_frontend/pages/resonance_music.py
+++ b/transcendental_resonance_frontend/pages/resonance_music.py
@@ -135,3 +135,8 @@ def main(main_container=None, status_container=None) -> None:
 
                 except Exception as exc:
                     alert(f"Failed to load summary: {exc}. Ensure backend is running and 'resonance-summary' route is available.", "error")
+
+
+def render() -> None:
+    """Wrapper to keep page loading consistent."""
+    main()

--- a/transcendental_resonance_frontend/pages/social.py
+++ b/transcendental_resonance_frontend/pages/social.py
@@ -14,3 +14,8 @@ def main(main_container=None) -> None:
 
     with main_container:
         render_social_tab()
+
+
+def render() -> None:
+    """Wrapper to keep page loading consistent."""
+    main()

--- a/transcendental_resonance_frontend/pages/validation.py
+++ b/transcendental_resonance_frontend/pages/validation.py
@@ -14,3 +14,8 @@ def main(main_container=None) -> None:
 
     with main_container:
         render_validation_ui()
+
+
+def render() -> None:
+    """Wrapper to keep page loading consistent."""
+    main()

--- a/transcendental_resonance_frontend/pages/voting.py
+++ b/transcendental_resonance_frontend/pages/voting.py
@@ -14,3 +14,8 @@ def main(main_container=None) -> None:
 
     with main_container:
         render_voting_tab(main_container=main_container)
+
+
+def render() -> None:
+    """Wrapper to keep page loading consistent."""
+    main()


### PR DESCRIPTION
## Summary
- wrap each Streamlit page's `main()` in a simple `render()` function

## Testing
- `pytest transcendental_resonance_frontend/tests/test_debug_panel_page.py -q`
- `pytest transcendental_resonance_frontend/tests/test_offline_mode.py -q` *(fails: test_generate_speculative_payload_offline)*

------
https://chatgpt.com/codex/tasks/task_e_68898a106d488320a1f4a991b3a59a98