### PR TITLE
Implement basic validation UI renderer

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -1007,6 +1007,20 @@ def render_validation_ui(
     """Main entry point for the validation analysis UI with error handling."""
     if main_container is None:
         main_container = st
+    if sidebar is None:
+        sidebar = st.sidebar
+
+    page_func = globals().get("render_modern_validation_page")
+    if page_func is None:
+        st.error("Validation UI helper missing")
+        return
+
+    try:
+        with main_container:
+            page_func()
+    except Exception as exc:
+        st.error("Failed to load validation UI")
+        st.code(str(exc))
 
 def main() -> None:
     """Entry point with comprehensive error handling and modern UI."""


### PR DESCRIPTION
## Summary
- add initial implementation of `render_validation_ui`
- handle missing helper gracefully

## Testing
- `pytest -q` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68898937c2a88320bfa983e3992bb5ea