### PR TITLE
Fix dynamic nav fallback handling

### DIFF
--- a/frontend/ui_layout.py
+++ b/frontend/ui_layout.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import streamlit as st
 from typing import Iterable, Optional
+import html
 
 
 def main_container() -> st.delta_generator.DeltaGenerator:
@@ -49,10 +50,11 @@ def render_title_bar(icon: str, label: str) -> None:
 
 def show_preview_badge(text: str = "\ud83d\udea7 Preview Mode") -> None:
     """Overlay a badge used when a fallback page is shown."""
+    safe = html.escape(text)
     st.markdown(
         f"<div style='position:fixed;top:1rem;right:1rem;"
         f"background:#ffc107;color:#000;padding:0.25rem 0.5rem;"
-        f"border-radius:4px;z-index:1000;'>{text}</div>",
+        f"border-radius:4px;z-index:1000;'>{safe}</div>",
         unsafe_allow_html=True,
     )
 

--- a/transcendental_resonance_frontend/pages/agents.py
+++ b/transcendental_resonance_frontend/pages/agents.py
@@ -1,19 +1,22 @@
 import streamlit as st
 
+try:
+    from agent_ui import render_agent_insights_tab
+except Exception:  # pragma: no cover - optional dependency
+    render_agent_insights_tab = None  # type: ignore
 
-def main():
-    """Safe agent page that won't crash."""
+
+def main(main_container=None) -> None:
+    """Display available agent tools or fallback stub."""
+    if main_container is None:
+        main_container = st
+
     try:
         st.title("🤖 Agents")
-        st.info("Agent functionality is under development")
-
-        agents = ["MetaValidator", "Guardian", "Resonance"]
-        selected_agent = st.selectbox("Select Agent", agents, key="agent_select")
-
-        if st.button("Test Agent", key="test_agent"):
-            st.success(f"✅ {selected_agent} agent test complete")
-            st.json({"agent": selected_agent, "status": "ok", "test": True})
-
+        if render_agent_insights_tab is not None:
+            render_agent_insights_tab(main_container=main_container)
+        else:
+            st.warning("Agent logic coming soon...")
     except Exception as e:  # pragma: no cover - UI
         st.error(f"Agent page error: {e}")
         if st.button("Reset", key="agent_reset"):

--- a/voting_ui.py
+++ b/voting_ui.py
@@ -5,6 +5,7 @@ import asyncio
 import json
 import streamlit as st
 import pandas as pd
+from utils.safe_markdown import safe_markdown
 try:
     from st_aggrid import AgGrid, GridOptionsBuilder
 except Exception:  # pragma: no cover - optional dependency
@@ -27,6 +28,12 @@ BOX_CSS = """
 }
 </style>
 """
+
+
+def _safe_markdown(text: str, **kwargs) -> None:
+    """Render markdown after stripping non UTF-8 characters."""
+    clean = text.encode("utf-8", "ignore").decode("utf-8", "ignore")
+    st.markdown(clean, **kwargs)
 
 
 def _run_async(coro):
@@ -59,7 +66,7 @@ def render_proposals_tab(main_container=None) -> None:
             )
             return
 
-        st.markdown(
+        _safe_markdown(
             BOX_CSS
             + """
         <style>
@@ -219,7 +226,7 @@ def render_governance_tab(main_container=None) -> None:
             )
             return
         with st.container():
-            st.markdown(BOX_CSS + "<div class='tab-box'>", unsafe_allow_html=True)
+            _safe_markdown(BOX_CSS + "<div class='tab-box'>", unsafe_allow_html=True)
             if st.button("Refresh Votes"):
                 with st.spinner("Working on it..."):
                     try:
@@ -277,7 +284,7 @@ def render_agent_ops_tab(main_container=None) -> None:
             )
             return
         with st.container():
-            st.markdown(BOX_CSS + "<div class='tab-box'>", unsafe_allow_html=True)
+            _safe_markdown(BOX_CSS + "<div class='tab-box'>", unsafe_allow_html=True)
             if st.button("Reload Agent List"):
                 with st.spinner("Working on it..."):
                     try:
@@ -338,7 +345,7 @@ def render_logs_tab(main_container=None) -> None:
             )
             return
         with st.container():
-            st.markdown(BOX_CSS + "<div class='tab-box'>", unsafe_allow_html=True)
+            _safe_markdown(BOX_CSS + "<div class='tab-box'>", unsafe_allow_html=True)
             trace_text = st.text_area("Audit Trace JSON", value="{}", height=200)
             if st.button("Explain Trace"):
                 try:


### PR DESCRIPTION
## Summary
- improve `load_page_with_fallback` to gracefully execute modules and show errors
- sanitize preview badge text
- improve agent page to use real agent tools when available
- sanitize markdown output in voting UI
- fix agent checks and pass page paths when loading in main UI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68899169a508832087fc94d7cfe55d58