### PR TITLE
Fix bad container contexts

### DIFF
--- a/modern_ui_components.py
+++ b/modern_ui_components.py
@@ -51,7 +51,14 @@ def render_modern_sidebar(
     """Render a navigation menu within ``container`` and return the selection."""
     if container is None:
         container = st
-    with container:
+    container_ctx = (
+        container()
+        if callable(container)
+        else container
+        if hasattr(container, "__enter__")
+        else nullcontext()
+    )
+    with container_ctx:
         st.markdown("<div class='glass-card'>", unsafe_allow_html=True)
         choice = st.radio("Navigate", list(pages.keys()))
         st.markdown("</div>", unsafe_allow_html=True)

--- a/transcendental_resonance_frontend/pages/validation.py
+++ b/transcendental_resonance_frontend/pages/validation.py
@@ -4,24 +4,24 @@
 """Validation analysis page."""
 
 import streamlit as st
+from contextlib import nullcontext
 from ui import render_validation_ui
 
 
 def main(main_container=None) -> None:
-    """Render the validation UI inside a container."""
-    container = main_container if main_container is not None else st.container()
+    """Render the validation UI inside ``main_container`` safely."""
+    if main_container is None:
+        main_container = st
 
+    container_ctx = (
+        main_container()
+        if callable(main_container)
+        else main_container
+        if hasattr(main_container, "__enter__")
+        else nullcontext()
+    )
 
-    try:
-        # Try to use the container as a context manager
-        with container:
-            render_validation_ui()
-    except AttributeError:
-        # If the container isn't a context manager, call directly
-        render_validation_ui()
-
-        render_validation_ui()
-    else:
+    with container_ctx:
         render_validation_ui(main_container=main_container)
 
 


### PR DESCRIPTION
## Summary
- ensure streamlit helpers use nullcontext fallback for containers
- clean up validation page container logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688997c80cf08320bd29945b87dd39ae