### PR TITLE
Simplify validation page context logic

### DIFF
--- a/tests/test_validation_page.py
+++ b/tests/test_validation_page.py
@@ -1,0 +1,18 @@
+import streamlit as st
+from pathlib import Path
+import sys
+
+root = Path(__file__).resolve().parents[1]
+if str(root) not in sys.path:
+    sys.path.insert(0, str(root))
+
+from transcendental_resonance_frontend.pages import validation
+
+
+def test_validation_main_runs(monkeypatch):
+    called = {}
+    def dummy_render_validation_ui(*, main_container):
+        called['container'] = main_container
+    monkeypatch.setattr(validation, 'render_validation_ui', dummy_render_validation_ui)
+    validation.main(main_container=st)
+    assert called['container'] is st

--- a/transcendental_resonance_frontend/pages/validation.py
+++ b/transcendental_resonance_frontend/pages/validation.py
@@ -4,18 +4,16 @@
 """Validation analysis page."""
 
 import streamlit as st
+from contextlib import nullcontext
 from ui import render_validation_ui
 
 
 def main(main_container=None) -> None:
     """Render the validation UI inside a container."""
-    container = main_container if main_container is not None else st.container()
-
-    try:
-        with container:
-            render_validation_ui(main_container=container)
-    except AttributeError:
-        render_validation_ui(main_container=container)
+    main_container = main_container or st
+    container_ctx = main_container if hasattr(main_container, "__enter__") else nullcontext()
+    with container_ctx:
+        render_validation_ui(main_container=main_container)
 
 
 def render() -> None:

--- a/ui.py
+++ b/ui.py
@@ -1122,7 +1122,7 @@ def main() -> None:
                 # ✅ Already reviewed — just paste all that intact beneath this line
 
 
-                    with dev_tabs[0]:
+                with dev_tabs[0]:
                         if 'cosmic_nexus' in globals() and 'Harmonizer' in globals():
                             try:
                                 user = safe_get_user()
@@ -1141,7 +1141,7 @@ def main() -> None:
                         else:
                             st.info("Fork operation unavailable")
 
-                    with dev_tabs[1]:
+                with dev_tabs[1]:
                         if 'SessionLocal' in globals() and 'UniverseBranch' in globals():
                             try:
                                 with SessionLocal() as db:
@@ -1165,7 +1165,7 @@ def main() -> None:
                         else:
                             st.info("Database unavailable")
 
-                    with dev_tabs[2]:
+                with dev_tabs[2]:
                         hid = st.text_input("Hypothesis ID", key="audit_id")
                         if st.button("Run Audit") and hid:
                             if 'dispatch_route' in globals() and 'SessionLocal' in globals():
@@ -1201,7 +1201,7 @@ def main() -> None:
                             else:
                                 st.info("Audit functionality unavailable")
 
-                    with dev_tabs[3]:
+                with dev_tabs[3]:
                         log_path = Path("logchain_main.log")
                         if not log_path.exists():
                             log_path = Path("remix_logchain.log")
@@ -1214,7 +1214,7 @@ def main() -> None:
                         else:
                             st.info("No log file found")
 
-                    with dev_tabs[4]:
+                with dev_tabs[4]:
                         event_json = st.text_area(
                             "Event JSON", value="{}", height=150, key="inject_event"
                         )
@@ -1230,7 +1230,7 @@ def main() -> None:
                             else:
                                 st.info("Agent unavailable")
 
-                    with dev_tabs[5]:
+                with dev_tabs[5]:
                         if 'AGENT_REGISTRY' in globals():
                             st.write("Available agents:", list(AGENT_REGISTRY.keys()))
                         if 'cosmic_nexus' in globals():
@@ -1249,6 +1249,8 @@ def main() -> None:
                                     user_count = len(agent_obj.storage.get_all_users())
                                     st.write(f"User count: {user_count}")
                             except Exception:
+                                st.error("Storage info unavailable")
+
                 with dev_tabs[6]:
                     flow_txt = st.text_area(
                         "Agent Flow JSON",


### PR DESCRIPTION
## Summary
- simplify page context handling for validation UI
- import `nullcontext` and remove redundant call/try block
- add regression test for `validation.main`
- fix indentation issue in `ui.py` so tests import correctly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68899a60a2688320b6f3359880181a9a