### PR TITLE
Add validation page AppTest

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -4,4 +4,4 @@ markers =
     asyncio: mark a test as using asyncio
 addopts = --import-mode=importlib
 asyncio_mode = auto
-testpaths = tests
+testpaths = tests transcendental_resonance_frontend/tests

--- a/transcendental_resonance_frontend/tests/test_validation_page_render.py
+++ b/transcendental_resonance_frontend/tests/test_validation_page_render.py
@@ -1,0 +1,27 @@
+import sys
+import types
+
+import streamlit as st
+from streamlit.testing.v1 import AppTest
+
+
+def run_validation_page():
+    from transcendental_resonance_frontend.pages.validation import main
+    main()
+
+
+def test_validation_page_renders(monkeypatch):
+    dummy_ui = types.ModuleType("ui")
+
+    def render_validation_ui(*args, **kwargs):
+        st.checkbox("dummy")
+
+    dummy_ui.render_validation_ui = render_validation_ui
+    sys.modules["ui"] = dummy_ui
+
+    at = AppTest.from_function(run_validation_page)
+    at.run()
+    assert len(at.exception) == 0
+    assert len(at.checkbox) > 0
+
+


### PR DESCRIPTION
## Summary
- test validation Streamlit page with `AppTest`
- run new tests by adding `transcendental_resonance_frontend/tests` to pytest

## Testing
- `pytest -q transcendental_resonance_frontend/tests/test_validation_page_render.py`
- `pytest -q` *(fails: IndentationError in ui.py)*

------
https://chatgpt.com/codex/tasks/task_e_68899a62597483208d590191c653461d