### PR TITLE
Move BOX_CSS to helpers module

### DIFF
--- a/agent_ui.py
+++ b/agent_ui.py
@@ -7,7 +7,12 @@ from datetime import datetime
 from typing import Any, cast
 
 import streamlit as st
-from streamlit_helpers import inject_global_styles, theme_selector, safe_container
+from streamlit_helpers import (
+    inject_global_styles,
+    theme_selector,
+    safe_container,
+    BOX_CSS,
+)
 from voting_ui import (
     render_proposals_tab,
     render_governance_tab,
@@ -15,17 +20,6 @@ from voting_ui import (
     render_logs_tab,
 )
 from ui_utils import summarize_text, load_rfc_entries
-
-BOX_CSS = """
-<style>
-.tab-box {
-    padding: 1rem;
-    border-radius: 8px;
-    border: 1px solid #ddd;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.05);
-}
-</style>
-"""
 
 
 def render_agent_insights_tab(main_container=None) -> None:

--- a/streamlit_helpers.py
+++ b/streamlit_helpers.py
@@ -16,6 +16,18 @@ from contextlib import nullcontext
 import streamlit as st
 from modern_ui import inject_modern_styles
 
+# Shared CSS style for sections displayed in bordered boxes
+BOX_CSS = """
+<style>
+.tab-box {
+    padding: 1rem;
+    border-radius: 8px;
+    border: 1px solid #ddd;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+}
+</style>
+"""
+
 
 def alert(
     message: str,
@@ -180,4 +192,5 @@ __all__ = [
     "centered_container",
     "safe_container",
     "inject_global_styles",
+    "BOX_CSS",
 ]

--- a/voting_ui.py
+++ b/voting_ui.py
@@ -4,7 +4,7 @@
 import asyncio
 import json
 import streamlit as st
-from streamlit_helpers import safe_container
+from streamlit_helpers import safe_container, BOX_CSS
 import pandas as pd
 try:
     from st_aggrid import AgGrid, GridOptionsBuilder
@@ -17,17 +17,6 @@ try:
     from frontend_bridge import dispatch_route
 except Exception:  # pragma: no cover - optional dependency
     dispatch_route = None  # type: ignore
-
-BOX_CSS = """
-<style>
-.tab-box {
-    padding: 1rem;
-    border-radius: 8px;
-    border: 1px solid #ddd;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.05);
-}
-</style>
-"""
 
 
 def _sanitize_markdown(text: str) -> str:


### PR DESCRIPTION
## Summary
- centralize the `BOX_CSS` style constant in `streamlit_helpers.py`
- import `BOX_CSS` from helpers in `agent_ui.py` and `voting_ui.py`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889abb2d3a08320b0e2efc05390ac39