### PR TITLE
Fix page const duplication in main

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -1230,15 +1230,7 @@ def main() -> None:
             unsafe_allow_html=True,
         )
         
-        PAGES = {
-            "Validation": "validation",
-            "Voting": "voting",
-            "Agents": "agents",
-            "Resonance Music": "resonance_music",
-            "Social": "social",
-        }
-        
-        PAGES_DIR = Path(__file__).resolve().parent / "transcendental_resonance_frontend" / "pages"
+        # Build page paths using globally defined constants
         page_paths = {label: str(PAGES_DIR / f"{mod}.py") for label, mod in PAGES.items()}
         choice = ui_layout.render_navbar(
             page_paths,


### PR DESCRIPTION
## Summary
- reuse module-level `PAGES` and `PAGES_DIR` constants in `main`
- build `page_paths` from those globals

## Testing
- `pytest -q` *(fails: httpx.ConnectError, KeyError, AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_6889b66ac7708320ad1dc966d0236783