### PR TITLE
Handle missing pages gracefully in main

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -1254,7 +1254,11 @@ def main() -> None:
                     f"transcendental_resonance_frontend.pages.{page_key}",
                     f"pages.{page_key}",
                 ]
-                load_page_with_fallback(choice, module_paths)
+                try:
+                    load_page_with_fallback(choice, module_paths)
+                except Exception:
+                    st.warning(f"Page not found: {choice}")
+                    _render_fallback(choice)
             else:
                 st.info("Select a page above to continue.")
                 _render_fallback("Validation")  # Default fallback page as a preview


### PR DESCRIPTION
## Summary
- show a warning when a selected page is missing and fallback

## Testing
- `pytest -q` *(fails: 27 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6889b6642e688320835c47eb4c3253f5