### PR TITLE
Add minimal video chat UI

### DIFF
--- a/transcendental_resonance_frontend/pages/__init__.py
+++ b/transcendental_resonance_frontend/pages/__init__.py
@@ -7,5 +7,6 @@ __all__ = [
     "agents",       # Assuming these were present before the conflict snippet
     "resonance_music", # This is the key addition to resolve the page inclusion
     "video",
+    "video_chat",
 ]
 

--- a/transcendental_resonance_frontend/pages/video_chat.py
+++ b/transcendental_resonance_frontend/pages/video_chat.py
@@ -1,0 +1,74 @@
+"""Minimal Streamlit UI for experimental video chat."""
+
+from __future__ import annotations
+
+import asyncio
+
+import streamlit as st
+
+from ai_video_chat import create_session
+from video_chat_router import ConnectionManager
+from streamlit_helpers import safe_container
+
+
+def _run_async(coro):
+    """Run ``coro`` regardless of event loop state."""
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+    else:
+        if loop.is_running():
+            return asyncio.run_coroutine_threadsafe(coro, loop).result()
+        return loop.run_until_complete(coro)
+
+
+manager = ConnectionManager()
+
+
+def main(main_container=None) -> None:
+    """Render the simple video chat demo."""
+    container = main_container if main_container is not None else st
+
+    container_ctx = safe_container(container)
+    with container_ctx:
+        st.subheader("🎥 Video Chat")
+
+        session = st.session_state.get("video_chat_session")
+        messages = st.session_state.setdefault("video_chat_messages", [])
+
+        if session is None:
+            if st.button("Start Session", key="video_chat_start"):
+                session = create_session(["local-user"])
+                _run_async(session.start())
+                st.session_state["video_chat_session"] = session
+                st.success("Session started")
+        else:
+            st.write(f"Session ID: {session.session_id}")
+            if st.button("End Session", key="video_chat_end"):
+                _run_async(session.end())
+                st.session_state["video_chat_session"] = None
+                st.session_state["video_chat_messages"] = []
+                st.success("Session ended")
+                return
+
+            msg = st.text_input("Message", key="video_chat_input")
+            if st.button("Send", key="video_chat_send"):
+                if msg:
+                    _run_async(manager.broadcast(msg, sender=None))
+                    messages.append(f"You: {msg}")
+                    st.session_state["video_chat_input"] = ""
+
+            st.markdown("**Chat Log**")
+            for line in messages:
+                st.write(line)
+
+
+def render() -> None:
+    """Wrapper for Streamlit multipage support."""
+    main()
+
+
+if __name__ == "__main__":
+    main()
+

--- a/ui.py
+++ b/ui.py
@@ -68,7 +68,7 @@ PAGES = {
     "Voting": "voting",
     "Agents": "agents",
     "Resonance Music": "resonance_music",
-    "Video Chat": "video",
+    "Video Chat": "video_chat",
     "Social": "social",
 }
 
@@ -436,6 +436,11 @@ def load_page_with_fallback(choice: str, module_paths: list[str] | None = None) 
 
 def _render_fallback(choice: str) -> None:
     """Render built-in fallback if module is missing or errors out."""
+    try:
+        from transcendental_resonance_frontend.src.utils.api import OFFLINE_MODE
+    except Exception:
+        OFFLINE_MODE = False
+
     fallback_pages = {
         "Validation": render_modern_validation_page,
         "Voting": render_modern_voting_page,
@@ -446,6 +451,8 @@ def _render_fallback(choice: str) -> None:
     }
     fallback_fn = fallback_pages.get(choice)
     if fallback_fn:
+        if OFFLINE_MODE:
+            st.info("Backend unavailable - offline mode active.")
         show_preview_badge("🚧 Preview Mode")
         fallback_fn()
     else:
@@ -1260,7 +1267,7 @@ def main() -> None:
             "Voting": "voting",
             "Agents": "agents",
             "Resonance Music": "resonance_music",
-            "Video Chat": "video",
+            "Video Chat": "video_chat",
             "Social": "social",
         }
         


### PR DESCRIPTION
## Summary
- implement simple Streamlit video chat page backed by `ai_video_chat` helpers
- expose new page module in package init
- map **Video Chat** to the new page in `ui.PAGES`
- show message in `_render_fallback` when backend is offline

## Testing
- `pip install -r requirements.txt`
- `pip install nicegui==1.2.8`
- `pytest -q` *(fails: ModuleNotFoundError & runtime warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688a2dd056848320b20910ced2406e8d