### PR TITLE
Add chat messaging to video chat page

### DIFF
--- a/transcendental_resonance_frontend/src/pages/video_chat_page.py
+++ b/transcendental_resonance_frontend/src/pages/video_chat_page.py
@@ -10,9 +10,11 @@ import json
 from nicegui import ui
 
 from utils import ErrorOverlay
-from utils.api import TOKEN, WS_CONNECTION, listen_ws
+from utils.api import TOKEN, WS_CONNECTION, connect_ws
 from utils.layout import navigation_bar, page_container
 from utils.styles import get_theme
+
+from realtime_comm import VideoChatManager
 
 from .login_page import login_page
 
@@ -34,21 +36,51 @@ async def video_chat_page() -> None:
 
         error_overlay = ErrorOverlay()
 
+        manager = VideoChatManager()
+
         local_cam = ui.camera().classes("w-full mb-4")
         remote_view = ui.video().props("autoplay playsinline").classes("w-full mb-4")
+
+        messages = (
+            ui.column()
+            .classes("w-full mb-4")
+            .style("max-height: 200px; overflow-y: auto")
+        )
+        message_input = ui.input(placeholder="Type a message").classes("w-full mb-2")
+        send_button = ui.button("Send")
 
         async def handle_event(event: dict) -> None:
             if event.get("type") == "frame":
                 remote_view.source = event.get("data")
+            elif event.get("type") == "chat":
+                with messages:
+                    ui.chat_message(event.get("text", ""), name="Remote")
+                manager.translate_audio("remote", "en", event.get("text", ""))
+
+        async def start_ws() -> None:
+            global WS_CONNECTION
+            ws = await connect_ws("/ws/video")
+            if not ws:
+                return
+            try:
+                async for message in ws:
+                    try:
+                        data = json.loads(message)
+                    except Exception:
+                        continue
+                    await handle_event(data)
+            finally:
+                if not ws.closed:
+                    await ws.close()
+                if WS_CONNECTION is ws:
+                    WS_CONNECTION = None
 
         join_button = ui.button("Join Call")
 
         async def join_call() -> None:
             try:
-        async def join_call() -> None:
-            try:
-                ws_task = listen_ws(handle_event)
-                await ws_task
+                ws_task = ui.run_async(start_ws())
+                ui.context.client.on_disconnect(lambda: ws_task.cancel())
             except Exception:  # pragma: no cover - network issues
                 ui.notify("Realtime updates unavailable", color="warning")
                 join_button.disable()
@@ -57,15 +89,21 @@ async def video_chat_page() -> None:
 
         join_button.on_click(lambda: ui.run_async(join_call()))
 
-
         async def send_frame() -> None:
             if WS_CONNECTION and local_cam.value:
-                await WS_CONNECTION.send_text(
-                    json.dumps({"type": "frame", "data": local_cam.value})
-                )
+                await WS_CONNECTION.send_text(json.dumps({"type": "frame", "data": local_cam.value}))
+
+        async def send_chat() -> None:
+            if WS_CONNECTION and message_input.value:
+                await WS_CONNECTION.send_text(json.dumps({"type": "chat", "text": message_input.value}))
+                with messages:
+                    ui.chat_message(message_input.value, name="You", sent=True)
+                manager.translate_audio("local", "en", message_input.value)
+                message_input.value = ""
 
         local_cam.on("capture", lambda _: ui.run_async(send_frame()))
-        join_button = ui.button("Join Call", on_click=lambda: ui.run_async(join_call()))
+        send_button.on_click(lambda: ui.run_async(send_chat()))
+
         ui.label("Note: Video chat is unavailable when offline.").classes(
             "text-xs opacity-75 mt-2"
         )


### PR DESCRIPTION
## Summary
- support sending text chat over `/ws/video`
- display chat messages and voice translations
- hook up translation overlay via `VideoChatManager`

## Testing
- `pytest -q` *(fails: 14 failed, 51 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688a3bc8cb00832086ff39a82a049145