### PR TITLE
Fix UI bugs, add dark theme

### DIFF
--- a/api_key_input.py
+++ b/api_key_input.py
@@ -22,10 +22,25 @@ PROVIDERS = {
 }
 
 
-def render_api_key_ui(default: str = "Dummy") -> dict[str, str | None]:
-    """Render model selection and API key fields.
+def render_api_key_ui(
+    default: str = "Dummy",
+    *,
+    key_prefix: str | None = None,
+) -> dict[str, str | None]:
+    """Render model selection and API key fields with unique widget keys.
 
-    Returns a dictionary with ``model`` and ``api_key`` keys.
+    Parameters
+    ----------
+    default:
+        The provider name to pre-select in the dropdown.
+    key_prefix:
+        Optional prefix used to ensure widget keys are unique when this
+        component is rendered multiple times on a page.
+
+    Returns
+    -------
+    dict
+        Dictionary containing ``model`` and ``api_key`` values.
     """
     if st is None:
         return {"model": "dummy", "api_key": None}
@@ -35,7 +50,15 @@ def render_api_key_ui(default: str = "Dummy") -> dict[str, str | None]:
         index = names.index(default)
     else:
         index = 0
-    choice = st.selectbox("LLM Model", names, index=index)
+
+    prefix = f"{key_prefix}_" if key_prefix else ""
+
+    choice = st.selectbox(
+        "LLM Model",
+        names,
+        index=index,
+        key=f"{prefix}llm_model_select",
+    )
     model, key_name = PROVIDERS[choice]
     key_val = ""
     if key_name is not None:
@@ -43,6 +66,7 @@ def render_api_key_ui(default: str = "Dummy") -> dict[str, str | None]:
             f"{choice} API Key",
             type="password",
             value=st.session_state.get(key_name, ""),
+            key=f"{prefix}{key_name.lower()}_input",
         )
         if key_val:
             st.session_state[key_name] = key_val

--- a/modern_ui.py
+++ b/modern_ui.py
@@ -12,8 +12,8 @@ def inject_modern_styles() -> None:
         """
         <style>
         body, .stApp {
-            background-color: var(--background, #F0F2F6);
-            color: var(--text-color, #333333);
+            background: radial-gradient(circle at top left, #0e0e0e, #1a1a1a);
+            color: #e2e2e2;
             font-family: 'Inter', sans-serif;
         }
         .main .block-container {
@@ -31,16 +31,16 @@ def inject_modern_styles() -> None:
             background-color: var(--secondary-bg, #FFFFFF);
         }
         .card {
-            background-color: var(--secondary-bg, #FFFFFF);
+            background: linear-gradient(145deg, #1f1f1f, #272727);
             padding: 1rem;
-            border: 1px solid rgba(0,0,0,0.1);
-            border-radius: 8px;
-            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+            border: 1px solid #333;
+            border-radius: 12px;
+            box-shadow: 0 4px 10px rgba(0,0,0,0.4);
             margin-bottom: 1rem;
             transition: box-shadow 0.2s ease, transform 0.2s ease;
         }
         .card:hover {
-            box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+            box-shadow: 0 6px 20px rgba(0,255,255,0.15);
             transform: translateY(-2px);
         }
         h1, h2, h3, h4, h5, h6 {
@@ -62,21 +62,21 @@ def inject_modern_styles() -> None:
             margin-bottom: 0.75rem;
         }
         .stButton > button {
-            background: linear-gradient(135deg, #4a90e2 0%, #5ba0f2 100%) !important;
+            background: linear-gradient(135deg, #00aaff 0%, #00ffee 100%) !important;
             border: none !important;
             border-radius: 12px !important;
             color: white !important;
             font-weight: 600 !important;
             padding: 0.75rem 2rem !important;
             transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1) !important;
-            box-shadow: 0 4px 15px rgba(74, 144, 226, 0.4) !important;
+            box-shadow: 0 0 8px rgba(0, 255, 255, 0.4) !important;
             font-size: 0.95rem !important;
             height: auto !important;
         }
         .stButton > button:hover {
             transform: translateY(-1px) !important;
-            box-shadow: 0 6px 20px rgba(74, 144, 226, 0.5) !important;
-            background: linear-gradient(135deg, #5ba0f2 0%, #6bb0ff 100%) !important;
+            box-shadow: 0 0 16px rgba(0, 255, 255, 0.6) !important;
+            background: linear-gradient(135deg, #00ffee 0%, #00aaff 100%) !important;
             filter: brightness(1.05);
         }
 

--- a/transcendental_resonance_frontend/pages/profile.py
+++ b/transcendental_resonance_frontend/pages/profile.py
@@ -17,7 +17,7 @@ def main(main_container=None) -> None:
     with container_ctx:
         st.subheader("👤 Profile")
         st.info("Manage API credentials for advanced features.")
-        render_api_key_ui()
+        render_api_key_ui(key_prefix="profile")
 
 
 def render() -> None:

--- a/ui.py
+++ b/ui.py
@@ -448,7 +448,7 @@ def _render_fallback(choice: str) -> None:
     fallback_fn = fallback_pages.get(choice)
     if fallback_fn:
         if OFFLINE_MODE:
-            st.info("Backend unavailable - offline mode active.")
+            st.toast("Backend unavailable - offline mode active.")
         show_preview_badge("🚧 Preview Mode")
         fallback_fn()
     else:
@@ -943,14 +943,15 @@ def render_validation_ui(
         ui_layout.render_navbar(
             page_paths,
             icons=[
-                "check2-square",
-                "graph-up",
-                "robot",
-                "music-note-beamed",
-                "chat-text",
-                "people",
-                "person-circle",
+                "✅",
+                "📊",
+                "🤖",
+                "🎵",
+                "💬",
+                "👥",
+                "👤",
             ],
+            key="validation_nav_menu",
         )
 
         # Page layout
@@ -1241,14 +1242,15 @@ def main() -> None:
         choice = ui_layout.render_navbar(
             page_paths,
             icons=[
-                "check2-square",
-                "graph-up",
-                "robot",
-                "music-note-beamed",
-                "chat-text",
-                "people",
-                "person-circle",
+                "✅",
+                "📊",
+                "🤖",
+                "🎵",
+                "💬",
+                "👥",
+                "👤",
             ],
+            key="main_nav_menu",
         )
         
         left_col, center_col, right_col = st.columns([1, 3, 1])
@@ -1291,7 +1293,7 @@ def main() -> None:
                     st.success("Analysis complete!")
         
             with st.expander("Agent Configuration"):
-                api_info = render_api_key_ui()
+                api_info = render_api_key_ui(key_prefix="agent_cfg")
                 backend_choice = api_info.get("model", "dummy")
                 api_key = api_info.get("api_key", "") or ""
                 event_type = st.text_input("Event", value="LLM_INCOMING")

--- a/voting_ui.py
+++ b/voting_ui.py
@@ -78,11 +78,11 @@ def render_proposals_tab(main_container=None) -> None:
             )
             return
 
-        safe_markdown(
+        st.markdown(
             BOX_CSS
             + """
             <style>
-        .app-container { padding: 1rem; }
+            .app-container { padding: 1rem; }
         .card {
             background: #fff;
             border-radius: 8px;
@@ -127,8 +127,8 @@ def render_proposals_tab(main_container=None) -> None:
         </style>
         <div class='app-container'>
         """,
-        unsafe_allow_html=True,
-    )
+            unsafe_allow_html=True,
+        )
 
         col1, col2 = st.columns([1, 1])
 


### PR DESCRIPTION
## Summary
- fix duplicate keys in API key UI
- show offline notification as toast
- replace navbar icon shortcodes with emoji
- inject CSS in Voting page properly
- refresh modern style with neon dark mode accents

## Testing
- `pytest -q` *(fails: RuntimeError in nicegui context & assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_688a3e9d155083208fbe05c3850a0804