### PR TITLE
Switch offline fallback to toast

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -448,7 +448,7 @@ def _render_fallback(choice: str) -> None:
     fallback_fn = fallback_pages.get(choice)
     if fallback_fn:
         if OFFLINE_MODE:
-            st.info("Backend unavailable - offline mode active.")
+            st.toast("Offline mode: using mock services", icon="⚠️")
         show_preview_badge("🚧 Preview Mode")
         fallback_fn()
     else:


### PR DESCRIPTION
## Summary
- use a toast notification for offline mode

## Testing
- `pytest -q` *(fails: 27 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_688a43e7143c83208d637e53a34599a1