### PR TITLE
Add unique keys for navbar and API inputs

### DIFF
--- a/api_key_input.py
+++ b/api_key_input.py
@@ -22,7 +22,11 @@ PROVIDERS = {
 }
 
 
-def render_api_key_ui(default: str = "Dummy") -> dict[str, str | None]:
+def render_api_key_ui(
+    default: str = "Dummy",
+    *,
+    key_prefix: str = "main",
+) -> dict[str, str | None]:
     """Render model selection and API key fields.
 
     Returns a dictionary with ``model`` and ``api_key`` keys.
@@ -35,7 +39,12 @@ def render_api_key_ui(default: str = "Dummy") -> dict[str, str | None]:
         index = names.index(default)
     else:
         index = 0
-    choice = st.selectbox("LLM Model", names, index=index)
+    choice = st.selectbox(
+        "LLM Model",
+        names,
+        index=index,
+        key=f"{key_prefix}_model",
+    )
     model, key_name = PROVIDERS[choice]
     key_val = ""
     if key_name is not None:
@@ -43,6 +52,7 @@ def render_api_key_ui(default: str = "Dummy") -> dict[str, str | None]:
             f"{choice} API Key",
             type="password",
             value=st.session_state.get(key_name, ""),
+            key=f"{key_prefix}_api_key",
         )
         if key_val:
             st.session_state[key_name] = key_val

--- a/transcendental_resonance_frontend/pages/profile.py
+++ b/transcendental_resonance_frontend/pages/profile.py
@@ -17,7 +17,7 @@ def main(main_container=None) -> None:
     with container_ctx:
         st.subheader("👤 Profile")
         st.info("Manage API credentials for advanced features.")
-        render_api_key_ui()
+        render_api_key_ui(key_prefix="profile")
 
 
 def render() -> None:

--- a/ui.py
+++ b/ui.py
@@ -952,6 +952,7 @@ def render_validation_ui(
                 "👥",
                 "👤",
             ],
+            key="validation_nav_menu",
         )
 
         # Page layout
@@ -1250,6 +1251,7 @@ def main() -> None:
                 "👥",
                 "👤",
             ],
+            key="frontend_nav_menu",
         )
         
         left_col, center_col, right_col = st.columns([1, 3, 1])
@@ -1292,7 +1294,7 @@ def main() -> None:
                     st.success("Analysis complete!")
         
             with st.expander("Agent Configuration"):
-                api_info = render_api_key_ui()
+                api_info = render_api_key_ui(key_prefix="main")
                 backend_choice = api_info.get("model", "dummy")
                 api_key = api_info.get("api_key", "") or ""
                 event_type = st.text_input("Event", value="LLM_INCOMING")


### PR DESCRIPTION
## Summary
- support unique `key_prefix` in `render_api_key_ui`
- update profile page and main UI to use new prefix
- assign keys to navbar menus

## Testing
- `pytest -q` *(fails: 11 failed, 54 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688a43e4a5dc83208596c512168fc005