### PR TITLE
Set unique key_prefix for API key UI

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -1295,7 +1295,7 @@ def main() -> None:
                     st.success("Analysis complete!")
         
             with st.expander("Agent Configuration"):
-                api_info = render_api_key_ui(key_prefix="agent_cfg")
+                api_info = render_api_key_ui(key_prefix="main")
                 backend_choice = api_info.get("model", "dummy")
                 api_key = api_info.get("api_key", "") or ""
                 event_type = st.text_input("Event", value="LLM_INCOMING")


### PR DESCRIPTION
## Summary
- use `key_prefix="main"` in `ui.py`
- keep profile page prefix as `profile`

## Testing
- `pytest -q` *(fails: 14 failed, 51 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688a43e9180083208c901cd14482edc7