### PR TITLE
Fix import error in UI

### DIFF
--- a/api_key_input.py
+++ b/api_key_input.py
@@ -1,3 +1,6 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
 """Reusable helpers for API key input in the Streamlit UI."""
 
 from __future__ import annotations
@@ -43,7 +46,6 @@ def render_api_key_ui(
         Dictionary containing ``model`` and ``api_key`` values.
     """
 
-    """
     if st is None:
         return {"model": "dummy", "api_key": None}
 


### PR DESCRIPTION
## Summary
- add missing disclaimers to `api_key_input.py`
- fix stray triple quote that broke module import

## Testing
- `pip install streamlit nicegui`
- `pip install sqlalchemy`
- `pip install networkx`
- `pytest -q` *(fails: async plugin missing, style errors)*

------
https://chatgpt.com/codex/tasks/task_e_688a45a4e1cc8320983bc17f4c711af2