### PR TITLE
Fix render_simulation_stubs import error

### DIFF
--- a/api_key_input.py
+++ b/api_key_input.py
@@ -43,7 +43,6 @@ def render_api_key_ui(
         Dictionary containing ``model`` and ``api_key`` values.
     """
 
-    """
     if st is None:
         return {"model": "dummy", "api_key": None}
 

--- a/ui.py
+++ b/ui.py
@@ -520,8 +520,18 @@ def render_modern_profile_page() -> None:
 
 
 def load_css() -> None:
-    """Placeholder for loading custom CSS."""
-    pass
+    """Inject minimal custom CSS for accent color styling."""
+    st.markdown(
+        f"""
+        <style>
+        .stButton>button {{
+            background-color: {ACCENT_COLOR};
+            color: white;
+        }}
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
 
 
 # Accent color used for button styling
@@ -1175,6 +1185,7 @@ def main() -> None:
             initial_sidebar_state="collapsed",
         )
         inject_modern_styles()
+        load_css()
 
         # Initialize session state
         defaults = {


### PR DESCRIPTION
## Summary
- remove stray triple quote from `api_key_input.py`
- add simple CSS injection helper and call it on startup

## Testing
- `python -m py_compile ui.py`
- `python -m py_compile api_key_input.py`
- `pytest -q transcendental_resonance_frontend/tests/test_styles.py::test_set_theme_switches -q`

------
https://chatgpt.com/codex/tasks/task_e_688a45a85610832085751438aa4b9211