### PR TITLE
Fix api_key_input import for UI

### DIFF
--- a/api_key_input.py
+++ b/api_key_input.py
@@ -43,7 +43,6 @@ def render_api_key_ui(
         Dictionary containing ``model`` and ``api_key`` values.
     """
 
-    """
     if st is None:
         return {"model": "dummy", "api_key": None}
 


### PR DESCRIPTION
## Summary
- fix syntax error in `api_key_input.py` so that `render_simulation_stubs` can be imported

## Testing
- `pytest tests/test_ui_pages.py -q`
- `pytest transcendental_resonance_frontend/tests/test_ai_assist_page.py::test_ai_assist_page_is_async -q`


------
https://chatgpt.com/codex/tasks/task_e_688a45a85610832085751438aa4b9211