### PR TITLE
Improve modern styles

### DIFF
--- a/modern_ui.py
+++ b/modern_ui.py
@@ -11,9 +11,14 @@ def inject_modern_styles() -> None:
     st.markdown(
         """
         <style>
+        :root {
+            --neon-accent: #08f7fe;
+            --bg-start: #07182c;
+            --bg-end: #06203f;
+        }
         body, .stApp {
-            background-color: var(--background, #F0F2F6);
-            color: var(--text-color, #333333);
+            background: linear-gradient(135deg, var(--bg-start), var(--bg-end));
+            color: var(--text-color, #e6e6e6);
             font-family: 'Inter', sans-serif;
         }
         .main .block-container {
@@ -22,26 +27,20 @@ def inject_modern_styles() -> None:
             padding-right: 3rem;
             max-width: 1200px;
         }
-        .custom-container {
-            padding: 1rem;
-            border-radius: 8px;
-            border: 1px solid rgba(0,0,0,0.05);
-            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-            margin-bottom: 1rem;
-            background-color: var(--secondary-bg, #FFFFFF);
-        }
+        .custom-container,
         .card {
-            background-color: var(--secondary-bg, #FFFFFF);
             padding: 1rem;
-            border: 1px solid rgba(0,0,0,0.1);
-            border-radius: 8px;
-            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+            border-radius: 12px;
+            border: 1px solid rgba(255,255,255,0.05);
+            box-shadow: 0 1px 4px rgba(0,0,0,0.2);
             margin-bottom: 1rem;
-            transition: box-shadow 0.2s ease, transform 0.2s ease;
+            background-color: rgba(255,255,255,0.05);
+            transition: box-shadow 0.3s ease, transform 0.3s ease;
         }
-        .card:hover {
-            box-shadow: 0 4px 12px rgba(0,0,0,0.15);
-            transform: translateY(-2px);
+        .card:hover,
+        .custom-container:hover {
+            box-shadow: 0 4px 14px rgba(0,0,0,0.4);
+            transform: translateY(-3px);
         }
         h1, h2, h3, h4, h5, h6 {
             font-family: 'Inter', sans-serif !important;
@@ -49,12 +48,12 @@ def inject_modern_styles() -> None:
             line-height: 1.3 !important;
             margin: 0 0 0.5rem 0 !important;
         }
-        h1 { font-size: 2.25rem !important; }
-        h2 { font-size: 1.75rem !important; }
-        h3 { font-size: 1.5rem !important; }
-        h4 { font-size: 1.25rem !important; }
-        h5 { font-size: 1rem !important; }
-        h6 { font-size: 0.875rem !important; }
+        h1 { font-size: clamp(1.8rem, 5vw, 2.4rem) !important; }
+        h2 { font-size: clamp(1.5rem, 4vw, 2rem) !important; }
+        h3 { font-size: clamp(1.25rem, 3vw, 1.6rem) !important; }
+        h4 { font-size: clamp(1.1rem, 2.5vw, 1.3rem) !important; }
+        h5 { font-size: clamp(1rem, 2vw, 1.1rem) !important; }
+        h6 { font-size: clamp(0.875rem, 1.5vw, 1rem) !important; }
         }
         p, span, div {
             line-height: 1.6 !important;
@@ -62,28 +61,28 @@ def inject_modern_styles() -> None:
             margin-bottom: 0.75rem;
         }
         .stButton > button {
-            background: linear-gradient(135deg, #4a90e2 0%, #5ba0f2 100%) !important;
+            background: linear-gradient(90deg, var(--neon-accent), #00ffff) !important;
             border: none !important;
-            border-radius: 12px !important;
-            color: white !important;
+            border-radius: 10px !important;
+            color: #00111e !important;
             font-weight: 600 !important;
             padding: 0.75rem 2rem !important;
             transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1) !important;
-            box-shadow: 0 4px 15px rgba(74, 144, 226, 0.4) !important;
+            box-shadow: 0 4px 15px rgba(0, 255, 255, 0.4) !important;
             font-size: 0.95rem !important;
             height: auto !important;
         }
         .stButton > button:hover {
             transform: translateY(-1px) !important;
-            box-shadow: 0 6px 20px rgba(74, 144, 226, 0.5) !important;
-            background: linear-gradient(135deg, #5ba0f2 0%, #6bb0ff 100%) !important;
+            box-shadow: 0 6px 20px rgba(0, 255, 255, 0.6) !important;
+            background: linear-gradient(90deg, #00ffff, var(--neon-accent)) !important;
             filter: brightness(1.05);
         }
 
         input, textarea, select {
-            background-color: #2d2d2d !important;
+            background-color: #1a1a1a !important;
             color: #eee !important;
-            border: 1px solid #555 !important;
+            border: 1px solid #444 !important;
             border-radius: 8px !important;
         }
         </style>

--- a/transcendental_resonance_frontend/pages/agents.py
+++ b/transcendental_resonance_frontend/pages/agents.py
@@ -1,5 +1,8 @@
 import streamlit as st
+from modern_ui import inject_modern_styles
 from agent_ui import render_agent_insights_tab
+
+inject_modern_styles()
 
 
 def main(main_container=None) -> None:

--- a/transcendental_resonance_frontend/pages/chat.py
+++ b/transcendental_resonance_frontend/pages/chat.py
@@ -4,7 +4,10 @@
 """Chat page with text, video, and voice features."""
 
 import streamlit as st
+from modern_ui import inject_modern_styles
 from streamlit_helpers import safe_container
+
+inject_modern_styles()
 
 
 ### TRANSLATION_LOGIC

--- a/transcendental_resonance_frontend/pages/profile.py
+++ b/transcendental_resonance_frontend/pages/profile.py
@@ -4,8 +4,11 @@
 """User profile and API configuration page."""
 
 import streamlit as st
+from modern_ui import inject_modern_styles
 from streamlit_helpers import safe_container
 from api_key_input import render_api_key_ui
+
+inject_modern_styles()
 
 
 def main(main_container=None) -> None:

--- a/transcendental_resonance_frontend/pages/resonance_music.py
+++ b/transcendental_resonance_frontend/pages/resonance_music.py
@@ -13,10 +13,13 @@ from pathlib import Path
 
 import requests
 import streamlit as st
+from modern_ui import inject_modern_styles
 from streamlit_helpers import alert, centered_container, safe_container
 from streamlit_autorefresh import st_autorefresh
 from status_indicator import render_status_icon, check_backend # Ensure check_backend is imported
 from utils.api import get_resonance_summary, dispatch_route # Import get_resonance_summary and dispatch_route from utils.api
+
+inject_modern_styles()
 
 # BACKEND_URL is defined in utils.api, but we keep it here for direct requests calls if needed
 BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:8000")

--- a/transcendental_resonance_frontend/pages/social.py
+++ b/transcendental_resonance_frontend/pages/social.py
@@ -4,8 +4,11 @@
 """Friends & Followers page."""
 
 import streamlit as st
+from modern_ui import inject_modern_styles
 from social_tabs import render_social_tab
 from streamlit_helpers import safe_container
+
+inject_modern_styles()
 
 
 def main(main_container=None) -> None:

--- a/transcendental_resonance_frontend/pages/validation.py
+++ b/transcendental_resonance_frontend/pages/validation.py
@@ -4,8 +4,11 @@
 """Validation analysis page."""
 
 import streamlit as st
+from modern_ui import inject_modern_styles
 from streamlit_helpers import safe_container
 from ui import render_validation_ui
+
+inject_modern_styles()
 
 
 def main(main_container=None) -> None:

--- a/transcendental_resonance_frontend/pages/video_chat.py
+++ b/transcendental_resonance_frontend/pages/video_chat.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 import asyncio
 
 import streamlit as st
+from modern_ui import inject_modern_styles
 
 from ai_video_chat import create_session
 from video_chat_router import ConnectionManager
 from streamlit_helpers import safe_container
+
+inject_modern_styles()
 
 
 def _run_async(coro):

--- a/transcendental_resonance_frontend/pages/voting.py
+++ b/transcendental_resonance_frontend/pages/voting.py
@@ -4,8 +4,11 @@
 """Governance and voting page."""
 
 import streamlit as st
+from modern_ui import inject_modern_styles
 from voting_ui import render_voting_tab
 from streamlit_helpers import safe_container
+
+inject_modern_styles()
 
 
 def main(main_container=None) -> None:

--- a/ui.py
+++ b/ui.py
@@ -121,6 +121,9 @@ from modern_ui import (
     open_card_container,
     close_card_container,
 )
+
+# Apply global styles immediately
+inject_modern_styles()
 try:
     from frontend.ui_layout import overlay_badge, render_title_bar
 except ImportError:  # optional dependency fallback
@@ -237,124 +240,9 @@ def render_landing_page():
         boot_diagnostic_ui()
 
 def inject_modern_styles() -> None:
-    """Inject a sleek dark theme inspired by modern IDEs."""
-    st.markdown(
-        """
-        <style>
-        .stApp {
-            background-color: #1e1e1e;
-            color: #ccc;
-            font-family: 'Inter', sans-serif;
-            min-height: 100vh;
-        }
-
-        .main .block-container {
-            background-color: #252525;
-            border: 1px solid #333;
-            border-radius: 8px;
-            padding: 2rem 3rem;
-            margin-top: 1rem;
-        }
-
-        [data-testid="stSidebar"] {
-            background-color: #2d2d2d;
-            color: #ccc;
-        }
-
-        [data-testid="stHorizontalMenu"] ul {
-            display: flex;
-            gap: 0.5rem;
-            background: #252525;
-            padding: 0.5rem 1rem;
-            border-radius: 6px;
-        }
-
-        [data-testid="stHorizontalMenu"] a {
-            color: #ccc;
-            padding: 0.5rem 1rem;
-            border-radius: 4px;
-            transition: background 0.2s;
-            text-decoration: none;
-        }
-
-        [data-testid="stHorizontalMenu"] a:hover {
-            background: #333;
-            color: #fff;
-        }
-
-        [data-testid="stHorizontalMenu"] .active a {
-            background: #4f8bf9;
-            color: #fff;
-        }
-
-        .status-grid {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-            gap: 1rem;
-            margin-bottom: 1.5rem;
-        }
-
-        .status-card {
-            background: #2d2d2d;
-            border: 1px solid #3a3a3a;
-            border-radius: 8px;
-            padding: 1rem;
-            text-align: center;
-            transition: transform 0.2s;
-        }
-
-        .status-card:hover {
-            transform: translateY(-2px);
-        }
-
-        .stButton > button {
-            background-color: #4f8bf9;
-            color: #fff;
-            border: none;
-            border-radius: 6px;
-            padding: 0.5rem 1.25rem;
-            font-weight: 600;
-        }
-
-        .stButton > button:hover {
-            background-color: #699cfc;
-        }
-
-        input, textarea, select {
-            background-color: #2d2d2d;
-            color: #eee;
-            border: 1px solid #555;
-            border-radius: 6px;
-        }
-
-        /* Modern scrollbar */
-        ::-webkit-scrollbar {
-            width: 8px;
-        }
-
-        ::-webkit-scrollbar-track {
-            background: #252525;
-            border-radius: 10px;
-        }
-
-        ::-webkit-scrollbar-thumb {
-            background: #4f8bf9;
-            border-radius: 10px;
-        }
-
-        /* Animations */
-        @keyframes fadeIn {
-            from { opacity: 0; transform: translateY(20px); }
-            to { opacity: 1; transform: translateY(0); }
-        }
-
-        .main .block-container > div {
-            animation: fadeIn 0.6s ease-out;
-        }
-        </style>
-        """,
-        unsafe_allow_html=True,
-    )
+    """Backward compatible alias forwarding to :mod:`modern_ui`."""
+    from modern_ui import inject_modern_styles as _impl
+    _impl()
 
 
 # Backward compatibility alias


### PR DESCRIPTION
## Summary
- refresh `modern_ui.inject_modern_styles` with neon-accent variables, dark gradients and responsive typography
- apply global styles at startup in `ui.py`
- call the style helper in each Streamlit page module
- forward old `ui.inject_modern_styles` to the new implementation

## Testing
- `pytest tests/test_modern_ui_components.py tests/test_ui_pages.py tests/test_validation_page.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688a43e7f68c83208119bbe5417bbd34