### PR TITLE
Improve error handling and offline notice

### DIFF
--- a/transcendental_resonance_frontend/src/main.py
+++ b/transcendental_resonance_frontend/src/main.py
@@ -57,7 +57,7 @@ from .utils.features import (
     theme_personalization_panel,
     onboarding_overlay,
 )
-from .utils import ErrorOverlay, ApiStatusFooter
+from .utils import ApiStatusFooter
 
 ui.context.client.on_disconnect(clear_token)
 apply_global_styles()
@@ -69,7 +69,6 @@ onboarding = onboarding_overlay()
 contrast_toggle = high_contrast_switch()
 contrast_toggle.on("change", lambda e: toggle_high_contrast(e.value))
 theme_personalization_panel()
-error_overlay = ErrorOverlay()
 api_status = ApiStatusFooter()
 
 ws_status = (
@@ -78,21 +77,10 @@ ws_status = (
     .style("color: red")
 )
 
-# Show whether the frontend is running in offline mode
-if OFFLINE_MODE:
-    # Label bar across the bottom
-    ui.label("OFFLINE MODE – using mock services.")
-        .classes("fixed bottom-0 w-full text-center bg-red-600 text-white text-sm")
-
-    # Icon indicator (cloud_off)
-    ui.icon("cloud_off")
-        .classes("fixed bottom-0 right-0 m-2")
-        .style("color: red")
-else:
-    # Icon indicator (cloud_done)
-    ui.icon("cloud_done")
-        .classes("fixed bottom-0 right-0 m-2")
-        .style("color: green")
+# Show connection state icon
+ui.icon("cloud_off" if OFFLINE_MODE else "cloud_done")\
+    .classes("fixed bottom-0 right-0 m-2")\
+    .style(f"color: {'red' if OFFLINE_MODE else 'green'}")
 
 
 def _update_ws_status(status: str) -> None:
@@ -100,10 +88,8 @@ def _update_ws_status(status: str) -> None:
     ws_status.style(f"color: {color}")
     if status == "connected":
         ui.notify("WebSocket connected", color="positive")
-        error_overlay.hide()
     else:
-        ui.notify("WebSocket disconnected", color="warning")
-        error_overlay.show("Connection lost. Trying to reconnect...")
+        ui.notify("Connection lost. Trying to reconnect...", color="warning")
 
 on_ws_status_change(_update_ws_status)
 

--- a/transcendental_resonance_frontend/src/pages/messages_page.py
+++ b/transcendental_resonance_frontend/src/pages/messages_page.py
@@ -6,7 +6,6 @@
 from components.emoji_toolbar import emoji_toolbar
 from nicegui import ui
 
-from utils import ErrorOverlay
 from utils.api import TOKEN, api_call, listen_ws
 from utils.layout import navigation_bar, page_container
 from utils.safe_markdown import safe_markdown
@@ -30,7 +29,6 @@ async def messages_page():
             f'color: {THEME["accent"]};'
         )
 
-        error_overlay = ErrorOverlay()
 
         with ui.row().classes("w-full mb-2"):
             recipient = ui.input("Recipient Username").classes("w-full")
@@ -135,7 +133,6 @@ async def messages_page():
                 await ws_task
             except Exception:
                 ui.notify("Realtime updates unavailable", color="warning")
-                error_overlay.show("Realtime updates unavailable")
 
         ui.run_async(start_ws())
 

--- a/transcendental_resonance_frontend/src/pages/vibenodes_page.py
+++ b/transcendental_resonance_frontend/src/pages/vibenodes_page.py
@@ -12,7 +12,6 @@ from components.emoji_toolbar import emoji_toolbar
 from components.media_renderer import render_media_block
 from nicegui import ui
 
-from utils import ErrorOverlay
 from utils.api import TOKEN, api_call, listen_ws
 from utils.features import skeleton_loader
 from utils.layout import navigation_bar, page_container
@@ -37,7 +36,6 @@ async def vibenodes_page():
             f'color: {THEME["accent"]};'
         )
 
-        error_overlay = ErrorOverlay()
 
         ui.label("Trending").classes("text-xl font-bold mb-2")
         trending_list = ui.column().classes("w-full mb-4")
@@ -335,7 +333,6 @@ async def vibenodes_page():
                 await ws_task
             except Exception:
                 ui.notify("Realtime updates unavailable", color="warning")
-                error_overlay.show("Realtime updates unavailable")
 
         ui.run_async(start_ws())
 

--- a/transcendental_resonance_frontend/src/pages/video_chat_page.py
+++ b/transcendental_resonance_frontend/src/pages/video_chat_page.py
@@ -9,7 +9,6 @@ import json
 
 from nicegui import ui
 
-from utils import ErrorOverlay
 from utils.api import TOKEN, WS_CONNECTION, connect_ws
 from utils.layout import navigation_bar, page_container
 from utils.styles import get_theme
@@ -34,7 +33,6 @@ async def video_chat_page() -> None:
             f'color: {THEME["accent"]};'
         )
 
-        error_overlay = ErrorOverlay()
         manager = VideoChatManager()
 
         local_cam = ui.camera().classes("w-full mb-4")
@@ -96,7 +94,6 @@ async def video_chat_page() -> None:
                 ui.notify("Realtime updates unavailable", color="warning")
                 join_button.disable()
                 local_cam.disable()
-                error_overlay.show("Realtime updates unavailable")
 
 
         async def send_frame() -> None:

--- a/transcendental_resonance_frontend/src/utils/layout.py
+++ b/transcendental_resonance_frontend/src/utils/layout.py
@@ -32,7 +32,7 @@ except Exception:  # pragma: no cover - fallback stub for testing
     ui = types.SimpleNamespace(column=_dummy_column)
 
 from .styles import get_theme
-from .api import combined_search
+from .api import combined_search, OFFLINE_MODE
 
 
 def navigation_bar() -> Element:
@@ -114,5 +114,9 @@ def page_container(theme: Optional[dict] = None) -> Generator[Element, None, Non
     with ui.column().classes('w-full p-4').style(
         f"background: {theme['gradient']}; color: {theme['text']};"
     ) as container:
+        if OFFLINE_MODE:
+            ui.label("Offline Mode – using mock services.").classes(
+                "text-xs opacity-75 mb-2"
+            )
         yield container
 


### PR DESCRIPTION
## Summary
- centralize offline mode notice in page container
- show connection state icon without blocking label
- swap blocking error overlays for simple toasts
- adjust message, vibenodes, and video chat pages

## Testing
- `pytest -q` *(fails: 14 failed, 51 passed, 25 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688a43ce1a088320b180cc29b5b9156c