### PR TITLE
Fix widget key conflicts for API key input

### DIFF
--- a/api_key_input.py
+++ b/api_key_input.py
@@ -35,12 +35,13 @@ def render_api_key_ui(default: str = "Dummy") -> dict[str, str | None]:
         index = names.index(default)
     else:
         index = 0
-    choice = st.selectbox("LLM Model", names, index=index)
+    choice = st.selectbox("LLM Model", names, index=index, key="llm_model_select")
     model, key_name = PROVIDERS[choice]
     key_val = ""
     if key_name is not None:
         key_val = st.text_input(
             f"{choice} API Key",
+            key=f"{model}_api_key",
             type="password",
             value=st.session_state.get(key_name, ""),
         )


### PR DESCRIPTION
## Summary
- use a stable key for model select box
- use per-model key on API key input

## Testing
- `pytest tests/test_ui_pages.py tests/test_validation_page.py transcendental_resonance_frontend/tests/test_debug_panel_page.py transcendental_resonance_frontend/tests/test_offline_mode.py -q` *(fails: test_generate_speculative_payload_offline)*

------
https://chatgpt.com/codex/tasks/task_e_688a43cd54e08320be8f6bcc8d799f5e