### PR TITLE
Improve Streamlit layout styling

### DIFF
--- a/frontend/ui_layout.py
+++ b/frontend/ui_layout.py
@@ -97,7 +97,7 @@ def render_navbar(
         return st.session_state.get(key, opts[0][0])  # Return current selection
 
     except Exception as e:
-        st.warning(f"Navigation setup failed: {e}. Falling back to radio.")
+        st.toast(f"Navigation setup failed: {e}. Falling back to radio.", icon="⚠️")
         if USE_OPTION_MENU:
             icon_list = list(icons or ["dot"] * len(opts))
             return option_menu(

--- a/modern_ui_components.py
+++ b/modern_ui_components.py
@@ -18,12 +18,50 @@ except Exception:  # pragma: no cover - optional dependency
     option_menu = None  # type: ignore
     USE_OPTION_MENU = False
 
+# Sidebar styling for a dark glass look with hover and active states
+SIDEBAR_STYLES = """
+<style>
+.sidebar-nav {
+    background: rgba(0, 0, 0, 0.35);
+    border-radius: 12px;
+    padding: 0.5rem;
+    margin-bottom: 1rem;
+}
+.sidebar-nav .nav-item {
+    color: #f0f4f8;
+    font-weight: 500;
+    padding: 0.5rem 1rem;
+    border-radius: 8px;
+    margin-bottom: 0.25rem;
+    transition: background 0.2s ease;
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+}
+.sidebar-nav .nav-item:hover {
+    background: rgba(255, 255, 255, 0.05);
+}
+.sidebar-nav .nav-item.selected {
+    background: rgba(255, 255, 255, 0.15);
+}
+@media (max-width: 768px) {
+    .sidebar-nav {
+        padding: 0.25rem;
+    }
+    .sidebar-nav .nav-item {
+        padding: 0.75rem;
+    }
+}
+</style>
+"""
+
 
 def render_modern_layout() -> None:
     """Apply global styles and base glassmorphism containers."""
     inject_modern_styles()
     st.markdown(
         """
+        <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
         <style>
         .glass-card {
             background: rgba(255,255,255,0.3);
@@ -59,14 +97,21 @@ def render_modern_sidebar(
     pages: dict[str, str],
     container: Optional[st.delta_generator.DeltaGenerator] = None,
     icons: Optional[list[str]] = None,
+    *,
+    key: str = "nav_selection",
 ) -> str:
     """Render a vertical navigation menu and return the selected label."""
     if container is None:
         container = st.sidebar
 
+    state = getattr(st, "session_state", {})
+    if key not in state:
+        state[key] = list(pages.keys())[0]
+
     opts = list(pages.keys())
     container_ctx = safe_container(container)
     with container_ctx:
+        st.markdown(SIDEBAR_STYLES, unsafe_allow_html=True)
         st.markdown("<div class='glass-card sidebar-nav'>", unsafe_allow_html=True)
         if USE_OPTION_MENU and option_menu is not None:
             choice = option_menu(
@@ -74,12 +119,14 @@ def render_modern_sidebar(
                 options=opts,
                 icons=icons or ["dot"] * len(opts),
                 orientation="vertical",
-                key=f"sidebar_{id(pages)}",
+                key=key,
+                default_index=opts.index(state[key]),
             )
         else:
-            choice = st.radio("Navigate", opts, key=f"sidebar_{id(pages)}")
+            choice = st.radio("Navigate", opts, key=key, index=opts.index(state[key]))
+        state[key] = choice
         st.markdown("</div>", unsafe_allow_html=True)
-    return choice
+    return state[key]
 
 
 def render_validation_card(entry: dict) -> None:


### PR DESCRIPTION
## Summary
- apply toasts when navbar init fails
- add dark glass sidebar styles and responsive CSS
- ensure custom sidebar saves state without duplicate keys
- import Inter font in modern layout

## Testing
- `pytest tests/test_modern_ui_components.py::test_render_modern_sidebar_default_container -q`
- `pytest tests/test_ui_pages.py::test_unknown_page_triggers_fallback -q`
- `pytest tests -q`

------
https://chatgpt.com/codex/tasks/task_e_688a4ddc36c083209679f7492009285a