### PR TITLE
Document optional UI dependencies and skip tests when missing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
+# Contributing
+
+Thank you for your interest in improving this project! The notes below cover how to set up the testing environment.
+
+## Running the Tests
+
+Install the minimal dependencies first:
+
+```bash
+pip install -r requirements-minimal.txt
+```
+
+Some UI tests rely on optional packages. Install `streamlit` (already listed in `requirements.txt`) and [`nicegui`](https://github.com/zauberzeug/nicegui) if you want to run every test:
+
+```bash
+pip install streamlit nicegui
+```
+
+The test suite automatically skips UI tests when these packages are missing.
+
+After installing the packages, run:
+
+```bash
+pytest
+```
+
+We welcome pull requests that follow these guidelines.

--- a/README.md
+++ b/README.md
@@ -603,6 +603,13 @@ actual libraries:
 pip install redis passlib[bcrypt] python-jose[cryptography]
 ```
 
+UI-specific tests rely on additional optional packages. Install `streamlit` and
+`nicegui` if you want to exercise the full UI suite:
+
+```bash
+pip install streamlit nicegui
+```
+
 Installing both requirement files ensures all dependencies used in CI
 are available:
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,2 +1,38 @@
-# Root test fixtures placeholder
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
+"""Pytest configuration for optional UI dependencies."""
+
+import importlib.util
+import pytest
+
+try:
+    HAS_STREAMLIT = importlib.util.find_spec("streamlit") is not None
+except (ValueError, ImportError):
+    HAS_STREAMLIT = False
+
+try:
+    HAS_NICEGUI = importlib.util.find_spec("nicegui") is not None
+except (ValueError, ImportError):
+    HAS_NICEGUI = False
+
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line(
+        "markers",
+        "requires_streamlit: mark test to require the streamlit package",
+    )
+    config.addinivalue_line(
+        "markers",
+        "requires_nicegui: mark test to require the nicegui package",
+    )
+
+
+def pytest_runtest_setup(item: pytest.Item) -> None:
+    if item.get_closest_marker("requires_streamlit") and not HAS_STREAMLIT:
+        pytest.skip("streamlit not installed")
+    if item.get_closest_marker("requires_nicegui") and not HAS_NICEGUI:
+        pytest.skip("nicegui not installed")
 

--- a/tests/test_modern_ui_components.py
+++ b/tests/test_modern_ui_components.py
@@ -1,3 +1,11 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
+import pytest
+pytest.importorskip("streamlit")
+pytestmark = pytest.mark.requires_streamlit
+
 import types
 import sys
 from pathlib import Path

--- a/tests/test_ui_database.py
+++ b/tests/test_ui_database.py
@@ -1,3 +1,7 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
 import importlib
 import sqlite3
 from pathlib import Path
@@ -5,6 +9,8 @@ import sys
 import types
 
 import pytest
+pytest.importorskip("streamlit")
+pytestmark = pytest.mark.requires_streamlit
 
 
 def load_ui(monkeypatch):

--- a/tests/test_ui_pages.py
+++ b/tests/test_ui_pages.py
@@ -1,11 +1,17 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
 import importlib
 import contextlib
 import types
 from pathlib import Path
 import sys
 
-import streamlit as st
 import pytest
+pytest.importorskip("streamlit")
+pytestmark = pytest.mark.requires_streamlit
+import streamlit as st
 
 # Ensure repository root is importable
 root = Path(__file__).resolve().parents[1]

--- a/tests/test_validation_page.py
+++ b/tests/test_validation_page.py
@@ -1,3 +1,11 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
+import pytest
+pytest.importorskip("streamlit")
+pytestmark = pytest.mark.requires_streamlit
+
 import streamlit as st
 from pathlib import Path
 import sys

--- a/transcendental_resonance_frontend/tests/test_ai_assist_page.py
+++ b/transcendental_resonance_frontend/tests/test_ai_assist_page.py
@@ -1,3 +1,11 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
+import pytest
+pytest.importorskip("nicegui")
+pytestmark = pytest.mark.requires_nicegui
+
 import inspect
 from pages.ai_assist_page import ai_assist_page
 

--- a/transcendental_resonance_frontend/tests/test_api.py
+++ b/transcendental_resonance_frontend/tests/test_api.py
@@ -1,8 +1,15 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
+import pytest
+pytest.importorskip("nicegui")
+pytestmark = pytest.mark.requires_nicegui
+
 import inspect
 import importlib
 import types
 import utils.api as api_mod
-import pytest
 
 api_call = api_mod.api_call
 

--- a/transcendental_resonance_frontend/tests/test_api_failure_notifications.py
+++ b/transcendental_resonance_frontend/tests/test_api_failure_notifications.py
@@ -1,5 +1,12 @@
-import types
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
 import pytest
+pytest.importorskip("nicegui")
+pytestmark = pytest.mark.requires_nicegui
+
+import types
 
 import pages.network_analysis_page as network_page
 import pages.system_insights_page as system_insights_page

--- a/transcendental_resonance_frontend/tests/test_debug_panel_page.py
+++ b/transcendental_resonance_frontend/tests/test_debug_panel_page.py
@@ -1,3 +1,11 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
+import pytest
+pytest.importorskip("nicegui")
+pytestmark = pytest.mark.requires_nicegui
+
 import inspect
 from pages.debug_panel_page import debug_panel_page
 

--- a/transcendental_resonance_frontend/tests/test_demo_data.py
+++ b/transcendental_resonance_frontend/tests/test_demo_data.py
@@ -1,3 +1,11 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
+import pytest
+pytest.importorskip("nicegui")
+pytestmark = pytest.mark.requires_nicegui
+
 from utils import demo_data
 
 

--- a/transcendental_resonance_frontend/tests/test_events_page.py
+++ b/transcendental_resonance_frontend/tests/test_events_page.py
@@ -1,3 +1,11 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
+import pytest
+pytest.importorskip("nicegui")
+pytestmark = pytest.mark.requires_nicegui
+
 import inspect
 from pages.events_page import events_page
 

--- a/transcendental_resonance_frontend/tests/test_explore_page.py
+++ b/transcendental_resonance_frontend/tests/test_explore_page.py
@@ -1,6 +1,14 @@
 # STRICTLY A SOCIAL MEDIA PLATFORM
 # Intellectual Property & Artistic Inspiration
 # Legal & Ethical Safeguards
+
+import pytest
+pytest.importorskip("nicegui")
+pytestmark = pytest.mark.requires_nicegui
+
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
 import inspect
 
 from pages.explore_page import explore_page

--- a/transcendental_resonance_frontend/tests/test_features.py
+++ b/transcendental_resonance_frontend/tests/test_features.py
@@ -1,3 +1,11 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
+import pytest
+pytest.importorskip("nicegui")
+pytestmark = pytest.mark.requires_nicegui
+
 import inspect
 from utils.features import (
     quick_post_button,

--- a/transcendental_resonance_frontend/tests/test_feed_page.py
+++ b/transcendental_resonance_frontend/tests/test_feed_page.py
@@ -1,3 +1,11 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
+import pytest
+pytest.importorskip("nicegui")
+pytestmark = pytest.mark.requires_nicegui
+
 import inspect
 from pages.feed_page import feed_page
 

--- a/transcendental_resonance_frontend/tests/test_groups_page.py
+++ b/transcendental_resonance_frontend/tests/test_groups_page.py
@@ -1,3 +1,11 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
+import pytest
+pytest.importorskip("nicegui")
+pytestmark = pytest.mark.requires_nicegui
+
 import inspect
 from pages.groups_page import groups_page
 

--- a/transcendental_resonance_frontend/tests/test_layout.py
+++ b/transcendental_resonance_frontend/tests/test_layout.py
@@ -1,3 +1,11 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
+import pytest
+pytest.importorskip("nicegui")
+pytestmark = pytest.mark.requires_nicegui
+
 import inspect
 from utils.layout import search_widget, page_container
 

--- a/transcendental_resonance_frontend/tests/test_login_page.py
+++ b/transcendental_resonance_frontend/tests/test_login_page.py
@@ -1,3 +1,11 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
+import pytest
+pytest.importorskip("nicegui")
+pytestmark = pytest.mark.requires_nicegui
+
 import inspect
 from pages.login_page import login_page
 

--- a/transcendental_resonance_frontend/tests/test_messages_page.py
+++ b/transcendental_resonance_frontend/tests/test_messages_page.py
@@ -1,3 +1,11 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
+import pytest
+pytest.importorskip("nicegui")
+pytestmark = pytest.mark.requires_nicegui
+
 import inspect
 from pages.messages_page import messages_page
 

--- a/transcendental_resonance_frontend/tests/test_music_page.py
+++ b/transcendental_resonance_frontend/tests/test_music_page.py
@@ -1,3 +1,11 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
+import pytest
+pytest.importorskip("nicegui")
+pytestmark = pytest.mark.requires_nicegui
+
 import inspect
 from pages.music_page import music_page
 

--- a/transcendental_resonance_frontend/tests/test_network_analysis_page.py
+++ b/transcendental_resonance_frontend/tests/test_network_analysis_page.py
@@ -1,3 +1,11 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
+import pytest
+pytest.importorskip("nicegui")
+pytestmark = pytest.mark.requires_nicegui
+
 import inspect
 from pages.network_analysis_page import network_page
 

--- a/transcendental_resonance_frontend/tests/test_notifications_page.py
+++ b/transcendental_resonance_frontend/tests/test_notifications_page.py
@@ -1,3 +1,11 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
+import pytest
+pytest.importorskip("nicegui")
+pytestmark = pytest.mark.requires_nicegui
+
 import inspect
 from pages.notifications_page import notifications_page
 

--- a/transcendental_resonance_frontend/tests/test_offline_and_errors.py
+++ b/transcendental_resonance_frontend/tests/test_offline_and_errors.py
@@ -1,10 +1,16 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
+import pytest
+pytest.importorskip("nicegui")
+pytestmark = pytest.mark.requires_nicegui
+
 import asyncio
 import inspect
 import types
 import sys
 import importlib
-
-import pytest
 
 # Dummy NiceGUI components for testing
 class DummyElement:

--- a/transcendental_resonance_frontend/tests/test_offline_mode.py
+++ b/transcendental_resonance_frontend/tests/test_offline_mode.py
@@ -1,4 +1,11 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
 import pytest
+pytest.importorskip("nicegui")
+pytestmark = pytest.mark.requires_nicegui
+
 import inspect
 
 from utils.api import api_call, connect_ws, listen_ws

--- a/transcendental_resonance_frontend/tests/test_pages_init_imports.py
+++ b/transcendental_resonance_frontend/tests/test_pages_init_imports.py
@@ -1,3 +1,11 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
+import pytest
+pytest.importorskip("nicegui")
+pytestmark = pytest.mark.requires_nicegui
+
 import inspect
 
 from pages import register_page, network_page

--- a/transcendental_resonance_frontend/tests/test_profile_page.py
+++ b/transcendental_resonance_frontend/tests/test_profile_page.py
@@ -1,3 +1,11 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
+import pytest
+pytest.importorskip("nicegui")
+pytestmark = pytest.mark.requires_nicegui
+
 import inspect
 from pages.profile_page import profile_page
 

--- a/transcendental_resonance_frontend/tests/test_proposals_page.py
+++ b/transcendental_resonance_frontend/tests/test_proposals_page.py
@@ -1,3 +1,11 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
+import pytest
+pytest.importorskip("nicegui")
+pytestmark = pytest.mark.requires_nicegui
+
 import inspect
 from pages.proposals_page import proposals_page
 

--- a/transcendental_resonance_frontend/tests/test_quantum_futures.py
+++ b/transcendental_resonance_frontend/tests/test_quantum_futures.py
@@ -1,5 +1,12 @@
-import inspect
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
 import pytest
+pytest.importorskip("nicegui")
+pytestmark = pytest.mark.requires_nicegui
+
+import inspect
 from quantum_futures import generate_speculative_futures, DISCLAIMER
 
 

--- a/transcendental_resonance_frontend/tests/test_recommendations_page.py
+++ b/transcendental_resonance_frontend/tests/test_recommendations_page.py
@@ -1,3 +1,11 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
+import pytest
+pytest.importorskip("nicegui")
+pytestmark = pytest.mark.requires_nicegui
+
 import inspect
 from pages.recommendations_page import recommendations_page
 

--- a/transcendental_resonance_frontend/tests/test_simulation_graph.py
+++ b/transcendental_resonance_frontend/tests/test_simulation_graph.py
@@ -1,3 +1,11 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
+import pytest
+pytest.importorskip("nicegui")
+pytestmark = pytest.mark.requires_nicegui
+
 import sys
 from pathlib import Path
 

--- a/transcendental_resonance_frontend/tests/test_status_page.py
+++ b/transcendental_resonance_frontend/tests/test_status_page.py
@@ -1,3 +1,11 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
+import pytest
+pytest.importorskip("nicegui")
+pytestmark = pytest.mark.requires_nicegui
+
 import inspect
 from pages.status_page import status_page
 

--- a/transcendental_resonance_frontend/tests/test_styles.py
+++ b/transcendental_resonance_frontend/tests/test_styles.py
@@ -1,3 +1,11 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
+import pytest
+pytest.importorskip("nicegui")
+pytestmark = pytest.mark.requires_nicegui
+
 import types
 from utils import styles
 

--- a/transcendental_resonance_frontend/tests/test_system_insights_page.py
+++ b/transcendental_resonance_frontend/tests/test_system_insights_page.py
@@ -1,3 +1,11 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
+import pytest
+pytest.importorskip("nicegui")
+pytestmark = pytest.mark.requires_nicegui
+
 import inspect
 from pages.system_insights_page import system_insights_page
 

--- a/transcendental_resonance_frontend/tests/test_upload_page.py
+++ b/transcendental_resonance_frontend/tests/test_upload_page.py
@@ -1,3 +1,11 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
+import pytest
+pytest.importorskip("nicegui")
+pytestmark = pytest.mark.requires_nicegui
+
 import inspect
 from pages.upload_page import upload_page
 

--- a/transcendental_resonance_frontend/tests/test_validation_page_render.py
+++ b/transcendental_resonance_frontend/tests/test_validation_page_render.py
@@ -1,3 +1,15 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
+import pytest
+pytest.importorskip("nicegui")
+pytest.importorskip("streamlit")
+pytestmark = [
+    pytest.mark.requires_nicegui,
+    pytest.mark.requires_streamlit,
+]
+
 import sys
 import types
 

--- a/transcendental_resonance_frontend/tests/test_validator_graph_page.py
+++ b/transcendental_resonance_frontend/tests/test_validator_graph_page.py
@@ -1,3 +1,11 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
+import pytest
+pytest.importorskip("nicegui")
+pytestmark = pytest.mark.requires_nicegui
+
 import inspect
 from pages.validator_graph_page import validator_graph_page
 

--- a/transcendental_resonance_frontend/tests/test_vibenodes_page.py
+++ b/transcendental_resonance_frontend/tests/test_vibenodes_page.py
@@ -1,3 +1,11 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
+import pytest
+pytest.importorskip("nicegui")
+pytestmark = pytest.mark.requires_nicegui
+
 import inspect
 from pages.vibenodes_page import vibenodes_page
 


### PR DESCRIPTION
## Summary
- mention streamlit and nicegui as optional test dependencies
- add CONTRIBUTING notes about installing them for UI tests
- mark UI tests with `requires_streamlit` and `requires_nicegui`
- skip UI suites when those packages aren't installed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a4de422b48320b8bf6dbb50601ec8