### PR TITLE
Add profile card helper and sidebar expanders

### DIFF
--- a/frontend/ui_layout.py
+++ b/frontend/ui_layout.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 from typing import Dict, Iterable, Optional
 from uuid import uuid4
+import os
 import streamlit as st
 
 try:
@@ -39,6 +40,24 @@ def main_container() -> st.delta_generator.DeltaGenerator:
 def sidebar_container() -> st.delta_generator.DeltaGenerator:
     """Return the sidebar container."""
     return st.sidebar
+
+
+def render_profile_card(username: str, avatar_url: str) -> None:
+    """Render a compact profile card with an environment badge."""
+    env = os.getenv("APP_ENV", "development").lower()
+    badge = "\ud83d\ude80 Production" if env.startswith("prod") else "\ud83e\uddea Development"
+    st.markdown(
+        f"""
+        <div class='glass-card' style='display:flex;align-items:center;gap:0.5rem;'>
+            <img src="{avatar_url}" alt="avatar" width="48" style="border-radius:50%;" />
+            <div>
+                <strong>{username}</strong><br/>
+                <span style='font-size:0.85rem'>{badge}</span>
+            </div>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
 
 
 def render_navbar(
@@ -128,4 +147,5 @@ __all__ = [
     "render_navbar",
     "render_title_bar",
     "show_preview_badge",
+    "render_profile_card",
 ]

--- a/tests/test_profile_card.py
+++ b/tests/test_profile_card.py
@@ -1,0 +1,21 @@
+import types
+import sys
+from pathlib import Path
+import pytest
+pytest.importorskip("streamlit")
+pytestmark = pytest.mark.requires_streamlit
+
+root = Path(__file__).resolve().parents[1]
+if str(root) not in sys.path:
+    sys.path.insert(0, str(root))
+
+import frontend.ui_layout as ui_layout
+
+
+def test_render_profile_card_includes_env_badge(monkeypatch):
+    captured = {}
+    dummy_st = types.SimpleNamespace(markdown=lambda html, **k: captured.setdefault('html', html))
+    monkeypatch.setattr(ui_layout, 'st', dummy_st)
+    monkeypatch.setenv('APP_ENV', 'production')
+    ui_layout.render_profile_card('User', 'avatar.png')
+    assert '🚀 Production' in captured.get('html', '')

--- a/ui.py
+++ b/ui.py
@@ -39,6 +39,7 @@ from frontend.ui_layout import (
     main_container,
     render_title_bar,
     show_preview_badge,
+    render_profile_card,
 )
 
 
@@ -405,15 +406,13 @@ def render_sidebar() -> str:
     user = safe_get_user()
     avatar = getattr(user, "profile_pic", "https://via.placeholder.com/64")
     username = getattr(user, "username", "Guest")
-    st.sidebar.image(avatar, width=48)
-    st.sidebar.markdown(f"**{username}**", unsafe_allow_html=True)
-    st.sidebar.button("Create Proposal")
-    st.sidebar.button("Run Validation")
-    dark = st.sidebar.toggle("Dark Mode", value=st.session_state.get("theme") == "dark")
-    st.session_state["theme"] = "dark" if dark else "light"
-    env = os.getenv("ENV", "development").lower()
-    env_tag = "🚀 Production" if env.startswith("prod") else "🧪 Development"
-    st.sidebar.markdown(env_tag)
+    render_profile_card(username, avatar)
+    with st.sidebar.expander("Create Proposal"):
+        st.button("Create Proposal")
+    with st.sidebar.expander("Run Validation"):
+        st.button("Run Validation")
+    with st.sidebar.expander("Theme"):
+        theme_selector("Theme")
     icon_map = dict(zip(PAGES.keys(), NAV_ICONS))
     choice = render_modern_sidebar(PAGES, container=st.sidebar, icons=icon_map)
     return choice


### PR DESCRIPTION
## Summary
- add `render_profile_card` helper to `frontend/ui_layout.py`
- use profile card and collapsible sections in sidebar
- test profile card helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a522e18548320a110d2afa32d1c8a