### PR TITLE
Improve sidebar labels

### DIFF
--- a/modern_ui_components.py
+++ b/modern_ui_components.py
@@ -26,10 +26,12 @@ SIDEBAR_STYLES = """
     border-radius: 12px;
     padding: 0.5rem;
     margin-bottom: 1rem;
+    font-size: 0.75rem;
 }
 .sidebar-nav .nav-item {
     color: #f0f4f8;
     font-weight: 500;
+    font-size: 0.75rem;
     padding: 0.5rem 1rem;
     border-radius: 8px;
     margin-bottom: 0.25rem;
@@ -97,7 +99,8 @@ def render_modern_sidebar(
     pages: Dict[str, str],
     container: Optional[st.delta_generator.DeltaGenerator] = None,
     icons: Optional[Dict[str, str]] = None,
-
+    *,
+    key: str = "nav_selection",
 ) -> str:
     """Render a vertical navigation menu with optional icons."""
     if container is None:
@@ -109,6 +112,18 @@ def render_modern_sidebar(
 
     opts = list(pages.keys())
     icon_map = icons or {}
+    short_map = {
+        "Validation": "Validate",
+        "Voting": "Voting",
+        "Agents": "Agent",
+        "Resonance Music": "Music",
+        "Chat": "Chat",
+        "Social": "Social",
+        "Profile": "Profile",
+    }
+
+    display_opts = [short_map.get(o, o.split()[0]) for o in opts]
+
     session_key = f"sidebar_{id(pages)}"
     st.session_state.setdefault(session_key, opts[0])
 
@@ -116,18 +131,25 @@ def render_modern_sidebar(
     with container_ctx:
         st.markdown(SIDEBAR_STYLES, unsafe_allow_html=True)
         st.markdown("<div class='glass-card sidebar-nav'>", unsafe_allow_html=True)
-    if USE_OPTION_MENU and option_menu is not None:
-        choice = option_menu(
-            menu_title=None,
-            options=opts,
-            icons=icons or ["dot"] * len(opts),
-            orientation="vertical",
-            key=key,
-            default_index=opts.index(state.get(key, opts[0])),
-        )
-    else:
-        choice = st.radio("Navigate", opts, key=key, index=opts.index(state.get(key, opts[0])))
-    
+
+        if USE_OPTION_MENU and option_menu is not None:
+            choice_disp = option_menu(
+                menu_title=None,
+                options=display_opts,
+                icons=[icon_map.get(o, "dot") for o in opts],
+                orientation="vertical",
+                key=key,
+                default_index=display_opts.index(short_map.get(state.get(key, opts[0]), opts[0])),
+            )
+        else:
+            choice_disp = st.radio(
+                "Navigate",
+                display_opts,
+                key=key,
+                index=display_opts.index(short_map.get(state.get(key, opts[0]), opts[0])),
+            )
+
+    choice = opts[display_opts.index(choice_disp)]
     state[key] = choice
     st.markdown("</div>", unsafe_allow_html=True)
     return state[key]

--- a/tests/test_modern_ui_components.py
+++ b/tests/test_modern_ui_components.py
@@ -11,16 +11,17 @@ import modern_ui_components as mui
 
 def test_render_modern_sidebar_default_container(monkeypatch):
     calls = []
-    def dummy_button(label, key=None, help=None):
-        calls.append(label)
-        return False
+    def dummy_radio(label, options, key=None, index=0):
+        calls.append(options)
+        return options[index]
 
     dummy_st = types.SimpleNamespace(
         markdown=lambda *a, **k: None,
-        button=dummy_button,
-        sidebar=types.SimpleNamespace(markdown=lambda *a, **k: None, button=dummy_button),
+        radio=dummy_radio,
+        sidebar=types.SimpleNamespace(markdown=lambda *a, **k: None, radio=dummy_radio),
         session_state={},
     )
+    monkeypatch.setattr(mui, "USE_OPTION_MENU", False)
     monkeypatch.setattr(mui, "st", dummy_st)
     pages = {"A": "a", "B": "b"}
     assert mui.render_modern_sidebar(pages) == "A"


### PR DESCRIPTION
## Summary
- shorten sidebar labels with emoji and 1-word text
- shrink sidebar font size for compact nav
- update sidebar unit test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'streamlit')*

------
https://chatgpt.com/codex/tasks/task_e_688a51a955508320a48862dd3de20816