### PR TITLE
Add keyboard shortcuts and query params

### DIFF
--- a/modern_ui_components.py
+++ b/modern_ui_components.py
@@ -97,7 +97,8 @@ def render_modern_sidebar(
     pages: Dict[str, str],
     container: Optional[st.delta_generator.DeltaGenerator] = None,
     icons: Optional[Dict[str, str]] = None,
-
+    *,
+    key: str = "sidebar_nav",
 ) -> str:
     """Render a vertical navigation menu with optional icons."""
     if container is None:
@@ -116,20 +117,24 @@ def render_modern_sidebar(
     with container_ctx:
         st.markdown(SIDEBAR_STYLES, unsafe_allow_html=True)
         st.markdown("<div class='glass-card sidebar-nav'>", unsafe_allow_html=True)
-    if USE_OPTION_MENU and option_menu is not None:
-        choice = option_menu(
-            menu_title=None,
-            options=opts,
-            icons=icons or ["dot"] * len(opts),
-            orientation="vertical",
-            key=key,
-            default_index=opts.index(state.get(key, opts[0])),
-        )
-    else:
-        choice = st.radio("Navigate", opts, key=key, index=opts.index(state.get(key, opts[0])))
-    
-    state[key] = choice
-    st.markdown("</div>", unsafe_allow_html=True)
+        if USE_OPTION_MENU and option_menu is not None:
+            choice = option_menu(
+                menu_title=None,
+                options=opts,
+                icons=icons or ["dot"] * len(opts),
+                orientation="vertical",
+                key=key,
+                default_index=opts.index(state.get(key, opts[0])),
+            )
+        else:
+            choice = state.get(key, opts[0])
+            for opt in opts:
+                icon = icon_map.get(opt, "")
+                label = f"{icon} {opt}" if icon else opt
+                if st.button(label, key=f"{key}_{opt}"):
+                    choice = opt
+        state[key] = choice
+        st.markdown("</div>", unsafe_allow_html=True)
     return state[key]
 
 

--- a/ui.py
+++ b/ui.py
@@ -1043,7 +1043,7 @@ def main() -> None:
         st.info("Running in fallback mode")
 
     # Respond to lightweight health-check probes
-    params = st.query_params
+    params = st.experimental_get_query_params()
     path_info = os.environ.get("PATH_INFO", "").rstrip("/")
     if (
         "1" in params.get(HEALTH_CHECK_PARAM, [])
@@ -1058,6 +1058,27 @@ def main() -> None:
             page_title="superNova_2177",
             layout="wide",
             initial_sidebar_state="collapsed",
+        )
+        # Inject keyboard shortcuts for quick navigation
+        st.markdown(
+            """
+            <script>
+            document.addEventListener('keydown', function(e) {
+              const tag = document.activeElement.tagName;
+              if (tag === 'INPUT' || tag === 'TEXTAREA') { return; }
+              const params = new URLSearchParams(window.location.search);
+              if (e.key === 'N' || e.key === 'n') {
+                params.set('page', 'Voting');
+                window.location.search = params.toString();
+              }
+              if (e.key === 'V' || e.key === 'v') {
+                params.set('page', 'Validation');
+                window.location.search = params.toString();
+              }
+            });
+            </script>
+            """,
+            unsafe_allow_html=True,
         )
         inject_modern_styles()
 
@@ -1125,11 +1146,19 @@ def main() -> None:
             for label, mod in PAGES.items()
         }
 
-        # Modern Sidebar Nav
+        # Determine page from query params and sidebar
+        query = st.experimental_get_query_params()
+        forced_page = query.get("page", [None])[0]
+
         choice = render_modern_sidebar(
             page_paths,
             icons=["✅", "📊", "🤖", "🎵", "💬", "👥", "👤"],
         )
+
+        if forced_page in page_paths:
+            choice = forced_page
+
+        st.experimental_set_query_params(page=choice)
 
         # Page layout: left for tools, center for content
         left_col, center_col, _ = st.columns([1, 3, 1])


### PR DESCRIPTION
## Summary
- add javascript hotkeys in `ui.py`
- wire navigation query params to page choice
- expose `key` argument for `render_modern_sidebar`
- simplify sidebar rendering fallback

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a523011cc83209ee50b668a3ff92f