### PR TITLE
Improve text tab navigation

### DIFF
--- a/modern_ui_components.py
+++ b/modern_ui_components.py
@@ -18,39 +18,30 @@ except Exception:  # pragma: no cover - optional dependency
     option_menu = None  # type: ignore
     USE_OPTION_MENU = False
 
-# Sidebar styling for a dark glass look with hover and active states
+# Sidebar styling for lightweight text-based navigation
 SIDEBAR_STYLES = """
 <style>
 .sidebar-nav {
-    background: rgba(0, 0, 0, 0.35);
-    border-radius: 12px;
-    padding: 0.5rem;
+    display: flex;
+    flex-direction: column;
+    padding: 0;
     margin-bottom: 1rem;
 }
-.sidebar-nav .nav-item {
-    color: #f0f4f8;
-    font-weight: 500;
-    padding: 0.5rem 1rem;
-    border-radius: 8px;
-    margin-bottom: 0.25rem;
-    transition: background 0.2s ease;
-    display: flex;
-    gap: 0.5rem;
+.sidebar-nav.horizontal {
+    flex-direction: row;
     align-items: center;
 }
-.sidebar-nav .nav-item:hover {
+.sidebar-nav .stButton>button {
+    background: none;
+    border: none;
+    color: #f0f4f8;
+    padding: 0.35rem 0.75rem;
+    font-size: 0.8rem;
+    font-weight: 500;
+    white-space: nowrap;
+}
+.sidebar-nav .stButton>button:hover {
     background: rgba(255, 255, 255, 0.05);
-}
-.sidebar-nav .nav-item.selected {
-    background: rgba(255, 255, 255, 0.15);
-}
-@media (max-width: 768px) {
-    .sidebar-nav {
-        padding: 0.25rem;
-    }
-    .sidebar-nav .nav-item {
-        padding: 0.75rem;
-    }
 }
 </style>
 """
@@ -97,40 +88,35 @@ def render_modern_sidebar(
     pages: Dict[str, str],
     container: Optional[st.delta_generator.DeltaGenerator] = None,
     icons: Optional[Dict[str, str]] = None,
-
+    *,
+    key: str = "nav",
+    horizontal: bool = False,
 ) -> str:
-    """Render a vertical navigation menu with optional icons."""
+    """Render navigation links styled as modern text tabs."""
     if container is None:
         container = st.sidebar
 
-    state = getattr(st, "session_state", {})
-    if key not in state:
-        state[key] = list(pages.keys())[0]
-
     opts = list(pages.keys())
     icon_map = icons or {}
-    session_key = f"sidebar_{id(pages)}"
-    st.session_state.setdefault(session_key, opts[0])
+    st.session_state.setdefault(key, opts[0])
+
+    orientation_cls = "horizontal" if horizontal else "vertical"
 
     container_ctx = safe_container(container)
     with container_ctx:
         st.markdown(SIDEBAR_STYLES, unsafe_allow_html=True)
-        st.markdown("<div class='glass-card sidebar-nav'>", unsafe_allow_html=True)
-    if USE_OPTION_MENU and option_menu is not None:
-        choice = option_menu(
-            menu_title=None,
-            options=opts,
-            icons=icons or ["dot"] * len(opts),
-            orientation="vertical",
-            key=key,
-            default_index=opts.index(state.get(key, opts[0])),
+        st.markdown(
+            f"<div class='glass-card sidebar-nav {orientation_cls}'>",
+            unsafe_allow_html=True,
         )
-    else:
-        choice = st.radio("Navigate", opts, key=key, index=opts.index(state.get(key, opts[0])))
-    
-    state[key] = choice
-    st.markdown("</div>", unsafe_allow_html=True)
-    return state[key]
+        columns = container.columns(len(opts)) if horizontal else [container] * len(opts)
+        for col, label in zip(columns, opts):
+            disp = f"{icon_map.get(label, '')} {label}".strip()
+            if col.button(disp, key=f"{key}_{label}"):
+                st.session_state[key] = label
+        st.markdown("</div>", unsafe_allow_html=True)
+
+    return st.session_state[key]
 
 
 


### PR DESCRIPTION
## Summary
- style nav controls as lightweight text tabs
- support horizontal layout for modern sidebar navigation

## Testing
- `python -m py_compile modern_ui_components.py`
- `pytest tests/test_modern_ui_components.py::test_render_modern_sidebar_default_container -q` *(fails: ModuleNotFoundError: No module named 'streamlit')*

------
https://chatgpt.com/codex/tasks/task_e_688a51a25018832088150d9bdebc7398