### PR TITLE
Improve dynamic agent registry loading

### DIFF
--- a/protocols/__init__.py
+++ b/protocols/__init__.py
@@ -1,6 +1,6 @@
 # protocols/__init__.py
 
-from ._registry import AGENT_REGISTRY  # noqa: F401
+from ._registry import AGENT_REGISTRY, load_registry  # noqa: F401
 from .core.contracts import AgentTaskContract  # noqa: F401
 from .core.profiles import AgentProfile  # noqa: F401
 from .profiles.dream_weaver import DreamWeaver  # noqa: F401
@@ -8,6 +8,9 @@ from .profiles.validator_elf import ValidatorElf  # noqa: F401
 from .utils.forking import fork_agent  # noqa: F401
 from .utils.reflection import self_reflect  # noqa: F401
 from .utils.remote import handshake, ping_agent  # noqa: F401
+
+# Ensure the registry is populated before exposing agent classes
+load_registry()
 
 # Expose agent classes for convenience
 for _name, _info in AGENT_REGISTRY.items():

--- a/protocols/_registry.py
+++ b/protocols/_registry.py
@@ -1,78 +1,119 @@
 """Registry of core protocol agents and their purposes."""
 
-from .agents.ci_pr_protector_agent import CI_PRProtectorAgent
-from .agents.guardian_interceptor_agent import GuardianInterceptorAgent
-from .agents.meta_validator_agent import MetaValidatorAgent
-from .agents.observer_agent import ObserverAgent
-from .agents.collaborative_planner_agent import CollaborativePlannerAgent
-from .agents.coordination_sentinel_agent import CoordinationSentinelAgent
-from .agents.harmony_synthesizer_agent import HarmonySynthesizerAgent
-from .agents.temporal_audit_agent import TemporalAuditAgent
-from .agents.cross_universe_bridge_agent import CrossUniverseBridgeAgent
-from .agents.anomaly_spotter_agent import AnomalySpotterAgent
-from .agents.quantum_resonance_agent import QuantumResonanceAgent
-from .agents.codex_agent import CodexAgent
+from __future__ import annotations
 
-# Mapping of agent names to metadata dictionaries
-AGENT_REGISTRY = {
+import importlib
+import logging
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+
+# Map of agent names to the modules that implement them
+_AGENT_SPECS = {
     "CI_PRProtectorAgent": {
-        "class": CI_PRProtectorAgent,
+        "module": "protocols.agents.ci_pr_protector_agent",
+        "class": "CI_PRProtectorAgent",
         "description": "Repairs CI/PR failures by proposing patches.",
         "llm_capable": True,
     },
     "GuardianInterceptorAgent": {
-        "class": GuardianInterceptorAgent,
+        "module": "protocols.agents.guardian_interceptor_agent",
+        "class": "GuardianInterceptorAgent",
         "description": "Inspects LLM suggestions for risky content.",
         "llm_capable": True,
     },
     "MetaValidatorAgent": {
-        "class": MetaValidatorAgent,
+        "module": "protocols.agents.meta_validator_agent",
+        "class": "MetaValidatorAgent",
         "description": "Audits patches and adjusts trust scores.",
         "llm_capable": True,
     },
     "ObserverAgent": {
-        "class": ObserverAgent,
+        "module": "protocols.agents.observer_agent",
+        "class": "ObserverAgent",
         "description": "Monitors agent outputs and suggests forks when needed.",
         "llm_capable": False,
     },
     "CollaborativePlannerAgent": {
-        "class": CollaborativePlannerAgent,
+        "module": "protocols.agents.collaborative_planner_agent",
+        "class": "CollaborativePlannerAgent",
         "description": "Coordinates tasks and delegates to the best agent.",
         "llm_capable": False,
     },
     "CoordinationSentinelAgent": {
-        "class": CoordinationSentinelAgent,
+        "module": "protocols.agents.coordination_sentinel_agent",
+        "class": "CoordinationSentinelAgent",
         "description": "Detects suspicious validator coordination patterns.",
         "llm_capable": False,
     },
     "HarmonySynthesizerAgent": {
-        "class": HarmonySynthesizerAgent,
+        "module": "protocols.agents.harmony_synthesizer_agent",
+        "class": "HarmonySynthesizerAgent",
         "description": "Transforms metrics into short MIDI snippets.",
         "llm_capable": False,
     },
     "TemporalAuditAgent": {
-        "class": TemporalAuditAgent,
+        "module": "protocols.agents.temporal_audit_agent",
+        "class": "TemporalAuditAgent",
         "description": "Audits timestamps for suspicious gaps or disorder.",
         "llm_capable": False,
     },
     "CrossUniverseBridgeAgent": {
-        "class": CrossUniverseBridgeAgent,
+        "module": "protocols.agents.cross_universe_bridge_agent",
+        "class": "CrossUniverseBridgeAgent",
         "description": "Validates cross-universe remix provenance.",
         "llm_capable": True,
     },
     "AnomalySpotterAgent": {
-        "class": AnomalySpotterAgent,
+        "module": "protocols.agents.anomaly_spotter_agent",
+        "class": "AnomalySpotterAgent",
         "description": "Flags anomalies in metrics streams.",
         "llm_capable": True,
     },
     "QuantumResonanceAgent": {
-        "class": QuantumResonanceAgent,
+        "module": "protocols.agents.quantum_resonance_agent",
+        "class": "QuantumResonanceAgent",
         "description": "Tracks resonance via quantum simulation.",
         "llm_capable": True,
     },
     "CodexAgent": {
-        "class": CodexAgent,
+        "module": "protocols.agents.codex_agent",
+        "class": "CodexAgent",
         "description": "Base agent with in-memory utilities.",
         "llm_capable": False,
     },
 }
+
+# Mapping of agent names to metadata dictionaries
+AGENT_REGISTRY: Dict[str, Dict[str, Any]] = {}
+
+
+def load_registry() -> Dict[str, Dict[str, Any]]:
+    """Populate ``AGENT_REGISTRY`` using dynamic imports."""
+
+    if AGENT_REGISTRY:
+        return AGENT_REGISTRY
+
+    for name, info in _AGENT_SPECS.items():
+        try:
+            module = importlib.import_module(info["module"])
+            agent_cls = getattr(module, info["class"])
+        except Exception as exc:  # pragma: no cover - error path
+            logger.error(
+                "Failed to load agent %s from %s: %s", name, info["module"], exc
+            )
+            continue
+
+        AGENT_REGISTRY[name] = {
+            "class": agent_cls,
+            "description": info["description"],
+            "llm_capable": info["llm_capable"],
+        }
+
+    return AGENT_REGISTRY
+
+
+# Initialize registry at import time for backward compatibility
+load_registry()
+


### PR DESCRIPTION
## Summary
- make `_registry` use `importlib` to load agents dynamically
- initialize registry via helper `load_registry`
- ensure `__init__` calls `load_registry` before exposing agent classes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a5e9cbd508320838ca733b6adc141