### PR TITLE
Ensure Validation page is default

### DIFF
--- a/tests/test_ui_pages.py
+++ b/tests/test_ui_pages.py
@@ -89,3 +89,72 @@ def test_unknown_page_triggers_fallback(monkeypatch):
     ui.main()
 
     assert fallback_called.get("choice") == "Ghost"
+
+
+def test_main_defaults_to_validation(monkeypatch):
+    monkeypatch.setenv("UI_DEBUG_PRINTS", "0")
+    importlib.reload(ui)
+
+    loaded = {}
+    monkeypatch.setattr(
+        ui,
+        "load_page_with_fallback",
+        lambda choice, paths: loaded.setdefault("choice", choice),
+    )
+    monkeypatch.setattr(ui, "get_st_secrets", lambda: {})
+    monkeypatch.setattr(mui, "render_modern_sidebar", lambda *a, **k: st.session_state.get("active_page"))
+    monkeypatch.setattr(ui, "render_modern_sidebar", lambda *a, **k: st.session_state.get("active_page"))
+
+    class Dummy(contextlib.AbstractContextManager):
+        def __enter__(self):
+            return self
+        def __exit__(self, *exc):
+            return False
+        def container(self):
+            return Dummy()
+        def expander(self, *a, **k):
+            return Dummy()
+        def tabs(self, labels):
+            return [Dummy() for _ in labels]
+
+    monkeypatch.setattr(st, "set_page_config", lambda *a, **k: None)
+    monkeypatch.setattr(st, "expander", lambda *a, **k: Dummy())
+    monkeypatch.setattr(st, "container", lambda: Dummy())
+    monkeypatch.setattr(st, "columns", lambda *a, **k: [Dummy(), Dummy(), Dummy()])
+    monkeypatch.setattr(st, "tabs", lambda labels: [Dummy() for _ in labels])
+    for fn in [
+        "markdown",
+        "info",
+        "error",
+        "warning",
+        "write",
+        "button",
+        "file_uploader",
+        "text_input",
+        "text_area",
+        "divider",
+        "progress",
+        "json",
+        "subheader",
+        "radio",
+        "toggle",
+    ]:
+        monkeypatch.setattr(st, fn, lambda *a, **k: None)
+
+    monkeypatch.setattr(st, "session_state", {})
+    monkeypatch.setattr(st, "query_params", {})
+
+    for helper in [
+        "apply_theme",
+        "inject_modern_styles",
+        "render_status_icon",
+        "render_simulation_stubs",
+        "render_stats_section",
+    ]:
+        monkeypatch.setattr(ui, helper, lambda *a, **k: None)
+
+    monkeypatch.setattr(ui, "render_api_key_ui", lambda *a, **k: {"model": "dummy", "api_key": ""})
+
+    ui.main()
+
+    assert loaded.get("choice") == "Validation"

--- a/ui.py
+++ b/ui.py
@@ -1212,7 +1212,7 @@ def main() -> None:
             st.session_state.setdefault(k, v)
 
         if st.session_state.get("critical_error"):
-            st.error("Application Error: " + st.session_state["critical_error"])
+            st.error("Application Error: " + st.session_state.get("critical_error", ""))
             if st.button("Reset Application", key="reset_app_critical"):
                 st.session_state.clear()
                 st.rerun()
@@ -1224,7 +1224,7 @@ def main() -> None:
             logger.warning("CSS load failed: %s", exc)
 
         try:
-            apply_theme(st.session_state["theme"])
+            apply_theme(st.session_state.get("theme", "light"))
         except Exception as exc:
             st.warning(f"Theme load failed: {exc}")
 
@@ -1270,6 +1270,9 @@ def main() -> None:
         param = query.get("page")
         forced_page = param[0] if isinstance(param, list) else param
 
+        if st.session_state.get("active_page") not in PAGES:
+            st.session_state["active_page"] = "Validation"
+
 
         choice = render_modern_sidebar(
             page_paths,
@@ -1298,7 +1301,7 @@ def main() -> None:
                 info_text = (
                     f"DB: {secrets.get('DATABASE_URL', 'not set')} | "
                     f"ENV: {os.getenv('ENV', 'dev')} | "
-                    f"Session: {st.session_state['session_start_ts']} UTC"
+                    f"Session: {st.session_state.get('session_start_ts', '')} UTC"
                 )
                 st.info(info_text)
 
@@ -1402,10 +1405,10 @@ def main() -> None:
                 # Show agent output
                 if st.session_state.get("agent_output") is not None:
                     st.subheader("Agent Output")
-                    st.json(st.session_state["agent_output"])
+                    st.json(st.session_state.get("agent_output"))
 
                 render_stats_section()
-                st.markdown(f"**Runs:** {st.session_state['run_count']}")
+                st.markdown(f"**Runs:** {st.session_state.get('run_count', 0)}")
 
 
     except Exception as exc:


### PR DESCRIPTION
## Summary
- guard session state lookups with `get()`
- reset the active page to Validation if invalid
- test that startup defaults to Validation preview

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a5ea039ec83209b1bada9f81d833a