### PR TITLE
Handle missing agents or backends gracefully

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -1366,38 +1366,47 @@ def main() -> None:
                     except Exception as exc:
                         alert(f"Invalid payload: {exc}", "error")
                     else:
-                        backend_fn = get_backend(backend_choice.lower(), api_key or None)
-                        if backend_fn is None:
-                            alert("Invalid backend selected", "error")
-                            st.session_state["agent_output"] = None
-                            st.stop()
+                        try:
+                            backend_fn = get_backend(
+                                backend_choice.lower(), api_key or None
+                            )
+                            if backend_fn is None:
+                                raise KeyError("backend")
 
-                        agent_cls = AGENT_REGISTRY.get(agent_choice, {}).get("class")
-                        if agent_cls is None:
-                            alert("Unknown agent selected", "error")
-                        else:
-                            try:
-                                if agent_choice == "CI_PRProtectorAgent":
-                                    talker = backend_fn or (lambda p: p)
-                                    selected_agent = agent_cls(
-                                        talker, llm_backend=backend_fn
-                                    )
-                                elif agent_choice == "MetaValidatorAgent":
-                                    selected_agent = agent_cls({}, llm_backend=backend_fn)
-                                elif agent_choice == "GuardianInterceptorAgent":
-                                    selected_agent = agent_cls(llm_backend=backend_fn)
-                                else:
-                                    selected_agent = agent_cls(llm_backend=backend_fn)
+                            agent_cls = AGENT_REGISTRY.get(agent_choice, {}).get(
+                                "class"
+                            )
+                            if agent_cls is None:
+                                raise KeyError("agent")
 
-                                st.session_state["agent_instance"] = selected_agent
-                                result = selected_agent.process_event(
-                                    {"event": event_type, "payload": payload}
+                            if agent_choice == "CI_PRProtectorAgent":
+                                talker = backend_fn or (lambda p: p)
+                                selected_agent = agent_cls(
+                                    talker, llm_backend=backend_fn
                                 )
-                                st.session_state["agent_output"] = result
-                                st.success("Agent executed")
-                            except Exception as exc:
-                                st.session_state["agent_output"] = {"error": str(exc)}
-                                alert(f"Agent error: {exc}", "error")
+                            elif agent_choice == "MetaValidatorAgent":
+                                selected_agent = agent_cls({}, llm_backend=backend_fn)
+                            elif agent_choice == "GuardianInterceptorAgent":
+                                selected_agent = agent_cls(llm_backend=backend_fn)
+                            else:
+                                selected_agent = agent_cls(llm_backend=backend_fn)
+
+                            st.session_state["agent_instance"] = selected_agent
+                            result = selected_agent.process_event(
+                                {"event": event_type, "payload": payload}
+                            )
+                            st.session_state["agent_output"] = result
+                            st.success("Agent executed")
+                        except KeyError as missing:
+                            if str(missing) == "'backend'":
+                                st.warning("No backend available")
+                            else:
+                                st.warning("No agents available")
+                            st.session_state["agent_output"] = None
+                            _render_fallback("Agents")
+                        except Exception as exc:
+                            st.session_state["agent_output"] = {"error": str(exc)}
+                            alert(f"Agent error: {exc}", "error")
 
                 # Show agent output
                 if st.session_state.get("agent_output") is not None:


### PR DESCRIPTION
## Summary
- avoid stopping the Streamlit UI when agent or backend is missing
- show a warning and fallback page if no agents or backends can be used

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a5eb46a14832084a7da3392228f2e