### PR TITLE
Fix sidebar state updates and default page

### DIFF
--- a/modern_ui_components.py
+++ b/modern_ui_components.py
@@ -109,6 +109,8 @@ def render_modern_sidebar(
 
     # Default session state for selected page
     st.session_state.setdefault(key, opts[0])
+    if st.session_state.get(key) not in opts:
+        st.session_state[key] = opts[0]
 
     orientation_cls = "horizontal" if horizontal else "vertical"
 
@@ -154,7 +156,8 @@ def render_modern_sidebar(
             # Final fallback
             choice = st.session_state.get(key, opts[0])
 
-        st.session_state[key] = choice
+        if st.session_state.get(key) != choice:
+            st.session_state[key] = choice
         st.markdown("</div>", unsafe_allow_html=True)
         return choice
 

--- a/tests/test_ui_pages.py
+++ b/tests/test_ui_pages.py
@@ -89,3 +89,73 @@ def test_unknown_page_triggers_fallback(monkeypatch):
     ui.main()
 
     assert fallback_called.get("choice") == "Ghost"
+
+
+def test_main_defaults_to_validation(monkeypatch):
+    monkeypatch.setenv("UI_DEBUG_PRINTS", "0")
+    importlib.reload(ui)
+
+    monkeypatch.setattr(ui, "_render_fallback", lambda choice: None)
+    monkeypatch.setattr(ui, "load_page_with_fallback", lambda choice, paths: None)
+    monkeypatch.setattr(ui, "get_st_secrets", lambda: {})
+
+    class Dummy(contextlib.AbstractContextManager):
+        def __enter__(self):
+            return self
+        def __exit__(self, *exc):
+            return False
+        def container(self):
+            return Dummy()
+        def expander(self, *a, **k):
+            return Dummy()
+        def tabs(self, labels):
+            return [Dummy() for _ in labels]
+
+    monkeypatch.setattr(st, "set_page_config", lambda *a, **k: None)
+    monkeypatch.setattr(st, "expander", lambda *a, **k: Dummy())
+    monkeypatch.setattr(st, "container", lambda: Dummy())
+    monkeypatch.setattr(st, "columns", lambda *a, **k: [Dummy(), Dummy(), Dummy()])
+    monkeypatch.setattr(st, "tabs", lambda labels: [Dummy() for _ in labels])
+    for fn in [
+        "markdown",
+        "info",
+        "error",
+        "warning",
+        "write",
+        "button",
+        "file_uploader",
+        "text_input",
+        "text_area",
+        "divider",
+        "progress",
+        "json",
+        "subheader",
+        "radio",
+        "toggle",
+    ]:
+        monkeypatch.setattr(st, fn, lambda *a, **k: None)
+
+    session = {"sidebar_nav": "Ghost"}
+    monkeypatch.setattr(st, "session_state", session)
+    params = {"page": "Unknown"}
+    monkeypatch.setattr(st, "query_params", params)
+    monkeypatch.setattr(st, "experimental_get_query_params", lambda: params)
+    monkeypatch.setattr(st, "experimental_set_query_params", lambda **k: params.update(k))
+
+    for helper in [
+        "apply_theme",
+        "inject_modern_styles",
+        "render_status_icon",
+        "render_simulation_stubs",
+        "render_stats_section",
+    ]:
+        monkeypatch.setattr(ui, helper, lambda *a, **k: None)
+
+    monkeypatch.setattr(ui, "render_api_key_ui", lambda *a, **k: {"model": "dummy", "api_key": ""})
+    monkeypatch.setattr(mui, "render_modern_sidebar", lambda *a, **k: session.get("sidebar_nav"))
+    monkeypatch.setattr(ui, "render_modern_sidebar", lambda *a, **k: session.get("sidebar_nav"))
+
+    ui.main()
+
+    assert params.get("page") == "Validation"
+    assert session.get("sidebar_nav") == "Validation"

--- a/ui.py
+++ b/ui.py
@@ -1270,13 +1270,19 @@ def main() -> None:
         param = query.get("page")
         forced_page = param[0] if isinstance(param, list) else param
 
+        # Validate session state and query params
+        if st.session_state.get("sidebar_nav") not in page_paths:
+            st.session_state["sidebar_nav"] = "Validation"
+
+        if forced_page not in page_paths:
+            forced_page = None
 
         choice = render_modern_sidebar(
             page_paths,
             icons=["✅", "📊", "🤖", "🎵", "💬", "👥", "👤"],
         )
 
-        if forced_page in page_paths:
+        if forced_page:
             choice = forced_page
 
         try:


### PR DESCRIPTION
## Summary
- update `render_modern_sidebar` to avoid unnecessary state writes
- ensure UI always falls back to the Validation page if the stored page or query parameter is invalid
- add regression tests for sidebar state and default page behaviour

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a5eb17c8c83208dc4bbbf5b5bd6d1