### PR TITLE
Refine sidebar component

### DIFF
--- a/docs/codex_theme.md
+++ b/docs/codex_theme.md
@@ -36,3 +36,7 @@ The `inject_modern_styles()` helper exposes a few utility classes:
 | `.gradient-btn` | Applies the gradient button styling with hover animations. |
 | `.sidebar-nav .nav-item` | Sidebar navigation element with soft highlights. |
 | `.sidebar-nav .icon` | Emoji icon wrapper used inside nav items. |
+
+``SIDEBAR_STYLES`` in ``modern_ui_components`` exposes the sidebar navigation
+CSS. Inject it via ``st.markdown(SIDEBAR_STYLES, unsafe_allow_html=True)`` when
+building custom sidebars to match the default look.

--- a/frontend/ui_layout.py
+++ b/frontend/ui_layout.py
@@ -23,6 +23,7 @@ from typing import Dict, Iterable, Optional
 from uuid import uuid4
 import os
 import streamlit as st
+from modern_ui_components import SIDEBAR_STYLES
 
 try:
     from streamlit_option_menu import option_menu
@@ -86,6 +87,8 @@ def _render_sidebar_nav(
     choice = active
     container = st.sidebar.container()
     with container:
+        st.markdown(SIDEBAR_STYLES, unsafe_allow_html=True)
+        st.markdown("<div class='glass-card sidebar-nav'>", unsafe_allow_html=True)
         if hasattr(st.sidebar, "page_link"):
             for (label, path), icon in zip(opts, icon_list):
                 try:
@@ -106,6 +109,8 @@ def _render_sidebar_nav(
             labels = [f"{icon or ''} {label}".strip() for (label, _), icon in zip(opts, icon_list)]
             choice = st.radio("", labels, index=index, key=key)
             choice = opts[labels.index(choice)][0]
+
+        st.markdown("</div>", unsafe_allow_html=True)
 
     st.session_state[session_key] = choice
     return choice

--- a/modern_ui_components.py
+++ b/modern_ui_components.py
@@ -19,7 +19,9 @@ except Exception:  # pragma: no cover - optional dependency
     option_menu = None  # type: ignore
     USE_OPTION_MENU = False
 
-# Sidebar styling for lightweight text-based navigation
+# Sidebar styling for lightweight text-based navigation.
+# Inject this CSS string with ``st.markdown`` to keep sidebar navigation
+# consistent across pages.
 SIDEBAR_STYLES = """
 <style>
 .sidebar-nav {
@@ -50,6 +52,12 @@ SIDEBAR_STYLES = """
 }
 .sidebar-nav .stButton>button:hover {
     background: rgba(255, 255, 255, 0.05);
+}
+@media (max-width: 600px) {
+    .sidebar-nav.horizontal {
+        flex-direction: column;
+        align-items: stretch;
+    }
 }
 </style>
 """
@@ -97,10 +105,14 @@ def render_modern_sidebar(
     container: Optional[st.delta_generator.DeltaGenerator] = None,
     icons: Optional[Dict[str, str]] = None,
     *,
-    key: str = "sidebar_nav",
+    session_key: str = "sidebar_nav",
     horizontal: bool = False,
 ) -> str:
-    """Render navigation links styled as modern text tabs, with fallback modes."""
+    """Render navigation links styled as modern text tabs.
+
+    ``session_key`` determines where the active page is stored in
+    ``st.session_state`` so multiple sidebars can coexist without collisions.
+    """
     if container is None:
         container = st.sidebar
 
@@ -108,7 +120,9 @@ def render_modern_sidebar(
     icon_map = icons or {}
 
     # Default session state for selected page
-    st.session_state.setdefault(key, opts[0])
+    st.session_state.setdefault(session_key, opts[0])
+
+    widget_key = f"{session_key}_ctrl"
 
     orientation_cls = "horizontal" if horizontal else "vertical"
 
@@ -126,25 +140,25 @@ def render_modern_sidebar(
                     menu_title=None,
                     options=opts,
                     icons=[icon_map.get(o, "dot") for o in opts],
-                    orientation="vertical",
-                    key=key,
-                    default_index=opts.index(st.session_state.get(key, opts[0])),
+                    orientation="horizontal" if horizontal else "vertical",
+                    key=widget_key,
+                    default_index=opts.index(st.session_state.get(session_key, opts[0])),
                 )
             elif horizontal:
                 # Render as horizontal buttons
                 columns = container.columns(len(opts))
                 for col, label in zip(columns, opts):
                     disp = f"{icon_map.get(label, '')} {label}".strip()
-                    if col.button(disp, key=f"{key}_{label}"):
-                        st.session_state[key] = label
-                choice = st.session_state[key]
+                    if col.button(disp, key=f"{widget_key}_{label}"):
+                        st.session_state[session_key] = label
+                choice = st.session_state[session_key]
             else:
                 # Vertical fallback (radio or buttons)
                 choice_disp = st.radio(
                     "Navigate",
                     [f"{icon_map.get(o, '')} {o}".strip() for o in opts],
-                    key=key,
-                    index=opts.index(st.session_state.get(key, opts[0])),
+                    key=widget_key,
+                    index=opts.index(st.session_state.get(session_key, opts[0])),
                 )
                 choice = opts[
                     [f"{icon_map.get(o, '')} {o}".strip() for o in opts].index(choice_disp)
@@ -152,9 +166,9 @@ def render_modern_sidebar(
 
         except Exception:
             # Final fallback
-            choice = st.session_state.get(key, opts[0])
+            choice = st.session_state.get(session_key, opts[0])
 
-        st.session_state[key] = choice
+        st.session_state[session_key] = choice
         st.markdown("</div>", unsafe_allow_html=True)
         return choice
 
@@ -190,6 +204,7 @@ def render_stats_section(stats: dict) -> None:
 
 
 __all__ = [
+    "SIDEBAR_STYLES",
     "render_modern_layout",
     "render_modern_header",
     "render_modern_sidebar",

--- a/ui.py
+++ b/ui.py
@@ -499,7 +499,12 @@ def render_sidebar() -> str:
     # Navigation
     icon_map = dict(zip(PAGES.keys(), NAV_ICONS))
     if "render_modern_sidebar" in globals():
-        choice = render_modern_sidebar(PAGES, container=st.sidebar, icons=icon_map)
+        choice = render_modern_sidebar(
+            PAGES,
+            container=st.sidebar,
+            icons=icon_map,
+            session_key="active_page",
+        )
     else:
         choice = render_sidebar_nav(PAGES, icons=NAV_ICONS, session_key="active_page")
 
@@ -1274,6 +1279,7 @@ def main() -> None:
         choice = render_modern_sidebar(
             page_paths,
             icons=["✅", "📊", "🤖", "🎵", "💬", "👥", "👤"],
+            session_key="active_page",
         )
 
         if forced_page in page_paths:

--- a/ui_utils.py
+++ b/ui_utils.py
@@ -63,7 +63,11 @@ def render_modern_layout() -> None:
     inject_global_styles()
 
     pages = {"Home": "home", "Profile": "profile"}
-    choice = render_modern_sidebar(pages, icons={"Home": "🏠", "Profile": "👤"})
+    choice = render_modern_sidebar(
+        pages,
+        icons={"Home": "🏠", "Profile": "👤"},
+        session_key="demo_nav",
+    )
 
     render_modern_header("NovaNet 🚀")
 


### PR DESCRIPTION
## Summary
- document `SIDEBAR_STYLES`
- add mobile fallback CSS for horizontal navigation
- allow `render_modern_sidebar()` to take a `session_key`
- use the constant and new parameter across the codebase
- mention `SIDEBAR_STYLES` in Codex theme docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a5e9ef4288320ac4add1bf653b249