### PR TITLE
Prevent duplicate CSS injection

### DIFF
--- a/modern_ui.py
+++ b/modern_ui.py
@@ -4,6 +4,7 @@
 """Modern UI helpers for Streamlit pages."""
 
 import streamlit as st
+import logging
 
 try:  # pragma: no cover - optional dependency
     from streamlit_lottie import st_lottie
@@ -24,6 +25,10 @@ def render_lottie_animation(url: str, *, height: int = 200, fallback: str = "ðŸš
 def inject_modern_styles() -> None:
     """Inject global CSS for a sleek dark appearance."""
     from modern_ui_components import SIDEBAR_STYLES
+
+    if st.session_state.get("modern_styles_injected"):
+        logging.debug("inject_modern_styles skipped: already applied")
+        return
 
     st.markdown(
         """
@@ -168,6 +173,7 @@ def inject_modern_styles() -> None:
         unsafe_allow_html=True,
     )
     st.markdown(SIDEBAR_STYLES, unsafe_allow_html=True)
+    st.session_state["modern_styles_injected"] = True
 
 
 def inject_premium_styles() -> None:


### PR DESCRIPTION
## Summary
- only inject modern sidebar styles once
- avoid running `st.markdown(SIDEBAR_STYLES)` multiple times

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a636b966c832087d4f9fb614816f1