### PR TITLE
Update query param API usage

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -1147,7 +1147,7 @@ def main() -> None:
     # Respond to lightweight health-check probes
     try:
         params = st.query_params
-    except Exception:
+    except AttributeError:
         # Fallback for older Streamlit versions
         params = st.experimental_get_query_params()
 
@@ -1263,7 +1263,7 @@ def main() -> None:
         # Determine page from query params and sidebar selection
         try:
             query = st.query_params
-        except Exception:
+        except AttributeError:
             # Fallback for legacy versions
             query = st.experimental_get_query_params()
 
@@ -1281,7 +1281,7 @@ def main() -> None:
 
         try:
             st.query_params["page"] = choice
-        except Exception:
+        except AttributeError:
             st.experimental_set_query_params(page=choice)
 
 


### PR DESCRIPTION
## Summary
- use `st.query_params` with AttributeError fallback for health probes
- update sidebar navigation to use new query param API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a5e9e0a808320a391b016ee66802f