### PR TITLE
Improve sidebar page validation

### DIFF
--- a/modern_ui_components.py
+++ b/modern_ui_components.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import streamlit as st
 from typing import Optional, Dict
+from pathlib import Path
 from uuid import uuid4
 from streamlit_helpers import safe_container
 
@@ -159,6 +160,27 @@ def render_modern_sidebar(
     if container is None:
         container = st.sidebar
 
+    # Validate that referenced page files exist before rendering navigation
+    page_dir_candidates = [
+        Path.cwd() / "pages",
+        Path(__file__).resolve().parent / "pages",
+        Path(__file__).resolve().parent / "transcendental_resonance_frontend" / "pages",
+    ]
+
+    valid_pages: Dict[str, str] = {}
+    for label, page_ref in pages.items():
+        slug = str(page_ref).strip("/").split("?")[0].rsplit(".", 1)[-1]
+        exists = any((d / f"{slug}.py").exists() for d in page_dir_candidates if d.exists())
+        if exists:
+            valid_pages[label] = page_ref
+        else:
+            st.warning(f"Page file missing for '{label}' -> {page_ref}", icon="⚠️")
+
+    if not valid_pages:
+        st.error("No valid pages available", icon="⚠️")
+        return ""
+
+    pages = valid_pages
     opts = list(pages.keys())
     icon_map = icons or {}
 

--- a/tests/test_modern_ui_components.py
+++ b/tests/test_modern_ui_components.py
@@ -28,9 +28,12 @@ def test_render_modern_sidebar_default_container(monkeypatch):
         radio=dummy_radio,
         sidebar=types.SimpleNamespace(markdown=lambda *a, **k: None, radio=dummy_radio),
         session_state={},
+        warning=lambda *a, **k: None,
+        error=lambda *a, **k: None,
     )
     monkeypatch.setattr(mui, "USE_OPTION_MENU", False)
     monkeypatch.setattr(mui, "st", dummy_st)
+    monkeypatch.setattr(mui.Path, "exists", lambda self: True)
     pages = {"A": "a", "B": "b"}
     assert mui.render_modern_sidebar(pages) == "A"
     assert calls, "buttons rendered"
@@ -58,9 +61,12 @@ def test_render_modern_sidebar_state_changes(monkeypatch):
         radio=dummy_radio,
         sidebar=types.SimpleNamespace(markdown=lambda *a, **k: None, radio=dummy_radio),
         session_state=session,
+        warning=lambda *a, **k: None,
+        error=lambda *a, **k: None,
     )
 
     monkeypatch.setattr(mui, "st", dummy_st)
+    monkeypatch.setattr(mui.Path, "exists", lambda self: True)
     pages = {"A": "a", "B": "b"}
 
     # No change expected


### PR DESCRIPTION
## Summary
- validate page files before showing sidebar links
- silence warnings in tests and ensure placeholder Path.exists for sidebar validation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688a6e6c10548320b218a02151141e27