### PR TITLE
Fix page exports

### DIFF
--- a/transcendental_resonance_frontend/pages/__init__.py
+++ b/transcendental_resonance_frontend/pages/__init__.py
@@ -2,13 +2,11 @@
 
 __all__ = [
     "validation",
+    "voting",
+    "agents",
+    "resonance_music",
+    "chat",
     "social",
     "profile",
-    "voting",       # Assuming these were present before the conflict snippet
-    "agents",       # Assuming these were present before the conflict snippet
-    "resonance_music", # This is the key addition to resolve the page inclusion
-    "chat",
-    "video",
-    "video_chat",
 ]
 


### PR DESCRIPTION
## Summary
- clean up exported page names for Streamlit

## Testing
- `pytest transcendental_resonance_frontend/tests/test_pages_init_imports.py -q`
- `pytest -k pages_init -q`


------
https://chatgpt.com/codex/tasks/task_e_688a74d4c0d88320ab74ff0f0a6d5c68