### PR TITLE
Fix page path mapping

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -1261,9 +1261,12 @@ def main() -> None:
             / "transcendental_resonance_frontend"
             / "pages"
         )
-        # Map labels to Streamlit URL paths, not file system paths, for
-        # ``st.sidebar.page_link`` compatibility
-        page_paths = {label: f"/{mod}" for label, mod in PAGES.items()}
+        # Map labels to file system paths relative to the working directory so
+        # ``st.sidebar.page_link`` can locate the correct page modules.
+        page_paths = {
+            label: os.path.relpath(PAGES_DIR / f"{mod}.py", start=Path.cwd())
+            for label, mod in PAGES.items()
+        }
 
         # Determine page from query params and sidebar selection
         try:


### PR DESCRIPTION
## Summary
- set `page_paths` to map page labels to file paths
- keep Streamlit page switching working for Validation

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688a750701fc83209a410f6c5171399f