### PR TITLE
Fix CSS injection for Streamlit

### DIFF
--- a/agent_ui.py
+++ b/agent_ui.py
@@ -42,8 +42,8 @@ def render_agent_insights_tab(main_container=None) -> None:
     if main_container is None:
         main_container = st
 
-    theme_selector("Theme", key_suffix="agent_insights")
     inject_global_styles()
+    theme_selector("Theme", key_suffix="agent_insights")
     container_ctx = safe_container(main_container)
     with container_ctx:
         st.markdown(BOX_CSS + "<div class='tab-box'>", unsafe_allow_html=True)

--- a/modern_ui.py
+++ b/modern_ui.py
@@ -34,21 +34,7 @@ def inject_modern_styles() -> None:
         logger.debug("Modern styles already injected; skipping")
         return
 
-    st.markdown(
-        """
-        <link rel="preconnect" href="https://fonts.gstatic.com">
-        <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
-        <style>
-        ... (rest of your CSS)
-        </style>
-        """,
-        unsafe_allow_html=True,
-    )
-    st.markdown(SIDEBAR_STYLES, unsafe_allow_html=True)
-    st.session_state["modern_styles_injected"] = True
-
-    st.markdown(
-        """
+    css = """
         <link rel="preconnect" href="https://fonts.gstatic.com">
         <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
         <style>
@@ -124,7 +110,7 @@ def inject_modern_styles() -> None:
             background: linear-gradient(90deg, #00ffff, var(--neon-accent)) !important;
             filter: brightness(1.05);
         }
- 
+
         .stButton>button {
             background: rgba(255,255,255,0.05) !important;
             border: 1px solid rgba(255,255,255,0.15) !important;
@@ -186,11 +172,12 @@ def inject_modern_styles() -> None:
             }
         }
 
-        """,
-        unsafe_allow_html=True,
-    )
+        </style>
+    """
+    st.markdown(css, unsafe_allow_html=True)
     st.markdown(SIDEBAR_STYLES, unsafe_allow_html=True)
     st.session_state["modern_styles_injected"] = True
+
 
 
 def inject_premium_styles() -> None:

--- a/ui.py
+++ b/ui.py
@@ -1176,6 +1176,7 @@ def main() -> None:
             initial_sidebar_state="collapsed",
         )
         # Inject keyboard shortcuts for quick navigation
+        inject_modern_styles()
         st.markdown(
             """
             <script>
@@ -1196,7 +1197,6 @@ def main() -> None:
             """,
             unsafe_allow_html=True,
         )
-        inject_modern_styles()
 
         # Initialize session state
         defaults = {

--- a/voting_ui.py
+++ b/voting_ui.py
@@ -417,10 +417,10 @@ def render_voting_tab(main_container=None) -> None:
     """High level tab combining proposal and vote management."""
     if main_container is None:
         main_container = st
+    inject_global_styles()
 
     container_ctx = safe_container(main_container)
     with container_ctx:
-        inject_global_styles()
         st.markdown(VOTING_CSS, unsafe_allow_html=True)
         sub1, sub2, sub3, sub4 = st.tabs(
             [


### PR DESCRIPTION
## Summary
- clean up `inject_modern_styles` so CSS is injected once
- move style injection earlier in app initialization
- call `inject_global_styles` before creating layout containers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a77b559d48320aaf5262540822385