### PR TITLE
Fix navigation routing and sidebar CSS

### DIFF
--- a/frontend/ui_layout.py
+++ b/frontend/ui_layout.py
@@ -102,9 +102,9 @@ def _render_sidebar_nav(
     index = [label for label, _ in opts].index(active)
 
     choice = active
+    st.markdown(SIDEBAR_STYLES, unsafe_allow_html=True)
     container = st.sidebar.container()
     with container:
-        st.markdown(SIDEBAR_STYLES, unsafe_allow_html=True)
         st.markdown("<div class='glass-card sidebar-nav'>", unsafe_allow_html=True)
         if hasattr(st.sidebar, "page_link"):
             for (label, path), icon in zip(opts, icon_list):


### PR DESCRIPTION
## Summary
- provide helper to build page paths
- insert early sidebar styles
- keep default logs and users in session
- use web-accessible paths for navigation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a78549ac483209ab421e1eaa56a38