### PR TITLE
Move style injection earlier in agent insights tab

### DIFF
--- a/agent_ui.py
+++ b/agent_ui.py
@@ -42,8 +42,8 @@ def render_agent_insights_tab(main_container=None) -> None:
     if main_container is None:
         main_container = st
 
-    theme_selector("Theme", key_suffix="agent_insights")
     inject_global_styles()
+    theme_selector("Theme", key_suffix="agent_insights")
     container_ctx = safe_container(main_container)
     with container_ctx:
         st.markdown(BOX_CSS + "<div class='tab-box'>", unsafe_allow_html=True)


### PR DESCRIPTION
## Summary
- ensure global styles are injected before any UI in `render_agent_insights_tab`
- call `theme_selector` only after `inject_global_styles`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a79da5f30832089295a1b63b38bd5