### PR TITLE
Ensure Validation page always loads

### DIFF
--- a/pages/validation.py
+++ b/pages/validation.py
@@ -3,6 +3,11 @@
 import time
 import streamlit as st
 
+try:
+    from modern_ui_components import SIDEBAR_STYLES
+except Exception:  # pragma: no cover - optional styling
+    SIDEBAR_STYLES = ""
+
 # optional: custom sidebar styles if you define SIDEBAR_STYLES globally
 try:
     st.markdown(f"<style>{SIDEBAR_STYLES}</style>", unsafe_allow_html=True)


### PR DESCRIPTION
## Summary
- add explicit `SIDEBAR_STYLES` import fallback in `pages/validation.py`
- account for both `pages/` folders in `load_page_with_fallback`
- output error if Validation page fails
- replace `st.sleep` with `time.sleep`
- expose `time` in `ui.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a7f7a5b108320886cf075827023a6