### PR TITLE
Fix Validation page routing and fallback

### DIFF
--- a/pages/validation.py
+++ b/pages/validation.py
@@ -3,18 +3,26 @@
 import time
 import streamlit as st
 
-# optional: custom sidebar styles if you define SIDEBAR_STYLES globally
 try:
-    st.markdown(f"<style>{SIDEBAR_STYLES}</style>", unsafe_allow_html=True)
-except NameError:
-    pass  # no sidebar styling defined yet
+    from modern_ui_components import SIDEBAR_STYLES
+except Exception:
+    SIDEBAR_STYLES = ""
 
-st.title("🔍 Validation Dashboard")
 
-# simulate a short loading delay if needed
-time.sleep(0.1)
+def main() -> None:
+    """Render the Validation page with basic styling and diagnostics."""
+    try:
+        if SIDEBAR_STYLES:
+            st.markdown(f"<style>{SIDEBAR_STYLES}</style>", unsafe_allow_html=True)
 
-st.info("Validation page loaded successfully.")
+        st.title("🔍 Validation Dashboard")
+        time.sleep(0.1)
+        st.info("Validation page loaded successfully.")
+    except Exception as exc:
+        st.error(f"Failed to load Validation page: {exc}")
+        st.toast("Validation page encountered an error.", icon="⚠️")
 
-# optional: fetch or display something
-# st.write("Add validation checks or form inputs here.")
+
+if __name__ == "__main__":
+    main()
+

--- a/ui.py
+++ b/ui.py
@@ -17,6 +17,7 @@ import asyncio
 import difflib
 import io
 import json
+import time
 import logging
 import math
 import sys
@@ -34,6 +35,10 @@ from modern_ui_components import (
     render_validation_card,
     render_stats_section,
 )
+try:
+    from modern_ui_components import SIDEBAR_STYLES
+except Exception:  # pragma: no cover - fallback if module missing
+    SIDEBAR_STYLES = ""
 
 # Prefer modern sidebar render if available
 try:
@@ -420,7 +425,7 @@ def render_modern_validation_page():
     st.markdown("- Task queued\n- Running analysis\n- Completed")
     progress = st.progress(0)
     for i in range(5):
-        st.sleep(0.1)
+        time.sleep(0.1)
         progress.progress((i + 1) / 5)
     st.success("Status: OK")
 


### PR DESCRIPTION
## Summary
- define fallback SIDEBAR_STYLES constant
- change st.sleep to time.sleep
- wrap `pages/validation.py` in a main function
- ensure Validation page diagnostics appear on failure

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a7f760f28832097e91aa0ec567583