### PR TITLE
Fix fallback pages

### DIFF
--- a/pages/validation.py
+++ b/pages/validation.py
@@ -1,20 +1,7 @@
-# pages/validation.py
+"""Entry point for the Validation page used by Streamlit multipage."""
 
-import time
-import streamlit as st
+from transcendental_resonance_frontend.pages.validation import main
 
-# optional: custom sidebar styles if you define SIDEBAR_STYLES globally
-try:
-    st.markdown(f"<style>{SIDEBAR_STYLES}</style>", unsafe_allow_html=True)
-except NameError:
-    pass  # no sidebar styling defined yet
+if __name__ == "__main__":  # pragma: no cover - executed by Streamlit
+    main()
 
-st.title("🔍 Validation Dashboard")
-
-# simulate a short loading delay if needed
-time.sleep(0.1)
-
-st.info("Validation page loaded successfully.")
-
-# optional: fetch or display something
-# st.write("Add validation checks or form inputs here.")

--- a/transcendental_resonance_frontend/pages/validation.py
+++ b/transcendental_resonance_frontend/pages/validation.py
@@ -11,6 +11,7 @@ from ui import render_validation_ui
 inject_modern_styles()
 
 
+@st.experimental_page("Validation")
 def main(main_container=None) -> None:
     """Render the validation UI inside a container safely."""
     if main_container is None:


### PR DESCRIPTION
## Summary
- properly load validation module in multipage setup
- mark validation page with `st.experimental_page`
- skip fallback preview when the actual page exists
- avoid repeated fallback rendering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a8298d03c8320951c362d3233629c