### PR TITLE
Fix UI page fallback

### DIFF
--- a/pages/validation.py
+++ b/pages/validation.py
@@ -1,20 +1,15 @@
-# pages/validation.py
+"""Streamlit entry point for the Validation page."""
 
-import time
 import streamlit as st
+from transcendental_resonance_frontend.pages.validation import (
+    main as _frontend_main,
+)
 
-# optional: custom sidebar styles if you define SIDEBAR_STYLES globally
-try:
-    st.markdown(f"<style>{SIDEBAR_STYLES}</style>", unsafe_allow_html=True)
-except NameError:
-    pass  # no sidebar styling defined yet
 
-st.title("🔍 Validation Dashboard")
+def render() -> None:
+    """Render the validation dashboard."""
+    _frontend_main()
 
-# simulate a short loading delay if needed
-time.sleep(0.1)
 
-st.info("Validation page loaded successfully.")
-
-# optional: fetch or display something
-# st.write("Add validation checks or form inputs here.")
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    render()


### PR DESCRIPTION
## Summary
- normalize page selection names
- add render wrapper for Validation page
- skip fallback render when a page file exists
- ensure sidebar choice normalization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a829be768832092da4e368cbf9896