### PR TITLE
Fix fallback page logic

### DIFF
--- a/pages/validation.py
+++ b/pages/validation.py
@@ -3,18 +3,21 @@
 import time
 import streamlit as st
 
-# optional: custom sidebar styles if you define SIDEBAR_STYLES globally
-try:
-    st.markdown(f"<style>{SIDEBAR_STYLES}</style>", unsafe_allow_html=True)
-except NameError:
-    pass  # no sidebar styling defined yet
 
-st.title("🔍 Validation Dashboard")
+def render() -> None:
+    """Simple validation page used during tests."""
+    try:
+        st.markdown(f"<style>{SIDEBAR_STYLES}</style>", unsafe_allow_html=True)
+    except NameError:  # pragma: no cover - style constant not defined
+        pass
 
-# simulate a short loading delay if needed
-time.sleep(0.1)
+    st.title("🔍 Validation Dashboard")
 
-st.info("Validation page loaded successfully.")
+    # simulate a short loading delay if needed
+    time.sleep(0.1)
 
-# optional: fetch or display something
-# st.write("Add validation checks or form inputs here.")
+    st.info("Validation page loaded successfully.")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    render()


### PR DESCRIPTION
## Summary
- normalize sidebar selection to match lower-case page names
- update query param handling to keep title-cased labels
- skip rendering fallback when actual page exists
- add debug log for unnecessary fallback calls
- expose a render() function for `pages/validation`

## Testing
- `pytest tests/test_ui_pages.py::test_unknown_page_triggers_fallback -q`
- `pytest tests/test_ui_pages.py::test_main_defaults_to_validation -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a829be768832092da4e368cbf9896