### PR TITLE
Add debug logging for page fallbacks

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -375,11 +375,13 @@ def load_page_with_fallback(choice: str, module_paths: list[str] | None = None) 
                     return
                 except StreamlitAPIException as exc:
                     st.toast(f"Switch failed for {choice}: {exc}", icon="⚠️")
+                    logger.debug("File exists but switch failed: %s", page_file)
                     break
                 except Exception as exc:
                     logging.error(
                         "switch_page failed for %s: %s", rel_path, exc, exc_info=True
                     )
+                    logger.debug("File exists but switch failed: %s", page_file)
                     last_exc = exc
                     break
 
@@ -426,6 +428,7 @@ def _render_fallback(choice: str) -> None:
     }
     fallback_fn = fallback_pages.get(choice)
     if fallback_fn:
+        logger.debug("Rendering fallback for %s", choice)
         if OFFLINE_MODE:
             st.toast("Offline mode: using mock services", icon="⚠️")
 


### PR DESCRIPTION
## Summary
- log when fallback pages are rendered
- log when a page file exists but fails to load

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a844a4e688320b52fb02fc2bbba0c