### PR TITLE
Add theme helper and integrate with modern UI

### DIFF
--- a/frontend/theme.py
+++ b/frontend/theme.py
@@ -1,0 +1,30 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+"""Color theme utilities for Streamlit frontend."""
+
+from __future__ import annotations
+
+
+def get_global_css(dark: bool) -> str:
+    """Return ``:root`` CSS variables for dark or light mode."""
+    if dark:
+        return (
+            "<style>"
+            ":root {"
+            "--bg:#001E26;"
+            "--card:#002B36;"
+            "--accent:#00F0FF;"
+            "--text-muted:#7e9aaa;"
+            "}</style>"
+        )
+    return (
+        "<style>"
+        ":root {"
+        "--bg:#F0F2F6;"
+        "--card:#FFFFFF;"
+        "--accent:#0A84FF;"
+        "--text-muted:#666666;"
+        "}</style>"
+    )
+

--- a/modern_ui.py
+++ b/modern_ui.py
@@ -32,10 +32,13 @@ def inject_modern_styles() -> None:
     Call this before rendering any UI elements so the styles apply correctly.
     """
     from modern_ui_components import SIDEBAR_STYLES
+    from frontend.theme import get_global_css
 
     if st.session_state.get("modern_styles_injected"):
         logger.debug("Modern styles already injected; skipping")
         return
+
+    st.markdown(get_global_css(True), unsafe_allow_html=True)
 
     css = """
         <link rel="preconnect" href="https://fonts.gstatic.com">


### PR DESCRIPTION
## Summary
- add `frontend/theme.py` with a new `get_global_css()` helper
- inject CSS variables in `modern_ui.inject_modern_styles()`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688a9018281c8320ad8cf4da2ed11dfc