### PR TITLE
Add topbar component

### DIFF
--- a/frontend/topbar.py
+++ b/frontend/topbar.py
@@ -1,0 +1,49 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+"""Simple sticky top bar component for Streamlit UIs."""
+
+from __future__ import annotations
+
+import streamlit as st
+
+
+def render_topbar() -> None:
+    """Render a translucent top navigation bar."""
+    st.markdown(
+        """
+        <style>
+        .sn-topbar {
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+            display: flex;
+            align-items: center;
+            gap: 1rem;
+            padding: 0.5rem 1rem;
+            background: rgba(30, 30, 30, 0.6);
+            backdrop-filter: blur(8px);
+        }
+        .sn-topbar input {
+            flex: 1;
+            padding: 0.25rem 0.5rem;
+            border-radius: 6px;
+            border: 1px solid rgba(255,255,255,0.3);
+            background: rgba(255,255,255,0.85);
+        }
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+    st.markdown(
+        """
+        <div class="sn-topbar">
+            <img src="https://placehold.co/32x32?text=SN" width="32" />
+            <input type="text" placeholder="Search..." />
+            <img src="https://placehold.co/32x32" width="32" style="border-radius:50%" />
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
+
+__all__ = ["render_topbar"]

--- a/ui.py
+++ b/ui.py
@@ -60,6 +60,7 @@ from frontend.ui_layout import (
     render_profile_card,
     render_sidebar_nav as _base_render_sidebar_nav,
 )
+from frontend.topbar import render_topbar
 
 
 def render_sidebar_nav(*args, **kwargs):
@@ -1349,6 +1350,8 @@ def main() -> None:
             """,
             unsafe_allow_html=True,
         )
+
+        render_topbar()
 
         # Setup: Pages and Icons
         PAGES = {


### PR DESCRIPTION
## Summary
- add `frontend/topbar.py` for a translucent sticky top bar
- show the top bar early in `ui.main()`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a90ee2808832087a38dc3e822c383