### PR TITLE
Revamp stats card layout

### DIFF
--- a/frontend/theme.py
+++ b/frontend/theme.py
@@ -1,0 +1,5 @@
+ACCENT_COLOR = "#00F0FF"
+
+def get_accent_color() -> str:
+    """Return the current theme accent color."""
+    return ACCENT_COLOR

--- a/modern_ui.py
+++ b/modern_ui.py
@@ -5,6 +5,7 @@
 
 import streamlit as st
 import logging
+from frontend import theme
 
 logger = logging.getLogger(__name__)
 
@@ -257,39 +258,77 @@ def render_validation_card() -> None:
 
 
 def render_stats_section() -> None:
-    """Display quick stats in four columns."""
-    col1, col2, col3, col4 = st.columns(4)
+    """Display quick stats using a responsive flexbox layout."""
+
+    accent = theme.get_accent_color()
+
+    st.markdown(
+        f"""
+        <style>
+        .stats-container {{
+            display: flex;
+            gap: 1rem;
+            flex-wrap: wrap;
+        }}
+        .stats-card {{
+            flex: 1 1 calc(25% - 1rem);
+            background: rgba(255, 255, 255, 0.03);
+            backdrop-filter: blur(15px);
+            border: 1px solid rgba(255, 255, 255, 0.1);
+            border-radius: 12px;
+            padding: 1rem;
+            text-align: center;
+            transition: transform 0.3s ease;
+        }}
+        .stats-card:hover {{
+            transform: scale(1.02);
+        }}
+        .stats-value {{
+            color: {accent};
+            font-size: calc(1rem + 0.5vw);
+            font-weight: 700;
+            margin-bottom: 0.25rem;
+        }}
+        .stats-label {{
+            color: #888;
+            font-size: calc(0.75rem + 0.3vw);
+            font-weight: 500;
+        }}
+        @media (max-width: 768px) {{
+            .stats-card {{
+                flex: 1 1 calc(50% - 1rem);
+            }}
+        }}
+        @media (max-width: 480px) {{
+            .stats-card {{
+                flex: 1 1 100%;
+            }}
+        }}
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+
     stats = [
-        ("🏃‍♂️", "Runs", "0", "#4a90e2"),
-        ("📝", "Proposals", "12", "#10b981"),
-        ("⚡", "Success Rate", "94%", "#f59e0b"),
-        ("🎯", "Accuracy", "98.2%", "#8b5cf6"),
+        ("🏃‍♂️", "Runs", "0"),
+        ("📝", "Proposals", "12"),
+        ("⚡", "Success Rate", "94%"),
+        ("🎯", "Accuracy", "98.2%"),
     ]
-    for col, (icon, label, value, color) in zip([col1, col2, col3, col4], stats):
-        with col:
-            st.markdown(
-                f"""
-                <div style="
-                    background: rgba(255, 255, 255, 0.03);
-                    backdrop-filter: blur(15px);
-                    border: 1px solid rgba(255, 255, 255, 0.1);
-                    border-radius: 12px;
-                    padding: 1.5rem;
-                    text-align: center;
-                    transition: all 0.3s ease;
-                " onmouseover="this.style.transform='scale(1.02)'"
-                   onmouseout="this.style.transform='scale(1)'">
-                    <div style="font-size: 2rem; margin-bottom: 0.5rem;">{icon}</div>
-                    <div style="color: {color}; font-size: 1.75rem; font-weight: 700; margin-bottom: 0.25rem;">
-                        {value}
-                    </div>
-                    <div style="color: #888; font-size: 0.85rem; font-weight: 500;">
-                        {label}
-                    </div>
-                </div>
-                """,
-                unsafe_allow_html=True,
-            )
+
+    st.markdown("<div class='stats-container'>", unsafe_allow_html=True)
+    for icon, label, value in stats:
+        st.markdown(
+            f"""
+            <div class='stats-card'>
+                <div style='font-size:2rem;margin-bottom:0.5rem;'>{icon}</div>
+                <div class='stats-value'>{value}</div>
+                <div class='stats-label'>{label}</div>
+            </div>
+            """,
+            unsafe_allow_html=True,
+        )
+    st.markdown("</div>", unsafe_allow_html=True)
 
 
 def open_card_container() -> None:


### PR DESCRIPTION
## Summary
- add a simple theme module exposing `get_accent_color`
- redesign `render_stats_section` with flexbox and responsive styling
- color stat values using the theme accent color

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a90aaa1f08320840e54a4b470a49a