### PR TITLE
Centralize page paths

### DIFF
--- a/frontend/ui_layout.py
+++ b/frontend/ui_layout.py
@@ -25,8 +25,7 @@ from __future__ import annotations
 from typing import Dict, Iterable, Optional
 from uuid import uuid4
 from pathlib import Path
-
-ROOT_DIR = Path(__file__).resolve().parents[1]
+from utils.paths import ROOT_DIR, PAGES_DIR
 import os
 import streamlit as st
 from modern_ui_components import SIDEBAR_STYLES
@@ -89,8 +88,10 @@ def _render_sidebar_nav(
     valid_opts = []
     valid_icons = []
     for (label, path), icon in zip(opts, icon_list):
-        file_path = (ROOT_DIR / path.lstrip("/")).with_suffix(".py")
-        if not file_path.exists():
+        rel = Path(path.lstrip("/"))
+        candidates = [ROOT_DIR / rel, PAGES_DIR / rel.name]
+        exists = any(c.with_suffix(".py").exists() for c in candidates)
+        if not exists:
             st.sidebar.error(f"Page not found: {path}")
             continue
         valid_opts.append((label, path))

--- a/modern_ui_components.py
+++ b/modern_ui_components.py
@@ -8,8 +8,7 @@ from __future__ import annotations
 import streamlit as st
 from typing import Optional, Dict
 from pathlib import Path
-
-ROOT_DIR = Path(__file__).resolve().parents[1]
+from utils.paths import ROOT_DIR, PAGES_DIR
 from uuid import uuid4
 from streamlit_helpers import safe_container
 
@@ -167,8 +166,7 @@ def render_modern_sidebar(
     page_dir_candidates = [
         Path.cwd() / "pages",
         ROOT_DIR / "pages",
-        Path(__file__).resolve().parent / "pages",
-        Path(__file__).resolve().parent / "transcendental_resonance_frontend" / "pages",
+        PAGES_DIR,
     ]
 
     existing_dirs = [d for d in page_dir_candidates if d.exists()]

--- a/ui.py
+++ b/ui.py
@@ -76,6 +76,7 @@ render_modern_sidebar = render_sidebar_nav
 # Utility path handling
 from pathlib import Path
 from utils.page_registry import ensure_pages
+from utils.paths import ROOT_DIR, PAGES_DIR
 
 logger = logging.getLogger(__name__)
 logger.propagate = False
@@ -91,8 +92,6 @@ os.environ["STREAMLIT_WATCHER_TYPE"] = "poll"
 HEALTH_CHECK_PARAM = "healthz"
 
 # Directory containing Streamlit page modules
-ROOT_DIR = Path(__file__).resolve().parent
-PAGES_DIR = ROOT_DIR / "transcendental_resonance_frontend" / "pages"
 
 # Mapping of navigation labels to page module names
 
@@ -363,9 +362,6 @@ def load_page_with_fallback(choice: str, module_paths: list[str] | None = None) 
 
 
     # Validate PAGES_DIR existence
-    PAGES_DIR = (
-        Path(__file__).resolve().parent / "transcendental_resonance_frontend" / "pages"
-    )
     if not PAGES_DIR.exists():
         st.error(f"Pages directory not found: {PAGES_DIR}")
         if "_render_fallback" in globals():
@@ -450,7 +446,7 @@ def _render_fallback(choice: str) -> None:
     # Candidate paths to try loading from
     page_candidates = [
         ROOT_DIR / "pages" / f"{slug}.py",
-        ROOT_DIR / "transcendental_resonance_frontend" / "pages" / f"{slug}.py",
+        PAGES_DIR / f"{slug}.py",
         Path.cwd() / "pages" / f"{slug}.py",
     ]
 

--- a/utils/paths.py
+++ b/utils/paths.py
@@ -1,0 +1,16 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+"""Common path constants for the Streamlit frontend."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# Repository root directory
+ROOT_DIR = Path(__file__).resolve().parent.parent
+
+# Default directory where Streamlit pages are located
+PAGES_DIR = ROOT_DIR / "transcendental_resonance_frontend" / "pages"
+
+__all__ = ["ROOT_DIR", "PAGES_DIR"]


### PR DESCRIPTION
## Summary
- define common `ROOT_DIR` and `PAGES_DIR` constants
- reuse path constants across ui modules
- validate page existence using shared paths

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a921bda0c8320b08f1479206bc3da