### PR TITLE
feat: handle missing nicegui in error overlay

### DIFF
--- a/transcendental_resonance_frontend/src/utils/error_overlay.py
+++ b/transcendental_resonance_frontend/src/utils/error_overlay.py
@@ -4,37 +4,45 @@ from __future__ import annotations
 
 try:  # pragma: no cover - optional dependency
     from nicegui import ui
-except Exception:  # pragma: no cover - fallback when NiceGUI missing
+except ModuleNotFoundError:  # pragma: no cover - fallback when NiceGUI missing
     ui = None  # type: ignore[misc]
 
 
-class ErrorOverlay:
-    """Display an overlay with an error message."""
+if ui is None:  # pragma: no cover - nicegui missing
 
-    def __init__(self) -> None:
-        if ui is None:  # NiceGUI not installed
+    class ErrorOverlay:
+        """Fallback overlay that prints errors to stdout."""
+
+        def __init__(self) -> None:
             self._dialog = None
             self._label = None
-        else:
+
+        def show(self, message: str) -> None:
+            print(f"ERROR: {message}")
+
+        def hide(self) -> None:
+            return
+
+else:
+
+    class ErrorOverlay:
+        """Display an overlay with an error message."""
+
+        def __init__(self) -> None:
             self._dialog = ui.dialog().props("persistent")
             with self._dialog:
                 with ui.card():
                     self._label = ui.label("Error")
                     ui.button("Close", on_click=self.hide)
 
-    def show(self, message: str) -> None:
-        if ui is None or self._dialog is None:
-            print(f"ERROR: {message}")
-            return
-        self._label.text = message
-        if not self._dialog.open:
-            self._dialog.open()
+        def show(self, message: str) -> None:
+            self._label.text = message
+            if not self._dialog.open:
+                self._dialog.open()
 
-    def hide(self) -> None:
-        if ui is None or self._dialog is None:
-            return
-        if self._dialog.open:
-            self._dialog.close()
+        def hide(self) -> None:
+            if self._dialog.open:
+                self._dialog.close()
 
 
 __all__ = ["ErrorOverlay"]


### PR DESCRIPTION
## Summary
- gracefully handle missing NiceGUI in `ErrorOverlay`
- provide stdout fallback when NiceGUI is unavailable

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688a952af4bc8320af226400c5f678a7