### PR TITLE
feat: add nicegui fallback for error overlay

### DIFF
--- a/transcendental_resonance_frontend/src/utils/error_overlay.py
+++ b/transcendental_resonance_frontend/src/utils/error_overlay.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 try:  # pragma: no cover - optional dependency
     from nicegui import ui
-except Exception:  # pragma: no cover - fallback when NiceGUI missing
+except ModuleNotFoundError:  # pragma: no cover - fallback when NiceGUI missing
     ui = None  # type: ignore[misc]
 
 
@@ -23,15 +23,15 @@ class ErrorOverlay:
                     ui.button("Close", on_click=self.hide)
 
     def show(self, message: str) -> None:
-        if ui is None or self._dialog is None:
-            print(f"ERROR: {message}")
+        if self._dialog is None:
+            print(message)
             return
         self._label.text = message
         if not self._dialog.open:
             self._dialog.open()
 
     def hide(self) -> None:
-        if ui is None or self._dialog is None:
+        if self._dialog is None:
             return
         if self._dialog.open:
             self._dialog.close()


### PR DESCRIPTION
## Summary
- handle optional nicegui import gracefully
- provide print-based fallback for ErrorOverlay when nicegui unavailable

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688a952af4bc8320af226400c5f678a7