### PR TITLE
chore: handle missing nicegui in error overlay

### DIFF
--- a/transcendental_resonance_frontend/src/utils/error_overlay.py
+++ b/transcendental_resonance_frontend/src/utils/error_overlay.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 try:  # pragma: no cover - optional dependency
     from nicegui import ui
-except Exception:  # pragma: no cover - fallback when NiceGUI missing
-    ui = None  # type: ignore[misc]
+except ModuleNotFoundError:  # pragma: no cover - fallback when NiceGUI missing
+    ui = None  # type: ignore[assignment]
 
 
 class ErrorOverlay:
@@ -24,7 +24,7 @@ class ErrorOverlay:
 
     def show(self, message: str) -> None:
         if ui is None or self._dialog is None:
-            print(f"ERROR: {message}")
+            print(message)
             return
         self._label.text = message
         if not self._dialog.open:


### PR DESCRIPTION
## Summary
- make `ErrorOverlay` robust to missing NiceGUI by catching `ModuleNotFoundError`
- fall back to printing errors when NiceGUI isn't available

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688a952af4bc8320af226400c5f678a7