### PR TITLE
fix: robust page registry import

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -77,33 +77,32 @@ render_modern_sidebar = render_sidebar_nav
 # Utility path handling
 from pathlib import Path
 import logging
-from utils.page_registry import ensure_pages
 from utils.paths import ROOT_DIR, PAGES_DIR
 
 
 logger = logging.getLogger(__name__)
 logger.propagate = False
 
+# Import page registry helper with robust fallbacks. Attempt the package-specific
+# path first, then fall back to a local ``utils`` package if available. As a last
+# resort provide a no-op stub so the application can continue running without
+# crashing when the registry utilities are missing.
 try:
-    from transcendental_resonance_frontend.src.utils.page_registry import ensure_pages
-except Exception as exc:  # pragma: no cover - best effort fallback
-    logger.error("Failed to import ensure_pages: %s", exc)
-
-    def ensure_pages(*_args, **_kwargs) -> None:
-        """Fallback no-op when page registry utilities are unavailable."""
-        logger.debug("ensure_pages fallback invoked")
-
-
-try:
-    from transcendental_resonance_frontend.src.utils.page_registry import ensure_pages
-except Exception as import_err:  # pragma: no cover - fallback if absolute import fails
-    logger.warning("Primary page_registry import failed: %s", import_err)
+    from transcendental_resonance_frontend.src.utils.page_registry import (
+        ensure_pages,
+    )
+except Exception as primary_err:  # pragma: no cover - best effort fallback
+    logger.debug("primary ensure_pages import failed: %s", primary_err)
     try:
         from utils.page_registry import ensure_pages  # type: ignore
-    except Exception as fallback_err:
-        logger.warning("Secondary page_registry import also failed: %s", fallback_err)
-        def ensure_pages(*_a, **_k):
-            logger.warning("ensure_pages noop fallback used")
+    except Exception as secondary_err:
+        logger.warning(
+            "ensure_pages import failed: %s; using noop fallback", secondary_err
+        )
+
+        def ensure_pages(*_args, **_kwargs) -> None:  # type: ignore
+            """Fallback no-op when page registry utilities are unavailable."""
+            logger.debug("ensure_pages noop fallback invoked")
             return None
 
 


### PR DESCRIPTION
## Summary
- consolidate `ensure_pages` imports with robust fallbacks
- support both module paths for page registry

## Testing
- `pytest tests/test_validation_page.py transcendental_resonance_frontend/tests/test_validation_page_render.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688a9656917083208c8a7447ecbbb9e8