### PR TITLE
Use global PAGES_DIR for page resolution

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -1387,11 +1387,6 @@ def main() -> None:
             "Social": "social",
             "Profile": "profile",
         }
-        PAGES_DIR = (
-            Path(__file__).resolve().parent
-            / "transcendental_resonance_frontend"
-            / "pages"
-        )
 
 
         page_paths: dict[str, str] = {}


### PR DESCRIPTION
## Summary
- Remove local PAGES_DIR override so the main routine relies on the shared constant
- Use the globally defined PAGES_DIR when loading fallback pages

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688a954b6e0483209663b8ee3a2f6159