### PR TITLE
feat: add flexbox stats component

### DIFF
--- a/modern_ui_components.py
+++ b/modern_ui_components.py
@@ -14,6 +14,7 @@ from uuid import uuid4
 from streamlit_helpers import safe_container
 
 from modern_ui import inject_modern_styles
+from frontend import theme
 
 try:
     from streamlit_option_menu import option_menu
@@ -295,17 +296,79 @@ def render_validation_card(entry: dict) -> None:
 
 
 def render_stats_section(stats: dict) -> None:
-    """Show quick statistics in a styled block."""
+    """Display quick stats using a responsive flexbox layout."""
+
+    accent = theme.get_accent_color()
+
     st.markdown(
         f"""
-        <div class='glass-card'>
-            <h4 style='margin-top:0'>Stats</h4>
-            <div>Runs: {stats.get('runs', 0)}</div>
-            <div>Proposals: {stats.get('proposals', 'N/A')}</div>
-        </div>
+        <style>
+        .stats-container {{
+            display: flex;
+            flex-wrap: wrap;
+            gap: 1rem;
+            justify-content: space-between;
+        }}
+        .stats-card {{
+            flex: 1 1 calc(25% - 1rem);
+            min-width: 120px;
+            background: rgba(255, 255, 255, 0.03);
+            backdrop-filter: blur(15px);
+            border: 1px solid rgba(255, 255, 255, 0.1);
+            border-radius: 12px;
+            padding: 1.5rem;
+            text-align: center;
+            transition: transform 0.3s ease;
+        }}
+        .stats-card:hover {{
+            transform: scale(1.02);
+        }}
+        .stats-value {{
+            color: {accent};
+            font-size: calc(1.5rem + 0.3vw);
+            font-weight: 700;
+            margin-bottom: 0.25rem;
+        }}
+        .stats-label {{
+            color: #888;
+            font-size: calc(0.8rem + 0.2vw);
+            font-weight: 500;
+        }}
+        @media (max-width: 768px) {{
+            .stats-card {{
+                flex: 1 1 calc(50% - 1rem);
+            }}
+        }}
+        @media (max-width: 480px) {{
+            .stats-card {{
+                flex: 1 1 100%;
+            }}
+        }}
+        </style>
         """,
         unsafe_allow_html=True,
     )
+
+    entries = [
+        ("🏃‍♂️", "Runs", stats.get("runs", 0)),
+        ("📝", "Proposals", stats.get("proposals", "N/A")),
+        ("⚡", "Success Rate", stats.get("success_rate", "N/A")),
+        ("🎯", "Accuracy", stats.get("accuracy", "N/A")),
+    ]
+
+    st.markdown("<div class='stats-container'>", unsafe_allow_html=True)
+    for icon, label, value in entries:
+        st.markdown(
+            f"""
+            <div class='stats-card'>
+                <div style='font-size:2rem;margin-bottom:0.5rem;'>{icon}</div>
+                <div class='stats-value'>{value}</div>
+                <div class='stats-label'>{label}</div>
+            </div>
+            """,
+            unsafe_allow_html=True,
+        )
+    st.markdown("</div>", unsafe_allow_html=True)
 
 
 __all__ = [

--- a/tests/test_ui_pages.py
+++ b/tests/test_ui_pages.py
@@ -192,3 +192,21 @@ def test_fallback_rendered_once(monkeypatch):
 
     assert called["count"] == 1
     assert "Validation" in ui._fallback_rendered
+
+
+def test_render_stats_section_uses_flexbox(monkeypatch):
+    """render_stats_section should output flexbox-based layout."""
+    outputs = []
+
+    dummy_st = types.SimpleNamespace(
+        markdown=lambda html, **k: outputs.append(html)
+    )
+
+    monkeypatch.setattr(mui, "st", dummy_st)
+
+    stats = {"runs": 1, "proposals": 2, "success_rate": "90%", "accuracy": "95%"}
+    mui.render_stats_section(stats)
+
+    combined = "\n".join(outputs)
+    assert "stats-container" in combined
+    assert "stats-card" in combined

--- a/ui.py
+++ b/ui.py
@@ -1581,8 +1581,13 @@ def main() -> None:
                 st.subheader("Agent Output")
                 st.json(st.session_state.get("agent_output"))
 
-            render_stats_section()
-            st.markdown(f"**Runs:** {st.session_state.get('run_count', 0)}")
+            stats = {
+                "runs": st.session_state.get("run_count", 0),
+                "proposals": st.session_state.get("proposal_count", "N/A"),
+                "success_rate": st.session_state.get("success_rate", "N/A"),
+                "accuracy": st.session_state.get("accuracy", "N/A"),
+            }
+            render_stats_section(stats)
 
     except Exception as exc:
         logger.critical("Unhandled error in main: %s", exc, exc_info=True)


### PR DESCRIPTION
## Summary
- implement flexbox-based `render_stats_section` in `modern_ui_components`
- pass runtime stats to the section from `ui.main`
- add regression test asserting flexbox structure

## Testing
- `pytest tests/test_modern_ui_components.py tests/test_ui_pages.py` *(skipped: streamlit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688a94866f648320bf5c87c5e086370b