### PR TITLE
feat: centralize pages directory lookup

### DIFF
--- a/modern_ui_components.py
+++ b/modern_ui_components.py
@@ -13,7 +13,24 @@ ROOT_DIR = Path(__file__).resolve().parents[1]
 from uuid import uuid4
 from streamlit_helpers import safe_container
 
-from modern_ui import inject_modern_styles
+try:
+    from modern_ui import inject_modern_styles
+except Exception:  # pragma: no cover - gracefully handle missing/invalid module
+    def inject_modern_styles(*_a, **_k):
+        return None
+
+try:
+    from transcendental_resonance_frontend.src.utils.page_registry import get_pages_dir
+except Exception:
+    try:  # type: ignore
+        from utils.page_registry import get_pages_dir  # type: ignore
+    except Exception:  # pragma: no cover - final fallback
+        def get_pages_dir() -> Path:
+            return (
+                Path(__file__).resolve().parent
+                / "transcendental_resonance_frontend"
+                / "pages"
+            )
 
 try:
     from streamlit_option_menu import option_menu
@@ -168,7 +185,7 @@ def render_modern_sidebar(
         Path.cwd() / "pages",
         ROOT_DIR / "pages",
         Path(__file__).resolve().parent / "pages",
-        Path(__file__).resolve().parent / "transcendental_resonance_frontend" / "pages",
+        get_pages_dir(),
     ]
 
     existing_dirs = [d for d in page_dir_candidates if d.exists()]

--- a/streamlit_helpers.py
+++ b/streamlit_helpers.py
@@ -14,7 +14,12 @@ from typing import Literal, Any, ContextManager
 from contextlib import nullcontext
 
 import streamlit as st
-from modern_ui import inject_modern_styles
+try:
+    from modern_ui import inject_modern_styles
+except Exception:  # pragma: no cover - gracefully handle missing/invalid module
+    def inject_modern_styles(*_a, **_k):
+        """Fallback no-op when modern_ui is unavailable."""
+        return None
 
 # Shared CSS style for sections displayed in bordered boxes
 BOX_CSS = """

--- a/transcendental_resonance_frontend/src/utils/__init__.py
+++ b/transcendental_resonance_frontend/src/utils/__init__.py
@@ -12,7 +12,7 @@ from .features import (
 )
 from .error_overlay import ErrorOverlay
 from .api_status_footer import ApiStatusFooter
-from .page_registry import ensure_pages
+from .page_registry import ensure_pages, get_pages_dir
 
 __all__ = [
     "quick_post_button",
@@ -28,4 +28,5 @@ __all__ = [
     "ErrorOverlay",
     "ApiStatusFooter",
     "ensure_pages",
+    "get_pages_dir",
 ]

--- a/transcendental_resonance_frontend/src/utils/page_registry.py
+++ b/transcendental_resonance_frontend/src/utils/page_registry.py
@@ -36,4 +36,10 @@ def ensure_pages(pages: dict[str, str], pages_dir: Path) -> None:
             )
             logger.info("Created placeholder page module %s", file_path.name)
 
-__all__ = ["ensure_pages"]
+def get_pages_dir() -> Path:
+    """Return the canonical directory for Streamlit page modules."""
+
+    return Path(__file__).resolve().parents[2] / "pages"
+
+
+__all__ = ["ensure_pages", "get_pages_dir"]

--- a/ui_utils.py
+++ b/ui_utils.py
@@ -6,7 +6,11 @@
 from pathlib import Path
 import streamlit as st
 from streamlit_helpers import inject_global_styles
-from modern_ui import render_modern_header
+try:
+    from modern_ui import render_modern_header
+except Exception:  # pragma: no cover - gracefully handle missing/invalid module
+    def render_modern_header(*_a, **_k):
+        return None
 from modern_ui_components import render_modern_sidebar
 
 


### PR DESCRIPTION
## Summary
- add `get_pages_dir` helper
- use helper for page discovery in UI and sidebar
- harden optional modern UI imports

## Testing
- `pytest tests/test_ui_pages.py`

------
https://chatgpt.com/codex/tasks/task_e_688a9485c0608320b3d951059764bda4