### PR TITLE
Refactor theme injection and modern UI styles

### DIFF
--- a/frontend/theme.py
+++ b/frontend/theme.py
@@ -5,45 +5,69 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 import streamlit as st
 
-ACCENT_COLOR = "#00F0FF"  # Default fallback accent
+
+@dataclass(frozen=True)
+class ColorTheme:
+    """Simple container for theme colors."""
+
+    bg: str
+    card: str
+    accent: str
+    text_muted: str
 
 
-def get_accent_color() -> str:
-    """Return the current theme accent color."""
-    return ACCENT_COLOR
+LIGHT_THEME = ColorTheme(
+    bg="#F0F2F6",
+    card="#FFFFFF",
+    accent="#0A84FF",
+    text_muted="#666666",
+)
+
+DARK_THEME = ColorTheme(
+    bg="#001E26",
+    card="#002B36",
+    accent="#00F0FF",
+    text_muted="#7e9aaa",
+)
 
 
-def get_global_css(dark: bool) -> str:
-    """Return ``:root`` CSS variables for dark or light mode."""
-    if dark:
-        bg = "#001E26"
-        card = "#002B36"
-        accent = "#00F0FF"
-        muted = "#7e9aaa"
-    else:
-        bg = "#F0F2F6"
-        card = "#FFFFFF"
-        accent = "#0A84FF"
-        muted = "#666666"
+def get_theme(dark: bool = True) -> ColorTheme:
+    """Return the dark or light :class:`ColorTheme`."""
 
-    return (
-        "<style>"
-        " :root {"
-        f" --bg: {bg};"
-        f" --card: {card};"
-        f" --accent: {accent};"
-        f" --text-muted: {muted};"
-        " }"
-        "</style>"
-    )
+    return DARK_THEME if dark else LIGHT_THEME
+
+
+def get_global_css(dark: bool = True) -> str:
+    """Return ``:root`` CSS variables for the selected theme."""
+
+    theme = get_theme(dark)
+    return f"""
+<style>
+:root {{
+    --bg: {theme.bg};
+    --card: {theme.card};
+    --accent: {theme.accent};
+    --text-muted: {theme.text_muted};
+}}
+</style>
+"""
 
 
 def inject_modern_styles(dark: bool = True) -> None:
     """Inject the base CSS variables for the modern theme."""
+
     if st.session_state.get("_theme_injected"):
         return
     st.markdown(get_global_css(dark), unsafe_allow_html=True)
     st.session_state["_theme_injected"] = True
+
+
+def get_accent_color() -> str:
+    """Return the accent color for the current theme."""
+
+    return get_theme(True).accent
 

--- a/modern_ui.py
+++ b/modern_ui.py
@@ -5,7 +5,7 @@
 
 import streamlit as st
 import logging
-from frontend.theme import inject_modern_styles as _theme_styles
+from frontend import theme
 
 
 logger = logging.getLogger(__name__)
@@ -28,165 +28,42 @@ def render_lottie_animation(url: str, *, height: int = 200, fallback: str = "ðŸš
 
 logger = logging.getLogger("modern_ui")
 
+
 def inject_modern_styles() -> None:
-    """Inject global CSS for a sleek dark appearance.
-
-    Call this before rendering any UI elements so the styles apply correctly.
-    """
+    """Inject global CSS using theme variables and local assets."""
     from modern_ui_components import SIDEBAR_STYLES
-    from frontend.theme import get_global_css
-
-    _theme_styles()
 
     if st.session_state.get("modern_styles_injected"):
         logger.debug("Modern styles already injected; skipping")
         return
 
-    st.markdown(get_global_css(True), unsafe_allow_html=True)
+    theme.inject_modern_styles()
 
     css = """
-        <link rel="preconnect" href="https://fonts.gstatic.com">
-        <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
-        <style>
-        :root {
-            --neon-accent: #00e6ff;
-            --bg-start: #0f0c29;
-            --bg-end: #302b63;
-            --text-color: #f0f4f8;
-        }
-        body, .stApp {
-            background: linear-gradient(135deg, var(--bg-start), var(--bg-end));
-            color: var(--text-color);
-            font-family: 'Inter', sans-serif;
-        }
-        .main .block-container {
-            padding: 2rem 3rem;
-            max-width: 1200px;
-        }
-        .custom-container,
-        .card {
-            padding: 1rem;
-            border-radius: 12px;
-            border: 1px solid rgba(255,255,255,0.1);
-            box-shadow: 0 2px 6px rgba(0,0,0,0.25);
-            backdrop-filter: blur(8px);
-
-            margin-bottom: 1rem;
-            background: linear-gradient(135deg, rgba(255,255,255,0.05), rgba(255,255,255,0.02));
-            transition: box-shadow 0.3s ease, transform 0.3s ease;
-        }
-        .card:hover,
-        .custom-container:hover {
-            box-shadow: 0 3px 10px rgba(0,0,0,0.3);
-            transform: translateY(-3px);
-
-
-        }
-        h1, h2, h3, h4, h5, h6 {
-            font-family: 'Inter', sans-serif;
-            font-weight: 600;
-            line-height: 1.3;
-            margin: 0 0 0.5rem 0;
-        }
-        h1 { font-size: clamp(1.8rem, 5vw, 2.4rem); }
-        h2 { font-size: clamp(1.5rem, 4vw, 2rem); }
-        h3 { font-size: clamp(1.25rem, 3vw, 1.6rem); }
-        h4 { font-size: clamp(1.1rem, 2.5vw, 1.3rem); }
-        h5 { font-size: clamp(1rem, 2vw, 1.1rem); }
-        h6 { font-size: clamp(0.875rem, 1.5vw, 1rem); }
-        }
-        p, span, div {
-            line-height: 1.6;
-            font-family: 'Inter', sans-serif;
-            margin-bottom: 0.75rem;
-        }
-        .gradient-btn,
-        .stButton > button {
-            background: linear-gradient(90deg, var(--neon-accent), #00ffff) !important;
-            border: none !important;
-            border-radius: 10px !important;
-            color: #00111e !important;
-            font-weight: 600 !important;
-            padding: 0.75rem 2rem !important;
-            transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1) !important;
-            box-shadow: 0 4px 15px rgba(0, 255, 255, 0.4) !important;
-            font-size: 0.95rem !important;
-            height: auto !important;
-        }
-        .gradient-btn:hover,
-        .stButton > button:hover {
-            transform: translateY(-1px) !important;
-            box-shadow: 0 6px 20px rgba(0, 255, 255, 0.6) !important;
-            background: linear-gradient(90deg, #00ffff, var(--neon-accent)) !important;
-            filter: brightness(1.05);
-        }
- 
-        .stButton>button {
-            background: rgba(255,255,255,0.05) !important;
-            border: 1px solid rgba(255,255,255,0.15) !important;
-            backdrop-filter: blur(8px) !important;
-            border-radius: 12px !important;
-            color: var(--text-color) !important;
-            font-weight: 600 !important;
-            padding: 0.6rem 1.4rem !important;
-            box-shadow: 0 2px 4px rgba(0,0,0,0.3) !important;
-            transition: all 0.2s ease !important;
-            font-size: 0.9rem !important;
-        }
-        .stButton>button:hover {
-            box-shadow: 0 4px 10px rgba(0,0,0,0.4) !important, 0 0 6px var(--neon-accent) !important;
-            background: rgba(255,255,255,0.08) !important;
-            transform: translateY(-1px) scale(1.03) !important;
-        }
-
-        input, textarea, select {
-            background-color: #1a1a1a !important;
-            color: #eee !important;
-            border: 1px solid #444 !important;
-            border-radius: 8px !important;
-        }
-
-        .stButton>button:hover {
-            box-shadow: 0 4px 12px rgba(0,0,0,0.4),0 0 6px var(--neon-accent);
-            transform: translateY(-2px) scale(1.03);
-        }
-        .custom-container, .card {
-            background: rgba(255,255,255,0.05);
-            border: 1px solid rgba(255,255,255,0.2);
-            backdrop-filter: blur(8px);
-            border-radius: 12px;
-            padding: 1rem;
-            margin-bottom: 1rem;
-            transition: box-shadow 0.3s, transform 0.3s;
-        }
-        .custom-container:hover, .card:hover {
-            box-shadow: 0 6px 20px rgba(0,0,0,0.3);
-            transform: translateY(-3px);
-        }
-
-
-        @media (max-width: 768px) {
-            .main .block-container {
-                padding-left: 1rem;
-                padding-right: 1rem;
-            }
-        }
-
-        @media (max-width: 480px) {
-            .main .block-container {
-                padding-left: 0.5rem;
-                padding-right: 0.5rem;
-            }
-            .stButton>button {
-                width: 100%;
-            }
-        }
-
-        """
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+    <script type="module" src="/static/lucide-react.min.js"></script>
+    <style>
+    body, .stApp {
+        background: var(--bg);
+        color: var(--text-muted);
+        font-family: 'Inter', sans-serif;
+    }
+    .card, .custom-container {
+        background: var(--card);
+        border-radius: 1rem;
+        box-shadow: 0 2px 6px rgba(0,0,0,0.08);
+        transition: transform .2s ease, box-shadow .2s ease;
+    }
+    .card:hover, .custom-container:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 12px rgba(0,0,0,0.12);
+    }
+    </style>
+    """
     st.markdown(css, unsafe_allow_html=True)
     st.markdown(SIDEBAR_STYLES, unsafe_allow_html=True)
     st.session_state["modern_styles_injected"] = True
-
 
 def inject_premium_styles() -> None:
     """Backward compatible alias for :func:`inject_modern_styles`."""

--- a/static/lucide-react.min.js
+++ b/static/lucide-react.min.js
@@ -1,0 +1,2 @@
+// Placeholder for Lucide-React icons bundle
+export const placeholder=true;


### PR DESCRIPTION
## Summary
- define reusable dark and light color themes with CSS variables
- refactor modern style injector to use theme, Inter font, and local Lucide icons
- add placeholder Lucide-React bundle in `static/`

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_688a972b992c83208fff5b77d7d8f2c5