### PR TITLE
Guard modern style injection

### DIFF
--- a/modern_ui.py
+++ b/modern_ui.py
@@ -259,8 +259,6 @@ def render_validation_card() -> None:
         unsafe_allow_html=True,
     )
 
-
-def render_stats_section() -> None:
 def render_stats_section() -> None:
     """Display quick stats using a responsive flexbox layout."""
 
@@ -330,12 +328,6 @@ def render_stats_section() -> None:
                 <div style='font-size:2rem;margin-bottom:0.5rem;'>{icon}</div>
                 <div class='stats-value'>{value}</div>
                 <div class='stats-label'>{label}</div>
-            </div>
-            """,
-            unsafe_allow_html=True,
-        )
-    st.markdown("</div>", unsafe_allow_html=True)
-
             </div>
             """,
             unsafe_allow_html=True,


### PR DESCRIPTION
## Summary
- Avoid double CSS injection by checking `st.session_state['modern_styles_injected']` before calling `inject_modern_styles`.
- Remove redundant `SIDEBAR_STYLES` injection and streamline page lookup logic.
- Stub `st.experimental_page` for compatibility with Streamlit versions lacking the API and clean up modern UI utilities.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688a94851ed08320beec9cfe1ab6805f