### PR TITLE
Remove fallback system; auto-generate page stubs

### DIFF
--- a/tests/test_page_registry.py
+++ b/tests/test_page_registry.py
@@ -1,0 +1,24 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "page_registry",
+    Path(__file__).resolve().parents[1] / "utils" / "page_registry.py",
+)
+page_registry = importlib.util.module_from_spec(spec)
+sys.modules["page_registry"] = page_registry
+spec.loader.exec_module(page_registry)
+ensure_pages = page_registry.ensure_pages
+
+
+def test_ensure_pages_creates_stubs(tmp_path):
+    pages = {"One": "one", "Two": "two"}
+    pages_dir = tmp_path / "pages"
+    ensure_pages(pages, pages_dir)
+    for slug in pages.values():
+        file_path = pages_dir / f"{slug}.py"
+        assert file_path.exists()
+        content = file_path.read_text()
+        assert "Placeholder page" in content
+

--- a/utils/page_registry.py
+++ b/utils/page_registry.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Mapping
+
+
+def ensure_pages(pages: Mapping[str, str], pages_dir: os.PathLike[str]) -> None:
+    """Ensure a module exists for each slug in ``pages``."""
+    dir_path = Path(pages_dir)
+    dir_path.mkdir(parents=True, exist_ok=True)
+
+    for slug in pages.values():
+        file_path = dir_path / f"{slug}.py"
+        if not file_path.exists():
+            file_path.write_text(
+                "# Auto-generated placeholder\n"
+                "import streamlit as st\n\n"
+                f"def main():\n    st.info('Placeholder page: {slug}')\n"
+            )
+


### PR DESCRIPTION
## Summary
- create `ensure_pages` helper to generate missing page modules
- call helper when launching the UI
- drop `_render_fallback` code and associated tracking
- update tests and add coverage for page stub creation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a90ebd994832095238a93d50f050f