### PR TITLE
Fix resonance summary logic

### DIFF
--- a/transcendental_resonance_frontend/pages/resonance_music.py
+++ b/transcendental_resonance_frontend/pages/resonance_music.py
@@ -165,63 +165,50 @@ def render_resonance_music_page(main_container=None, backend_ok: Optional[bool] 
         # --- Fetch Resonance Summary Section ---
         if st.button("Fetch resonance summary", key="fetch_summary_btn"):
             if not backend_ok:
-                alert(f"Cannot fetch summary: Backend service unreachable at {BACKEND_URL}.", "error")
+                alert(
+                    f"Cannot fetch summary: Backend service unreachable at {BACKEND_URL}.",
+                    "error",
+                )
                 return
 
             with st.spinner("Fetching summary..."):
                 try:
                     data = _run_async(get_resonance_summary(choice))
-
+                except Exception as exc:
+                    alert(
+                        f"Failed to load summary: {exc}. Ensure backend is running and 'resonance-summary' route is available.",
+                        "error",
+                    )
+                else:
                     if data:
                         metrics = data.get("metrics", {})
                         midi_bytes_count = data.get("midi_bytes", 0)
 
                         st.subheader("Metrics")
                         if metrics:
-                            st.table({
-                                "metric": list(metrics.keys()),
-                                "value": list(metrics.values())
-                            })
+                            st.table(
+                                {"metric": list(metrics.keys()), "value": list(metrics.values())}
+                            )
                         else:
                             st.toast("No metrics available for this profile.")
 
-                        st.write(f"Associated MIDI bytes (count/size): {midi_bytes_count}")
+                        st.write(
+                            f"Associated MIDI bytes (count/size): {midi_bytes_count}"
+                        )
 
                         summary_midi_b64 = data.get("midi_base64")
                         if summary_midi_b64:
                             summary_midi_bytes = base64.b64decode(summary_midi_b64)
-                            st.audio(summary_midi_bytes, format="audio/midi", key="summary_audio_player")
+                            st.audio(
+                                summary_midi_bytes,
+                                format="audio/midi",
+                                key="summary_audio_player",
+                            )
                             st.toast("Playing associated MIDI from summary.")
 
                         st.toast("Summary loaded!")
-                except Exception as exc:
-                    alert(f"Summary fetch failed: {exc}", "error")
-
-                        else:
-                        st.toast("No metrics available for this profile.")
-
-                    st.write(f"Associated MIDI bytes (count/size): {midi_bytes_count}")
-
-                    # If the summary also returns MIDI bytes (e.g., for preview), play it
-                    summary_midi_b64 = data.get("midi_base64")
-                    if summary_midi_b64:
-                        summary_midi_bytes = base64.b64decode(summary_midi_b64)
-                        st.audio(
-                            summary_midi_bytes,
-                            format="audio/midi",
-                            key="summary_audio_player",
-                        )
-                        st.toast("Playing associated MIDI from summary.")
-
-                    st.toast("Summary loaded!")
-                else:
-                    alert("No summary data returned for this profile.", "warning")
-
-            except Exception as exc:
-                alert(
-                    f"Failed to load summary: {exc}. Ensure backend is running and 'resonance-summary' route is available.",
-                    "error",
-                )
+                    else:
+                        alert("No summary data returned for this profile.", "warning")
 
 
 def render() -> None:


### PR DESCRIPTION
## Summary
- streamline the Fetch resonance summary block
- remove duplicated code and handle missing data with a proper `try`/`except`/`else`

## Testing
- `python -m py_compile transcendental_resonance_frontend/pages/resonance_music.py`


------
https://chatgpt.com/codex/tasks/task_e_688aa369433c8320954b3b841a25dbfb