### PR TITLE
Fix get_pages_dir fallback

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -104,10 +104,6 @@ except Exception as import_err:  # pragma: no cover - fallback if absolute impor
             return None
 
         def get_pages_dir() -> Path:
-            return Path(__file__).resolve().parents[2] / "pages"
-
-
-        def get_pages_dir() -> Path:
             return (
                 Path(__file__).resolve().parent
                 / "transcendental_resonance_frontend"


### PR DESCRIPTION
## Summary
- keep only one fallback `get_pages_dir()` in `ui.py`
- ensure fallback returns the frontend pages path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688aa3649bdc8320a5b970baec65a223