### PR TITLE
Fix validation page main function

### DIFF
--- a/transcendental_resonance_frontend/pages/validation.py
+++ b/transcendental_resonance_frontend/pages/validation.py
@@ -29,30 +29,8 @@ def main(main_container=None) -> None:
         with container_ctx:
             render_validation_ui(main_container=main_container)
     except AttributeError:
+        # Fallback: in case container_ctx fails due to unexpected type
         render_validation_ui(main_container=main_container)
-
-
-        container_ctx = safe_container(main_container)
-
-        try:
-            with container_ctx:
-                render_validation_ui(main_container=main_container)
-        except AttributeError:
-            render_validation_ui(main_container=main_container)
-else:
-    def main(main_container=None) -> None:
-        """Render the validation UI inside a container safely."""
-        if main_container is None:
-            main_container = st
-
-        container_ctx = safe_container(main_container)
-
-        try:
-            with container_ctx:
-                render_validation_ui(main_container=main_container)
-        except AttributeError:
-            # Fallback: in case container_ctx fails due to unexpected type
-            render_validation_ui(main_container=main_container)
 
 def render() -> None:
     """Wrapper to keep page loading consistent."""


### PR DESCRIPTION
## Summary
- simplify `validation.py` so there is just one `main` function decorated with `_page_decorator`
- keep fallback logic for when the container context is missing

## Testing
- `python -m py_compile transcendental_resonance_frontend/pages/validation.py`

------
https://chatgpt.com/codex/tasks/task_e_688aa35319b883208a11be73209fd8fe