### PR TITLE
Fix page registry setup and cleanup pages

### DIFF
--- a/transcendental_resonance_frontend/pages/resonance_music.py
+++ b/transcendental_resonance_frontend/pages/resonance_music.py
@@ -171,57 +171,36 @@ def render_resonance_music_page(main_container=None, backend_ok: Optional[bool] 
             with st.spinner("Fetching summary..."):
                 try:
                     data = _run_async(get_resonance_summary(choice))
+                    if not data:
+                        alert("No summary data returned for this profile.", "warning")
+                        return
 
-                    if data:
-                        metrics = data.get("metrics", {})
-                        midi_bytes_count = data.get("midi_bytes", 0)
+                    metrics = data.get("metrics", {})
+                    midi_bytes_count = data.get("midi_bytes", 0)
 
-                        st.subheader("Metrics")
-                        if metrics:
-                            st.table({
-                                "metric": list(metrics.keys()),
-                                "value": list(metrics.values())
-                            })
-                        else:
-                            st.toast("No metrics available for this profile.")
-
-                        st.write(f"Associated MIDI bytes (count/size): {midi_bytes_count}")
-
-                        summary_midi_b64 = data.get("midi_base64")
-                        if summary_midi_b64:
-                            summary_midi_bytes = base64.b64decode(summary_midi_b64)
-                            st.audio(summary_midi_bytes, format="audio/midi", key="summary_audio_player")
-                            st.toast("Playing associated MIDI from summary.")
-
-                        st.toast("Summary loaded!")
-                except Exception as exc:
-                    alert(f"Summary fetch failed: {exc}", "error")
-
-                        else:
+                    st.subheader("Metrics")
+                    if metrics:
+                        st.table({
+                            "metric": list(metrics.keys()),
+                            "value": list(metrics.values())
+                        })
+                    else:
                         st.toast("No metrics available for this profile.")
 
                     st.write(f"Associated MIDI bytes (count/size): {midi_bytes_count}")
 
-                    # If the summary also returns MIDI bytes (e.g., for preview), play it
                     summary_midi_b64 = data.get("midi_base64")
                     if summary_midi_b64:
                         summary_midi_bytes = base64.b64decode(summary_midi_b64)
-                        st.audio(
-                            summary_midi_bytes,
-                            format="audio/midi",
-                            key="summary_audio_player",
-                        )
+                        st.audio(summary_midi_bytes, format="audio/midi", key="summary_audio_player")
                         st.toast("Playing associated MIDI from summary.")
 
                     st.toast("Summary loaded!")
-                else:
-                    alert("No summary data returned for this profile.", "warning")
-
-            except Exception as exc:
-                alert(
-                    f"Failed to load summary: {exc}. Ensure backend is running and 'resonance-summary' route is available.",
-                    "error",
-                )
+                except Exception as exc:
+                    alert(
+                        f"Failed to load summary: {exc}. Ensure backend is running and 'resonance-summary' route is available.",
+                        "error",
+                    )
 
 
 def render() -> None:

--- a/transcendental_resonance_frontend/pages/validation.py
+++ b/transcendental_resonance_frontend/pages/validation.py
@@ -29,30 +29,8 @@ def main(main_container=None) -> None:
         with container_ctx:
             render_validation_ui(main_container=main_container)
     except AttributeError:
+        # Fallback in case safe_container fails with incompatible type
         render_validation_ui(main_container=main_container)
-
-
-        container_ctx = safe_container(main_container)
-
-        try:
-            with container_ctx:
-                render_validation_ui(main_container=main_container)
-        except AttributeError:
-            render_validation_ui(main_container=main_container)
-else:
-    def main(main_container=None) -> None:
-        """Render the validation UI inside a container safely."""
-        if main_container is None:
-            main_container = st
-
-        container_ctx = safe_container(main_container)
-
-        try:
-            with container_ctx:
-                render_validation_ui(main_container=main_container)
-        except AttributeError:
-            # Fallback: in case container_ctx fails due to unexpected type
-            render_validation_ui(main_container=main_container)
 
 def render() -> None:
     """Wrapper to keep page loading consistent."""

--- a/ui.py
+++ b/ui.py
@@ -104,10 +104,6 @@ except Exception as import_err:  # pragma: no cover - fallback if absolute impor
             return None
 
         def get_pages_dir() -> Path:
-            return Path(__file__).resolve().parents[2] / "pages"
-
-
-        def get_pages_dir() -> Path:
             return (
                 Path(__file__).resolve().parent
                 / "transcendental_resonance_frontend"
@@ -141,6 +137,17 @@ PAGES = {
     "Social": "social",
     "Profile": "profile",
 }
+
+ensure_pages(PAGES, PAGES_DIR)
+for file in PAGES_DIR.glob("*.py"):
+    counterpart = file.with_name(file.stem.lower() + file.suffix)
+    if file.name != counterpart.name and counterpart.exists():
+        logger.warning(
+            "Case-insensitive file collision for '%s': %s, %s",
+            file.stem.lower(),
+            file.name,
+            counterpart.name,
+        )
 
 # Case-insensitive lookup for labels
 _PAGE_LABELS = {label.lower(): label for label in PAGES}
@@ -1292,7 +1299,6 @@ def render_developer_tools() -> None:
 
 def main() -> None:
     """Entry point with comprehensive error handling and modern UI."""
-    ensure_pages(PAGES, PAGES_DIR)
     # Initialize database BEFORE anything else
     try:
         db_ready = ensure_database_exists()


### PR DESCRIPTION
## Summary
- fix page import fallback for transcendental_resonance_frontend
- call `ensure_pages` globally and warn on case-insensitive duplicates
- clean up Resonance Music and Validation pages
- remove unused startup call

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688aa211a98083208d61fc5f49e0fcb6