### PR TITLE
Fix page registry startup and page syntax

### DIFF
--- a/transcendental_resonance_frontend/pages/resonance_music.py
+++ b/transcendental_resonance_frontend/pages/resonance_music.py
@@ -178,10 +178,12 @@ def render_resonance_music_page(main_container=None, backend_ok: Optional[bool] 
 
                         st.subheader("Metrics")
                         if metrics:
-                            st.table({
-                                "metric": list(metrics.keys()),
-                                "value": list(metrics.values())
-                            })
+                            st.table(
+                                {
+                                    "metric": list(metrics.keys()),
+                                    "value": list(metrics.values()),
+                                }
+                            )
                         else:
                             st.toast("No metrics available for this profile.")
 
@@ -190,38 +192,22 @@ def render_resonance_music_page(main_container=None, backend_ok: Optional[bool] 
                         summary_midi_b64 = data.get("midi_base64")
                         if summary_midi_b64:
                             summary_midi_bytes = base64.b64decode(summary_midi_b64)
-                            st.audio(summary_midi_bytes, format="audio/midi", key="summary_audio_player")
+                            st.audio(
+                                summary_midi_bytes,
+                                format="audio/midi",
+                                key="summary_audio_player",
+                            )
                             st.toast("Playing associated MIDI from summary.")
 
                         st.toast("Summary loaded!")
+                    else:
+                        alert("No summary data returned for this profile.", "warning")
+
                 except Exception as exc:
-                    alert(f"Summary fetch failed: {exc}", "error")
-
-                        else:
-                        st.toast("No metrics available for this profile.")
-
-                    st.write(f"Associated MIDI bytes (count/size): {midi_bytes_count}")
-
-                    # If the summary also returns MIDI bytes (e.g., for preview), play it
-                    summary_midi_b64 = data.get("midi_base64")
-                    if summary_midi_b64:
-                        summary_midi_bytes = base64.b64decode(summary_midi_b64)
-                        st.audio(
-                            summary_midi_bytes,
-                            format="audio/midi",
-                            key="summary_audio_player",
-                        )
-                        st.toast("Playing associated MIDI from summary.")
-
-                    st.toast("Summary loaded!")
-                else:
-                    alert("No summary data returned for this profile.", "warning")
-
-            except Exception as exc:
-                alert(
-                    f"Failed to load summary: {exc}. Ensure backend is running and 'resonance-summary' route is available.",
-                    "error",
-                )
+                    alert(
+                        f"Failed to load summary: {exc}. Ensure backend is running and 'resonance-summary' route is available.",
+                        "error",
+                    )
 
 
 def render() -> None:

--- a/transcendental_resonance_frontend/pages/validation.py
+++ b/transcendental_resonance_frontend/pages/validation.py
@@ -29,30 +29,8 @@ def main(main_container=None) -> None:
         with container_ctx:
             render_validation_ui(main_container=main_container)
     except AttributeError:
+        # Fallback: in case container_ctx fails due to unexpected type
         render_validation_ui(main_container=main_container)
-
-
-        container_ctx = safe_container(main_container)
-
-        try:
-            with container_ctx:
-                render_validation_ui(main_container=main_container)
-        except AttributeError:
-            render_validation_ui(main_container=main_container)
-else:
-    def main(main_container=None) -> None:
-        """Render the validation UI inside a container safely."""
-        if main_container is None:
-            main_container = st
-
-        container_ctx = safe_container(main_container)
-
-        try:
-            with container_ctx:
-                render_validation_ui(main_container=main_container)
-        except AttributeError:
-            # Fallback: in case container_ctx fails due to unexpected type
-            render_validation_ui(main_container=main_container)
 
 def render() -> None:
     """Wrapper to keep page loading consistent."""


### PR DESCRIPTION
## Summary
- ensure page registry placeholder creation after config
- stub out `ensure_pages` when package isn't available
- warn about case conflicts
- clean up sidebar page display
- fix indentation in Resonance Music and Validation pages

## Testing
- `pytest -q`
- `python -m py_compile ui.py transcendental_resonance_frontend/pages/resonance_music.py transcendental_resonance_frontend/pages/validation.py`
- `python -m compileall -q transcendental_resonance_frontend/pages`

------
https://chatgpt.com/codex/tasks/task_e_688aa211a98083208d61fc5f49e0fcb6