### PR TITLE
Ensure unique page labels from slugs

### DIFF
--- a/tests/test_pages_unique.py
+++ b/tests/test_pages_unique.py
@@ -1,0 +1,33 @@
+import sys
+import types
+from pathlib import Path
+import pytest
+
+pytest.importorskip("streamlit")
+pytestmark = pytest.mark.requires_streamlit
+
+# Ensure repository root is importable
+root = Path(__file__).resolve().parents[1]
+if str(root) not in sys.path:
+    sys.path.insert(0, str(root))
+
+import ui
+from utils.paths import PAGES_DIR
+
+
+def test_pages_labels_generated_from_slugs():
+    pages = ui.build_pages(PAGES_DIR)
+    # Each label must be slug.replace('_', ' ').title()
+    for label, slug in pages.items():
+        assert label == slug.replace("_", " ").title()
+    # PAGES constant should match build_pages result
+    assert ui.PAGES == pages
+
+
+def test_each_page_appears_once():
+    pages = ui.build_pages(PAGES_DIR)
+    labels = list(pages.keys())
+    slugs = list(pages.values())
+    assert len(labels) == len(set(labels))
+    assert len(slugs) == len(set(slugs))
+

--- a/ui.py
+++ b/ui.py
@@ -130,17 +130,23 @@ HEALTH_CHECK_PARAM = "healthz"
 ROOT_DIR = Path(__file__).resolve().parent
 PAGES_DIR = get_pages_dir()
 
+
+def build_pages(pages_dir: Path) -> dict[str, str]:
+    """Return a mapping of sidebar labels to page slugs."""
+    pages: dict[str, str] = {}
+    for page_file in sorted(pages_dir.glob("*.py")):
+        if page_file.stem == "__init__":
+            continue
+        slug = page_file.stem
+        label = slug.replace("_", " ").title()
+        if label not in pages:
+            pages[label] = slug
+    return pages
+
+
 # Mapping of navigation labels to page module names
 
-PAGES = {
-    "Validation": "validation",
-    "Voting": "voting",
-    "Agents": "agents",
-    "Resonance Music": "resonance_music",
-    "Chat": "chat",
-    "Social": "social",
-    "Profile": "profile",
-}
+PAGES = build_pages(PAGES_DIR)
 
 # Case-insensitive lookup for labels
 _PAGE_LABELS = {label.lower(): label for label in PAGES}


### PR DESCRIPTION
## Summary
- build sidebar pages dynamically from slug files
- verify sidebar labels come from slugs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'utils.paths')*

------
https://chatgpt.com/codex/tasks/task_e_688aa35853488320adb2bf0324706696