### PR TITLE
Fix indentation issues in frontend pages

### DIFF
--- a/transcendental_resonance_frontend/pages/resonance_music.py
+++ b/transcendental_resonance_frontend/pages/resonance_music.py
@@ -194,35 +194,14 @@ def render_resonance_music_page(main_container=None, backend_ok: Optional[bool] 
                             st.toast("Playing associated MIDI from summary.")
 
                         st.toast("Summary loaded!")
+
+                    else:
+                        alert("No summary data returned for this profile.", "warning")
                 except Exception as exc:
-                    alert(f"Summary fetch failed: {exc}", "error")
-
-                        else:
-                        st.toast("No metrics available for this profile.")
-
-                    st.write(f"Associated MIDI bytes (count/size): {midi_bytes_count}")
-
-                    # If the summary also returns MIDI bytes (e.g., for preview), play it
-                    summary_midi_b64 = data.get("midi_base64")
-                    if summary_midi_b64:
-                        summary_midi_bytes = base64.b64decode(summary_midi_b64)
-                        st.audio(
-                            summary_midi_bytes,
-                            format="audio/midi",
-                            key="summary_audio_player",
-                        )
-                        st.toast("Playing associated MIDI from summary.")
-
-                    st.toast("Summary loaded!")
-                else:
-                    alert("No summary data returned for this profile.", "warning")
-
-            except Exception as exc:
-                alert(
-                    f"Failed to load summary: {exc}. Ensure backend is running and 'resonance-summary' route is available.",
-                    "error",
-                )
-
+                    alert(
+                        f"Failed to load summary: {exc}. Ensure backend is running and 'resonance-summary' route is available.",
+                        "error",
+                    )
 
 def render() -> None:
     """Wrapper to keep page loading consistent."""

--- a/transcendental_resonance_frontend/pages/validation.py
+++ b/transcendental_resonance_frontend/pages/validation.py
@@ -30,30 +30,6 @@ def main(main_container=None) -> None:
             render_validation_ui(main_container=main_container)
     except AttributeError:
         render_validation_ui(main_container=main_container)
-
-
-        container_ctx = safe_container(main_container)
-
-        try:
-            with container_ctx:
-                render_validation_ui(main_container=main_container)
-        except AttributeError:
-            render_validation_ui(main_container=main_container)
-else:
-    def main(main_container=None) -> None:
-        """Render the validation UI inside a container safely."""
-        if main_container is None:
-            main_container = st
-
-        container_ctx = safe_container(main_container)
-
-        try:
-            with container_ctx:
-                render_validation_ui(main_container=main_container)
-        except AttributeError:
-            # Fallback: in case container_ctx fails due to unexpected type
-            render_validation_ui(main_container=main_container)
-
 def render() -> None:
     """Wrapper to keep page loading consistent."""
     main()


### PR DESCRIPTION
## Summary
- remove duplicated summary code in `resonance_music` page
- clean up extra main definitions in `validation` page

## Testing
- `python -m py_compile transcendental_resonance_frontend/pages/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688aa36f5da48320b99840ce202c2c42