### PR TITLE
Fix ui startup and page modules

### DIFF
--- a/frontend/ui_layout.py
+++ b/frontend/ui_layout.py
@@ -136,6 +136,8 @@ def _render_sidebar_nav(
         valid_opts.append((label, path))
         valid_icons.append(icon)
 
+    display_labels = [lbl.replace("_", " ").title() for lbl, _ in valid_opts]
+
     opts = valid_opts
     icon_list = valid_icons
     if not opts:
@@ -152,25 +154,26 @@ def _render_sidebar_nav(
         st.markdown(SIDEBAR_STYLES, unsafe_allow_html=True)
         st.markdown("<div class='glass-card sidebar-nav'>", unsafe_allow_html=True)
         if hasattr(st.sidebar, "page_link"):
-            for (label, path), icon in zip(opts, icon_list):
+            for (label, path), icon, disp in zip(opts, icon_list, display_labels):
                 try:
-                    st.sidebar.page_link(path, label=label, icon=icon, help=label)
+                    st.sidebar.page_link(path, label=disp, icon=icon, help=disp)
                 except Exception:
                     url = f"?page={label}"
-                    st.sidebar.link_button(label, url=url, icon=icon)
+                    st.sidebar.link_button(disp, url=url, icon=icon)
         elif USE_OPTION_MENU and option_menu is not None:
-            choice = option_menu(
+            choice_disp = option_menu(
                 menu_title=None,
-                options=[label for label, _ in opts],
+                options=display_labels,
                 icons=[icon or "dot" for icon in icon_list],
                 orientation="vertical",
                 key=key,
                 default_index=index,
             )
+            choice = opts[display_labels.index(choice_disp)][0]
         else:
-            labels = [f"{icon or ''} {label}".strip() for (label, _), icon in zip(opts, icon_list)]
-            choice = st.radio("", labels, index=index, key=key)
-            choice = opts[labels.index(choice)][0]
+            labels = [f"{icon or ''} {disp}".strip() for disp, icon in zip(display_labels, icon_list)]
+            choice_disp = st.radio("", labels, index=index, key=key)
+            choice = opts[labels.index(choice_disp)][0]
 
         st.markdown("</div>", unsafe_allow_html=True)
 

--- a/transcendental_resonance_frontend/pages/resonance_music.py
+++ b/transcendental_resonance_frontend/pages/resonance_music.py
@@ -180,48 +180,35 @@ def render_resonance_music_page(main_container=None, backend_ok: Optional[bool] 
                         if metrics:
                             st.table({
                                 "metric": list(metrics.keys()),
-                                "value": list(metrics.values())
+                                "value": list(metrics.values()),
                             })
                         else:
                             st.toast("No metrics available for this profile.")
 
-                        st.write(f"Associated MIDI bytes (count/size): {midi_bytes_count}")
+                        st.write(
+                            f"Associated MIDI bytes (count/size): {midi_bytes_count}"
+                        )
 
                         summary_midi_b64 = data.get("midi_base64")
                         if summary_midi_b64:
                             summary_midi_bytes = base64.b64decode(summary_midi_b64)
-                            st.audio(summary_midi_bytes, format="audio/midi", key="summary_audio_player")
+                            st.audio(
+                                summary_midi_bytes,
+                                format="audio/midi",
+                                key="summary_audio_player",
+                            )
                             st.toast("Playing associated MIDI from summary.")
 
                         st.toast("Summary loaded!")
-                except Exception as exc:
-                    alert(f"Summary fetch failed: {exc}", "error")
-
-                        else:
-                        st.toast("No metrics available for this profile.")
-
-                    st.write(f"Associated MIDI bytes (count/size): {midi_bytes_count}")
-
-                    # If the summary also returns MIDI bytes (e.g., for preview), play it
-                    summary_midi_b64 = data.get("midi_base64")
-                    if summary_midi_b64:
-                        summary_midi_bytes = base64.b64decode(summary_midi_b64)
-                        st.audio(
-                            summary_midi_bytes,
-                            format="audio/midi",
-                            key="summary_audio_player",
+                    else:
+                        alert(
+                            "No summary data returned for this profile.", "warning"
                         )
-                        st.toast("Playing associated MIDI from summary.")
-
-                    st.toast("Summary loaded!")
-                else:
-                    alert("No summary data returned for this profile.", "warning")
-
-            except Exception as exc:
-                alert(
-                    f"Failed to load summary: {exc}. Ensure backend is running and 'resonance-summary' route is available.",
-                    "error",
-                )
+                except Exception as exc:
+                    alert(
+                        f"Failed to load summary: {exc}. Ensure backend is running and 'resonance-summary' route is available.",
+                        "error",
+                    )
 
 
 def render() -> None:

--- a/transcendental_resonance_frontend/pages/validation.py
+++ b/transcendental_resonance_frontend/pages/validation.py
@@ -29,31 +29,11 @@ def main(main_container=None) -> None:
         with container_ctx:
             render_validation_ui(main_container=main_container)
     except AttributeError:
+        # Fallback if container context fails due to older Streamlit versions
         render_validation_ui(main_container=main_container)
 
-
-        container_ctx = safe_container(main_container)
-
-        try:
-            with container_ctx:
-                render_validation_ui(main_container=main_container)
-        except AttributeError:
-            render_validation_ui(main_container=main_container)
-else:
-    def main(main_container=None) -> None:
-        """Render the validation UI inside a container safely."""
-        if main_container is None:
-            main_container = st
-
-        container_ctx = safe_container(main_container)
-
-        try:
-            with container_ctx:
-                render_validation_ui(main_container=main_container)
-        except AttributeError:
-            # Fallback: in case container_ctx fails due to unexpected type
-            render_validation_ui(main_container=main_container)
 
 def render() -> None:
     """Wrapper to keep page loading consistent."""
     main()
+

--- a/ui.py
+++ b/ui.py
@@ -82,7 +82,7 @@ render_modern_sidebar = render_sidebar_nav
 # Utility path handling
 from pathlib import Path
 import logging
-from utils.paths import ROOT_DIR, PAGES_DIR
+from utils.paths import ROOT_DIR
 
 logger = logging.getLogger(__name__)
 logger.propagate = False
@@ -104,15 +104,7 @@ except Exception as import_err:  # pragma: no cover - fallback if absolute impor
             return None
 
         def get_pages_dir() -> Path:
-            return Path(__file__).resolve().parents[2] / "pages"
-
-
-        def get_pages_dir() -> Path:
-            return (
-                Path(__file__).resolve().parent
-                / "transcendental_resonance_frontend"
-                / "pages"
-            )
+            return Path(__file__).resolve().parent / "pages"
 
 
 
@@ -145,6 +137,8 @@ PAGES = {
 # Case-insensitive lookup for labels
 _PAGE_LABELS = {label.lower(): label for label in PAGES}
 
+# Ensure stub pages exist and warn about case collisions
+ensure_pages(PAGES, PAGES_DIR)
 
 def normalize_choice(choice: str) -> str:
     """Return the canonical label for ``choice`` ignoring case."""
@@ -1292,7 +1286,6 @@ def render_developer_tools() -> None:
 
 def main() -> None:
     """Entry point with comprehensive error handling and modern UI."""
-    ensure_pages(PAGES, PAGES_DIR)
     # Initialize database BEFORE anything else
     try:
         db_ready = ensure_database_exists()


### PR DESCRIPTION
## Summary
- ensure page registry is loaded after defining `PAGES`
- simplify fallback page registry imports
- clean up resonance music and validation pages
- standardise sidebar labels

## Testing
- `python -m py_compile transcendental_resonance_frontend/pages/*.py ui.py modern_ui.py frontend/ui_layout.py pages/*.py`
- `pytest -q tests/test_ui_pages.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688aa20dd50c8320b25dfd7d44766a7c