### PR TITLE
Fix page registry and startup

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -141,8 +141,18 @@ def build_pages(pages_dir: Path) -> dict[str, str]:
 
 
 # Mapping of navigation labels to page module names
+PAGES = {
+    "Agents": "agents",
+    "Chat": "chat",
+    "Profile": "profile",
+    "Resonance Music": "resonance_music",
+    "Social": "social",
+    "Validation": "validation",
+    "Video Chat": "video_chat",
+    "Voting": "voting",
+}
 
-PAGES = build_pages(PAGES_DIR)
+ensure_pages(PAGES, PAGES_DIR)
 
 # Case-insensitive lookup for labels
 _PAGE_LABELS = {label.lower(): label for label in PAGES}
@@ -1294,7 +1304,6 @@ def render_developer_tools() -> None:
 
 def main() -> None:
     """Entry point with comprehensive error handling and modern UI."""
-    ensure_pages(PAGES, PAGES_DIR)
     # Initialize database BEFORE anything else
     try:
         db_ready = ensure_database_exists()

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,1 @@
+# namespace


### PR DESCRIPTION
## Summary
- define pages dictionary once and ensure creation
- call `ensure_pages` after the dictionary is built
- remove redundant `ensure_pages` call in `main`
- add empty `utils` package initializer

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'streamlit_javascript')*

------
https://chatgpt.com/codex/tasks/task_e_688aa69d69b483208a2908c1c23437ce