### PR TITLE
Fix duplicate import

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -32,7 +32,6 @@ import sys
 import traceback
 import sqlite3
 import importlib
-import time
 from streamlit.errors import StreamlitAPIException
 from sqlalchemy import create_engine, text
 from sqlalchemy.exc import OperationalError


### PR DESCRIPTION
## Summary
- remove redundant `import time` statement from `ui.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and NameError in existing tests)*

------
https://chatgpt.com/codex/tasks/task_e_688aa8a1c44483209e1d4e5ef66420bf