### PR TITLE
Handle lowercase page duplicates

### DIFF
--- a/tests/test_page_registry.py
+++ b/tests/test_page_registry.py
@@ -13,6 +13,11 @@ if str(root) not in sys.path:
     sys.path.insert(0, str(root))
 
 from transcendental_resonance_frontend.src.utils.page_registry import ensure_pages
+from disclaimers import (
+    STRICTLY_SOCIAL_MEDIA,
+    INTELLECTUAL_PROPERTY_ARTISTIC_INSPIRATION,
+    LEGAL_ETHICAL_SAFEGUARDS,
+)
 
 
 def create_duplicates(dir_path: Path) -> None:
@@ -75,3 +80,27 @@ def test_duplicates_removed_with_debug_flag(tmp_path, monkeypatch, caplog):
 
     assert count_slug_files(pages_dir, "foo") == 1
     assert any("Removed duplicate page module" in r.message for r in caplog.records)
+
+
+def test_disclaimers_intact_after_cleanup(tmp_path, monkeypatch):
+    pages_dir = tmp_path / "pages"
+    pages_dir.mkdir(parents=True, exist_ok=True)
+    canonical = pages_dir / "foo.py"
+    canonical.write_text(
+        f"# {STRICTLY_SOCIAL_MEDIA}\n"
+        f"# {INTELLECTUAL_PROPERTY_ARTISTIC_INSPIRATION}\n"
+        f"# {LEGAL_ETHICAL_SAFEGUARDS}\n"
+        "print('hi')\n"
+    )
+    (pages_dir / "Foo.py").write_text("print('dup')\n")
+    pages = {"Foo": "foo"}
+    monkeypatch.setenv("DEV", "1")
+    monkeypatch.setattr(sys, "argv", ["prog"])
+
+    ensure_pages(pages, pages_dir)
+
+    lines = canonical.read_text().splitlines()
+    assert lines[0] == f"# {STRICTLY_SOCIAL_MEDIA}"
+    assert lines[1] == f"# {INTELLECTUAL_PROPERTY_ARTISTIC_INSPIRATION}"
+    assert lines[2] == f"# {LEGAL_ETHICAL_SAFEGUARDS}"
+    assert count_slug_files(pages_dir, "foo") == 1

--- a/transcendental_resonance_frontend/src/utils/__init__.py
+++ b/transcendental_resonance_frontend/src/utils/__init__.py
@@ -12,7 +12,7 @@ from .features import (
 )
 from .error_overlay import ErrorOverlay
 from .api_status_footer import ApiStatusFooter
-from .page_registry import ensure_pages, get_pages_dir
+from .page_registry import ensure_pages, get_pages_dir, clean_duplicate_pages
 
 __all__ = [
     "quick_post_button",
@@ -29,4 +29,5 @@ __all__ = [
     "ApiStatusFooter",
     "ensure_pages",
     "get_pages_dir",
+    "clean_duplicate_pages",
 ]


### PR DESCRIPTION
## Summary
- add `clean_duplicate_pages` to cleanup case-insensitive duplicates
- call cleanup in `ensure_pages`
- export helper via utils package
- test that disclaimers survive cleanup

## Testing
- `pytest tests/test_page_registry.py -q`
- `pytest -q` *(fails: ModuleNotFoundError for utils.paths and other modules)*

------
https://chatgpt.com/codex/tasks/task_e_688aa8a1a5688320a7081f2f316962db