### PR TITLE
Add messaging center and richer profile hub

### DIFF
--- a/pages/messages.py
+++ b/pages/messages.py
@@ -1,0 +1,8 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
+from transcendental_resonance_frontend.pages.messages import main
+
+if __name__ == "__main__":
+    main()

--- a/transcendental_resonance_frontend/pages/messages.py
+++ b/transcendental_resonance_frontend/pages/messages.py
@@ -1,0 +1,78 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+"""Unified messages and chat center."""
+
+import streamlit as st
+from modern_ui import inject_modern_styles
+from streamlit_helpers import safe_container
+
+inject_modern_styles()
+
+DUMMY_CONVOS = [
+    {"user": "Alice", "preview": "Hey there!"},
+    {"user": "Bob", "preview": "Let's catch up."},
+]
+
+
+def _init_state() -> None:
+    st.session_state.setdefault("conversations", DUMMY_CONVOS)
+    st.session_state.setdefault(
+        "messages", {c["user"]: [] for c in st.session_state["conversations"]}
+    )
+    if "active_chat" not in st.session_state:
+        st.session_state["active_chat"] = DUMMY_CONVOS[0]["user"] if DUMMY_CONVOS else ""
+
+
+def _render_conversation_list() -> None:
+    users = [c["user"] for c in st.session_state["conversations"]]
+    active = st.session_state.get("active_chat")
+    if active not in users and users:
+        active = users[0]
+    col1, col2 = st.columns([1, 3])
+    with col1:
+        selected = st.radio("", users, index=users.index(active)) if users else ""
+        st.session_state["active_chat"] = selected
+    with col2:
+        st.write("Recent")
+        if users:
+            st.write(st.session_state["conversations"][users.index(selected)]["preview"])
+
+
+def _render_chat_panel(user: str) -> None:
+    st.subheader(f"Chat with {user}")
+    msgs = st.session_state["messages"].setdefault(user, [])
+    for msg in msgs:
+        st.write(f"{msg['sender']}: {msg['text']}")
+    txt = st.text_input("Message", key="msg_input")
+    if st.button("Send", key="send_btn") and txt:
+        msgs.append({"sender": "You", "text": txt})
+        st.session_state.msg_input = ""
+        st.experimental_rerun()
+    if st.button("Start Video Call", key="video_call"):
+        st.toast("Video call integration pending")
+
+
+def main(main_container=None) -> None:
+    if main_container is None:
+        main_container = st
+    _init_state()
+    container_ctx = safe_container(main_container)
+    with container_ctx:
+        st.subheader("✉️ Messages")
+        if not st.session_state["conversations"]:
+            st.info("No conversations yet")
+            return
+        user = st.session_state.get("active_chat")
+        _render_conversation_list()
+        st.divider()
+        if user:
+            _render_chat_panel(user)
+
+
+def render() -> None:
+    main()
+
+
+if __name__ == "__main__":
+    main()

--- a/transcendental_resonance_frontend/pages/profile.py
+++ b/transcendental_resonance_frontend/pages/profile.py
@@ -1,30 +1,68 @@
 # STRICTLY A SOCIAL MEDIA PLATFORM
 # Intellectual Property & Artistic Inspiration
 # Legal & Ethical Safeguards
-"""User profile and API configuration page."""
+"""User identity hub with profile and activity overview."""
 
 import streamlit as st
 from modern_ui import inject_modern_styles
 from streamlit_helpers import safe_container
 from api_key_input import render_api_key_ui
 
+try:
+    from social_tabs import _load_profile
+    from frontend_bridge import dispatch_route
+except Exception:  # pragma: no cover - optional dependencies
+    _load_profile = None  # type: ignore
+    dispatch_route = None  # type: ignore
+
 inject_modern_styles()
 
 
+def _render_profile(username: str) -> None:
+    if _load_profile is None:
+        st.error("Profile services unavailable")
+        return
+    try:
+        user, followers, following = _load_profile(username)
+    except Exception as exc:
+        st.error(f"Profile fetch failed: {exc}")
+        return
+    st.image("https://placehold.co/120x120", width=120)
+    st.markdown(f"### {user.get('username', username)}")
+    st.write(user.get("bio", ""))
+    st.markdown(
+        f"**Followers:** {len(followers.get('followers', []))}  \
+        **Following:** {len(following.get('following', []))}"
+    )
+    if dispatch_route is not None and st.button("Follow/Unfollow", key="follow"):
+        with st.spinner("Updating..."):
+            try:
+                dispatch_route("follow_user", {"username": username})
+                st.success("Updated")
+            except Exception as exc:
+                st.error(f"Failed: {exc}")
+    if st.button("Message", key="dm"):
+        st.switch_page("pages/messages.py")
+    if st.button("Video Chat", key="vc"):
+        st.switch_page("pages/video_chat.py")
+
+
 def main(main_container=None) -> None:
-    """Render the user profile page."""
     if main_container is None:
         main_container = st
-
     container_ctx = safe_container(main_container)
     with container_ctx:
         st.subheader("👤 Profile")
+        current = st.session_state.get("active_user", "guest")
+        current = st.text_input("Username", value=current, key="profile_user")
+        st.session_state["active_user"] = current
+        _render_profile(current)
+        st.divider()
         st.info("Manage API credentials for advanced features.")
         render_api_key_ui(key_prefix="profile")
 
 
 def render() -> None:
-    """Wrapper to keep page loading consistent."""
     main()
 
 

--- a/ui.py
+++ b/ui.py
@@ -154,7 +154,7 @@ def normalize_choice(choice: str) -> str:
 
 # Icons used in the navigation bar. Must be single-character emojis or
 # valid Bootstrap icon codes prefixed with ``"bi bi-"``.
-NAV_ICONS = ["✅", "📊", "🤖", "🎵", "💬", "👥", "👤"]
+NAV_ICONS = ["✅", "📊", "🤖", "🎵", "💬", "👥", "👤", "✉️"]
 
 
 # Toggle verbose output via ``UI_DEBUG_PRINTS``
@@ -1086,7 +1086,7 @@ def render_validation_ui(
         page_paths = {
             label: f"/pages/{mod}.py" for label, mod in PAGES.items()
         }
-        NAV_ICONS = ["✅", "📊", "🤖", "🎵", "💬", "👥", "👤"]
+        NAV_ICONS = ["✅", "📊", "🤖", "🎵", "💬", "👥", "👤", "✉️"]
 
         # ...
 


### PR DESCRIPTION
## Summary
- add new `Messages` page stub for chat and video call integration
- extend profile page with basic user info and follow/DM controls
- append mail icon to `NAV_ICONS` for navigation

## Testing
- `pip install -r requirements.txt`
- `pip install nicegui`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'utils.paths')*

------
https://chatgpt.com/codex/tasks/task_e_688aa92d03048320bdb51cc16523041a