### PR TITLE
Add profile hub and messages center

### DIFF
--- a/pages/messages_center.py
+++ b/pages/messages_center.py
@@ -1,0 +1,8 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
+from transcendental_resonance_frontend.pages.messages_center import main
+
+if __name__ == "__main__":
+    main()

--- a/transcendental_resonance_frontend/pages/messages_center.py
+++ b/transcendental_resonance_frontend/pages/messages_center.py
@@ -1,0 +1,79 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+"""Messages and chat center with placeholder data."""
+
+from __future__ import annotations
+
+import streamlit as st
+from modern_ui import inject_modern_styles
+from streamlit_helpers import safe_container
+
+inject_modern_styles()
+
+# Temporary in-memory conversation store
+DUMMY_CONVERSATIONS = {
+    "alice": [
+        {"user": "alice", "text": "Hi there!"},
+        {"user": "You", "text": "Hello!"},
+    ],
+    "bob": [
+        {
+            "user": "bob",
+            "text": "Check out this image!",
+            "image": "https://placehold.co/200x150",
+        }
+    ],
+}
+
+
+def _render_messages(messages: list[dict]) -> None:
+    """Display chat messages with optional media."""
+    for entry in messages:
+        user = entry.get("user", "?")
+        text = entry.get("text", "")
+        if image := entry.get("image"):
+            st.image(image, width=200)
+        if video := entry.get("video"):
+            st.video(video)
+        st.markdown(f"**{user}**: {text}")
+
+
+def main(main_container=None) -> None:
+    """Render the Messages / Chat Center page."""
+    if main_container is None:
+        main_container = st
+
+    container_ctx = safe_container(main_container)
+    with container_ctx:
+        st.subheader("💬 Messages")
+        st.session_state.setdefault("_conversations", DUMMY_CONVERSATIONS.copy())
+        convos = list(st.session_state["_conversations"].keys())
+        selected = st.radio("Conversations", convos, key="selected_convo")
+        msgs = st.session_state["_conversations"].setdefault(selected, [])
+        _render_messages(msgs)
+        cols = st.columns([4, 1])
+        with cols[0]:
+            msg = st.text_input("Message", key="msg_input")
+        with cols[1]:
+            if st.button("Send", key="send_msg") and msg:
+                msgs.append({"user": "You", "text": msg})
+                st.session_state.msg_input = ""
+                st.experimental_rerun()
+        st.divider()
+        from .chat import (
+            render_video_call_controls,
+            render_voice_chat_controls,
+        )
+        render_video_call_controls()
+        st.divider()
+        render_voice_chat_controls()
+
+
+def render() -> None:
+    """Wrapper for Streamlit multipage support."""
+    main()
+
+
+if __name__ == "__main__":
+    main()

--- a/transcendental_resonance_frontend/pages/profile.py
+++ b/transcendental_resonance_frontend/pages/profile.py
@@ -7,6 +7,7 @@ import streamlit as st
 from modern_ui import inject_modern_styles
 from streamlit_helpers import safe_container
 from api_key_input import render_api_key_ui
+from social_tabs import _load_profile
 
 inject_modern_styles()
 
@@ -21,6 +22,57 @@ def main(main_container=None) -> None:
         st.subheader("👤 Profile")
         st.info("Manage API credentials for advanced features.")
         render_api_key_ui(key_prefix="profile")
+
+        st.divider()
+        username = st.text_input(
+            "View Profile",
+            value=st.session_state.get("profile_username", "demo_user"),
+            key="profile_username",
+        )
+        if st.button("Load Profile", key="load_profile"):
+            try:
+                user, followers, following = _load_profile(username)
+                st.session_state["profile_data"] = user
+                st.session_state["profile_followers"] = followers
+                st.session_state["profile_following"] = following
+            except Exception:
+                st.warning("Profile data unavailable, using placeholder")
+                st.session_state["profile_data"] = {
+                    "username": username,
+                    "bio": "Exploring the cosmos.",
+                    "avatar": "https://placehold.co/100",
+                    "interests": ["science", "art"],
+                }
+                st.session_state["profile_followers"] = {"count": 0, "followers": []}
+                st.session_state["profile_following"] = {"count": 0, "following": []}
+
+        data = st.session_state.get(
+            "profile_data",
+            {
+                "username": username,
+                "bio": "Exploring the cosmos.",
+                "avatar": "https://placehold.co/100",
+                "interests": ["science", "art"],
+            },
+        )
+        st.image(data.get("avatar", "https://placehold.co/100"), width=100)
+        st.write(f"**{data.get('username', username)}**")
+        st.write(data.get("bio", ""))
+        st.write(
+            "Interests:",
+            ", ".join(data.get("interests", [])),
+        )
+
+        cols = st.columns(3)
+        with cols[0]:
+            st.button("Follow", key="follow_btn")
+        with cols[1]:
+            st.button("Message", key="dm_btn")
+        with cols[2]:
+            st.button("Video Chat", key="video_btn")
+
+        st.markdown("**Badges**: *(coming soon)*")
+        st.markdown("**Portfolio**: *(coming soon)*")
 
 
 def render() -> None:


### PR DESCRIPTION
## Summary
- scaffold messages center page with placeholder conversations
- expand profile page with basic user info and follow/DM actions
- expose messages center in Streamlit pages

## Testing
- `pip install -r requirements.txt`
- `pip install nicegui`
- `pytest -q` *(fails: ModuleNotFoundError: nicegui)*

------
https://chatgpt.com/codex/tasks/task_e_688aa92d03048320bdb51cc16523041a