### PR TITLE
Enhance profile page

### DIFF
--- a/transcendental_resonance_frontend/pages/profile.py
+++ b/transcendental_resonance_frontend/pages/profile.py
@@ -8,6 +8,45 @@ from modern_ui import inject_modern_styles
 from streamlit_helpers import safe_container
 from api_key_input import render_api_key_ui
 
+try:  # Optional social features
+    from frontend_bridge import dispatch_route
+except Exception:  # pragma: no cover - optional dependency
+    dispatch_route = None  # type: ignore
+
+try:  # Optional DB access for follow/unfollow
+    from db_models import SessionLocal, Harmonizer
+except Exception:  # pragma: no cover - optional dependency
+    SessionLocal = None  # type: ignore
+    Harmonizer = None  # type: ignore
+
+import asyncio
+
+
+def _run_async(coro):
+    """Execute ``coro`` whether or not an event loop is running."""
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+    else:
+        if loop.is_running():
+            return asyncio.run_coroutine_threadsafe(coro, loop).result()
+        return loop.run_until_complete(coro)
+
+
+def _fetch_social(username: str) -> tuple[dict, dict]:
+    """Return follower and following data for ``username`` via routes."""
+    if dispatch_route is None or SessionLocal is None:
+        return {}, {}
+    with SessionLocal() as db:
+        followers = _run_async(
+            dispatch_route("get_followers", {"username": username}, db=db)
+        )
+        following = _run_async(
+            dispatch_route("get_following", {"username": username}, db=db)
+        )
+    return followers or {}, following or {}
+
 inject_modern_styles()
 
 
@@ -19,6 +58,67 @@ def main(main_container=None) -> None:
     container_ctx = safe_container(main_container)
     with container_ctx:
         st.subheader("👤 Profile")
+
+        username = st.session_state.get("active_user", "demo_user")
+        avatar_url = "https://placekitten.com/200/200"
+        bio = "Exploring the frontiers of resonance."
+        interests = ["Music", "Physics", "Art"]
+
+        st.image(avatar_url, width=120)
+        st.markdown(f"### {username}")
+        st.write(bio)
+        st.markdown(f"**Interests:** {', '.join(interests)}")
+
+        followers, following = _fetch_social(username)
+        st.write(f"Followers: {followers.get('count', 0)}")
+        st.write(f"Following: {following.get('count', 0)}")
+
+        cols = st.columns(3)
+        follow_label = "Follow"
+        if followers.get("followers") and username in followers.get("followers", []):
+            follow_label = "Unfollow"
+
+        with cols[0]:
+            if st.button(follow_label, use_container_width=True):
+                if dispatch_route and SessionLocal and Harmonizer:
+                    with SessionLocal() as db:
+                        user_obj = (
+                            db.query(Harmonizer)
+                            .filter(Harmonizer.username == username)
+                            .first()
+                        )
+                        if user_obj:
+                            _run_async(
+                                dispatch_route(
+                                    "follow_user",
+                                    {"username": username},
+                                    db=db,
+                                    current_user=user_obj,
+                                )
+                            )
+                            followers, following = _fetch_social(username)
+                            st.experimental_rerun()
+                else:
+                    st.info("Follow service unavailable")
+
+        with cols[1]:
+            if st.button("Message", use_container_width=True):
+                try:
+                    st.switch_page("pages/messages")
+                except Exception:
+                    st.error("Messages page not available.")
+
+        with cols[2]:
+            if st.button("Video Chat", use_container_width=True):
+                try:
+                    st.switch_page("pages/video_chat")
+                except Exception:
+                    st.error("Video chat page not available.")
+
+        # st.markdown("### Badges")  # Placeholder for future badge display
+        # st.markdown("### Portfolio")  # Placeholder for portfolio section
+
+        st.divider()
         st.info("Manage API credentials for advanced features.")
         render_api_key_ui(key_prefix="profile")
 


### PR DESCRIPTION
## Summary
- expand profile features in transcendental_resonance_frontend/pages/profile.py
  - show avatar, username, bio and interests
  - fetch follower/following counts using frontend_bridge routes
  - add Follow/Unfollow, Message, and Video Chat buttons
  - include commented stubs for future badge and portfolio sections
- keep pages/profile.py as a thin wrapper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'utils.paths')*

------
https://chatgpt.com/codex/tasks/task_e_688aac97915083208d9a7d3a56e16e03