### PR TITLE
Add messages icon and test

### DIFF
--- a/tests/test_messages_page.py
+++ b/tests/test_messages_page.py
@@ -1,0 +1,41 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
+import importlib
+from pathlib import Path
+import sys
+
+import pytest
+pytest.importorskip("streamlit")
+pytestmark = pytest.mark.requires_streamlit
+
+root = Path(__file__).resolve().parents[1]
+if str(root) not in sys.path:
+    sys.path.insert(0, str(root))
+
+if "utils" in sys.modules:
+    pkg = sys.modules["utils"]
+    if hasattr(pkg, "__path__"):
+        pkg.__path__.append(str(root / "utils"))
+else:
+    import importlib
+    importlib.import_module("utils.paths")
+
+from disclaimers import (
+    STRICTLY_SOCIAL_MEDIA,
+    INTELLECTUAL_PROPERTY_ARTISTIC_INSPIRATION,
+    LEGAL_ETHICAL_SAFEGUARDS,
+)
+
+
+def test_messages_page_has_main_and_disclaimers():
+    messages = importlib.import_module(
+        "transcendental_resonance_frontend.pages.messages"
+    )
+    assert callable(getattr(messages, "main", None))
+
+    lines = Path(messages.__file__).read_text().splitlines()
+    assert STRICTLY_SOCIAL_MEDIA in "".join(lines[:3])
+    assert INTELLECTUAL_PROPERTY_ARTISTIC_INSPIRATION in "".join(lines[:3])
+    assert LEGAL_ETHICAL_SAFEGUARDS in "".join(lines[:3])

--- a/ui.py
+++ b/ui.py
@@ -153,7 +153,10 @@ def normalize_choice(choice: str) -> str:
 
 # Icons used in the navigation bar. Must be single-character emojis or
 # valid Bootstrap icon codes prefixed with ``"bi bi-"``.
-NAV_ICONS = ["✅", "📊", "🤖", "🎵", "💬", "👥", "👤", "✉️"]
+# Emoji icons for sidebar navigation in alphabetical page order.
+# Agents, Chat, Messages, Profile, Resonance Music, Social, Validation,
+# Video Chat, Voting
+NAV_ICONS = ["🤖", "💬", "✉️", "👤", "🎵", "👥", "✅", "🎥", "📊"]
 
 
 # Toggle verbose output via ``UI_DEBUG_PRINTS``
@@ -1103,13 +1106,13 @@ def render_validation_ui(
         page_paths = {
             label: f"/pages/{mod}.py" for label, mod in PAGES.items()
         }
-        NAV_ICONS = ["✅", "📊", "🤖", "🎵", "💬", "👥", "👤", "✉️"]
+        NAV_ICONS = ["🤖", "💬", "✉️", "👤", "🎵", "👥", "✅", "🎥", "📊"]
 
         # ...
 
         choice_label = render_sidebar_nav(
             page_paths,
-            icons=["✅", "📊", "🤖", "🎵", "💬", "👥", "👤"],
+            icons=NAV_ICONS,
             session_key="active_page",
         )
         choice = PAGES.get(choice_label, str(choice_label)).lower()


### PR DESCRIPTION
## Summary
- add messages emoji to `NAV_ICONS` list and update usage
- use icons list in `render_sidebar_nav` call
- add regression test for messages page

## Testing
- `pytest tests/test_messages_page.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688aac9a6a9c8320a9c0544a11818e4c