### PR TITLE
Add beta mode toggle via query param

### DIFF
--- a/social_tabs.py
+++ b/social_tabs.py
@@ -94,7 +94,8 @@ def render_social_tab(main_container=None) -> None:
                                     current_user=user_obj,
                                 )
                             )
-                            st.json(result)
+                            if st.session_state.get("beta_mode"):
+                                st.json(result)
                             st.toast("Success!")
                         except Exception as exc:  # pragma: no cover - UI feedback
                             alert(f"Operation failed: {exc}", "error")

--- a/ui.py
+++ b/ui.py
@@ -915,7 +915,8 @@ def run_analysis(validations, *, layout: str = "force"):
         )
 
     st.subheader("Analysis Result")
-    st.json(result)
+    if st.session_state.get("beta_mode"):
+        st.json(result)
 
     graph_data = build_validation_graph(validations)
     edges = graph_data.get("edges", [])
@@ -1205,7 +1206,8 @@ def render_developer_tools() -> None:
                                             db=db,
                                         )
                                     )
-                                    st.json(result)
+                                    if st.session_state.get("beta_mode"):
+                                        st.json(result)
                                     st.toast("Success!")
                                 except Exception as exc:
                                     st.error(f"Audit failed: {exc}")
@@ -1217,7 +1219,8 @@ def render_developer_tools() -> None:
                             with st.spinner("Working on it..."):
                                 try:
                                     result = run_full_audit(hid, db)
-                                    st.json(result)
+                                    if st.session_state.get("beta_mode"):
+                                        st.json(result)
                                     st.toast("Success!")
                                 except Exception as exc:
                                     st.error(f"Audit failed: {exc}")
@@ -1302,11 +1305,20 @@ def render_developer_tools() -> None:
                                 backend_fn = get_backend("dummy")
                                 a = agent_cls(llm_backend=backend_fn)
                                 results.append(a.process_event(evt))
-                        st.json(results)
+                        if st.session_state.get("beta_mode"):
+                            st.json(results)
                     except Exception as exc:
                         st.error(f"Flow execution failed: {exc}")
                 else:
                     st.toast("Agent registry unavailable", icon="⚠️")
+
+
+def parse_beta_mode(params: dict) -> bool:
+    """Update session state with beta flag from query params."""
+    val = params.get("beta")
+    enabled = val == "1" or (isinstance(val, list) and "1" in val)
+    st.session_state["beta_mode"] = enabled
+    return enabled
 
 
 def main() -> None:
@@ -1330,6 +1342,8 @@ def main() -> None:
     except AttributeError:
         # Fallback for older Streamlit versions
         params = st.experimental_get_query_params()
+
+    parse_beta_mode(params)
 
     value = params.get(HEALTH_CHECK_PARAM)
 
@@ -1615,7 +1629,8 @@ def main() -> None:
             # Show agent output
             if st.session_state.get("agent_output") is not None:
                 st.subheader("Agent Output")
-                st.json(st.session_state.get("agent_output"))
+                if st.session_state.get("beta_mode"):
+                    st.json(st.session_state.get("agent_output"))
 
             stats = {
                 "runs": st.session_state.get("run_count", 0),

--- a/voting_ui.py
+++ b/voting_ui.py
@@ -363,7 +363,8 @@ def render_agent_ops_tab(main_container=None) -> None:
             with st.spinner("Working on it..."):
                 try:
                     res = _run_async(dispatch_route("launch_agents", payload))
-                    st.json(res)
+                    if st.session_state.get("beta_mode"):
+                        st.json(res)
                     st.toast("Success!")
                 except Exception as exc:
                     alert(f"Launch failed: {exc}", "error")
@@ -372,7 +373,8 @@ def render_agent_ops_tab(main_container=None) -> None:
             with st.spinner("Working on it..."):
                 try:
                     res = _run_async(dispatch_route("step_agents", {}))
-                    st.json(res)
+                    if st.session_state.get("beta_mode"):
+                        st.json(res)
                     st.toast("Success!")
                 except Exception as exc:
                     alert(f"Step failed: {exc}", "error")


### PR DESCRIPTION
## Summary
- detect `beta=1` query param in ui.py and store in session state
- wrap debug `st.json` outputs behind a `beta_mode` check

## Testing
- `PYTHONPATH=. pytest tests/test_ui_pages.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688aaea1bbcc8320b23204aca551ec84