### PR TITLE
Display backend status on user pages

### DIFF
--- a/transcendental_resonance_frontend/pages/chat.py
+++ b/transcendental_resonance_frontend/pages/chat.py
@@ -6,6 +6,7 @@
 import streamlit as st
 from modern_ui import inject_modern_styles
 from streamlit_helpers import safe_container
+from status_indicator import render_status_icon
 
 inject_modern_styles()
 
@@ -71,7 +72,11 @@ def main(main_container=None) -> None:
 
     container_ctx = safe_container(main_container)
     with container_ctx:
-        st.subheader("💬 Chat")
+        header_col, status_col = st.columns([8, 1])
+        with header_col:
+            st.subheader("💬 Chat")
+        with status_col:
+            render_status_icon()
         render_chat_interface()
         st.divider()
         render_video_call_controls()

--- a/transcendental_resonance_frontend/pages/messages_center.py
+++ b/transcendental_resonance_frontend/pages/messages_center.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import streamlit as st
 from modern_ui import inject_modern_styles
 from streamlit_helpers import safe_container
+from status_indicator import render_status_icon
 
 inject_modern_styles()
 
@@ -46,7 +47,11 @@ def main(main_container=None) -> None:
 
     container_ctx = safe_container(main_container)
     with container_ctx:
-        st.subheader("💬 Messages")
+        header_col, status_col = st.columns([8, 1])
+        with header_col:
+            st.subheader("💬 Messages")
+        with status_col:
+            render_status_icon()
         st.session_state.setdefault("_conversations", DUMMY_CONVERSATIONS.copy())
         convos = list(st.session_state["_conversations"].keys())
         selected = st.radio("Conversations", convos, key="selected_convo")

--- a/transcendental_resonance_frontend/pages/profile.py
+++ b/transcendental_resonance_frontend/pages/profile.py
@@ -8,6 +8,7 @@ from modern_ui import inject_modern_styles
 from streamlit_helpers import safe_container
 from api_key_input import render_api_key_ui
 from social_tabs import _load_profile
+from status_indicator import render_status_icon
 
 try:
     from social_tabs import _load_profile
@@ -53,7 +54,11 @@ def main(main_container=None) -> None:
         main_container = st
     container_ctx = safe_container(main_container)
     with container_ctx:
-        st.subheader("👤 Profile")
+        header_col, status_col = st.columns([8, 1])
+        with header_col:
+            st.subheader("👤 Profile")
+        with status_col:
+            render_status_icon()
         current = st.session_state.get("active_user", "guest")
         current = st.text_input("Username", value=current, key="profile_user")
         st.session_state["active_user"] = current


### PR DESCRIPTION
## Summary
- show connection indicator on Chat, Messages Center and Profile pages

## Testing
- `pytest -q` *(fails: ImportError: failed to find libmagic for nicegui)*

------
https://chatgpt.com/codex/tasks/task_e_688aae9aa0108320ba42fdee181f1159