### PR TITLE
Streamline pages dir handling

### DIFF
--- a/modern_ui_components.py
+++ b/modern_ui_components.py
@@ -233,15 +233,17 @@ def render_modern_sidebar(
     orientation_cls = "horizontal" if horizontal else "vertical"
 
     collapsed_key = f"{session_key}_collapsed"
-    if collapsed_key not in st.session_state:
+    if collapsed_key in st.session_state:
+        collapsed = st.session_state[collapsed_key]
+    else:
         try:
             width = st_javascript("window.innerWidth")
-            st.session_state[collapsed_key] = bool(width) and int(width) <= 1024
+            collapsed = bool(width) and int(width) <= 1024
         except Exception:
-            st.session_state[collapsed_key] = False
+            collapsed = False
 
-    if st.button("☰", key=f"{collapsed_key}_btn"):
-        st.session_state[collapsed_key] = not st.session_state[collapsed_key]
+    if hasattr(st, "button") and st.button("☰", key=f"{collapsed_key}_btn"):
+        st.session_state[collapsed_key] = not collapsed
 
     container_ctx = safe_container(container)
     with container_ctx:

--- a/transcendental_resonance_frontend/src/quantum_futures.py
+++ b/transcendental_resonance_frontend/src/quantum_futures.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import random
 from typing import Any, Dict, List
 
-from external_services.llm_client import LLMClient
+from external_services.llm_client import LLMClient, get_speculative_futures
 from external_services.vision_client import VisionClient
 
 # Satirical disclaimer appended to all speculative output
@@ -54,8 +54,11 @@ async def generate_speculative_payload(description: str) -> List[Dict[str, str]]
     results: List[Dict[str, str]] = []
     vision = VisionClient()
     for text in texts:
-        # Mocking or replacing video preview call if removed
-        video_url = f"https://example.com/fake_video_for_{text[:10]}"
+        offline = llm.offline or vision.offline
+        if offline:
+            video_url = "https://example.com/placeholder"
+        else:
+            video_url = f"https://example.com/fake_video_for_{text[:10]}"
         vision_notes = (await vision.analyze_timeline(video_url)).get("events", [])
         results.append(
             {

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,2 @@
+from pkgutil import extend_path
+__path__ = extend_path(__path__, __name__)


### PR DESCRIPTION
## Summary
- clean up ui page registry imports
- handle test environment in `_render_fallback`
- guard sidebar toggle button call
- allow utils namespace to span multiple directories
- update speculative payload generator for offline mode

## Testing
- `pytest tests/test_modern_ui_components.py -q`
- `pytest tests/test_ui_pages.py::test_unknown_page_triggers_fallback -q`
- `pytest tests/test_ui_pages.py::test_main_defaults_to_validation -q`
- `pytest tests/test_ui_pages.py::test_fallback_rendered_once -q`
- `pytest transcendental_resonance_frontend/tests/test_offline_mode.py::test_generate_speculative_payload_offline -q`
- `pytest transcendental_resonance_frontend/tests/test_quantum_futures.py::test_generate_speculative_futures_length -q`
- `pytest transcendental_resonance_frontend/tests/test_validation_page_render.py::test_validation_page_renders -q`
- `OFFLINE_MODE=1 pytest -q` *(fails: 1 failed, 74 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688aa89dac18832084a5b8cffd24293f