### PR TITLE
Fix nicegui optional dependency

### DIFF
--- a/transcendental_resonance_frontend/src/utils/api.py
+++ b/transcendental_resonance_frontend/src/utils/api.py
@@ -10,7 +10,17 @@ import asyncio
 
 import httpx
 import websockets
-from nicegui import ui
+
+try:
+    from nicegui import ui  # type: ignore
+except ImportError:  # pragma: no cover - optional dependency
+    class _FallbackUI:
+        """Minimal fallback if ``nicegui`` isn't installed."""
+
+        def notify(self, *args: Any, **kwargs: Any) -> None:
+            """No-op notification method."""
+
+    ui = _FallbackUI()
 
 # Honor offline mode for development/testing
 OFFLINE_MODE = os.getenv("OFFLINE_MODE", "0") == "1"


### PR DESCRIPTION
## Summary
- prevent ImportError if `nicegui` isn't installed
- provide minimal fallback `ui.notify` to avoid runtime errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688abb4a84d48320a0e172740fc26651