### PR TITLE
Fix offline mode fallback

### DIFF
--- a/transcendental_resonance_frontend/tests/test_validation_page_render.py
+++ b/transcendental_resonance_frontend/tests/test_validation_page_render.py
@@ -30,7 +30,9 @@ def test_validation_page_renders(monkeypatch):
 
     dummy_ui.render_validation_ui = render_validation_ui
     sys.modules["ui"] = dummy_ui
-
+    import importlib
+    import transcendental_resonance_frontend.pages.validation as validation
+    importlib.reload(validation)
     at = AppTest.from_function(run_validation_page)
     at.run()
     assert len(at.exception) == 0

--- a/ui.py
+++ b/ui.py
@@ -523,10 +523,7 @@ def _render_fallback(choice: str) -> None:
             fallback_fn()
         return
 
-    try:
-        from transcendental_resonance_frontend.src.utils.api import OFFLINE_MODE
-    except Exception:
-        OFFLINE_MODE = False
+    OFFLINE_MODE = os.getenv("OFFLINE_MODE", "0") == "1"
 
     # Candidate paths to try loading from
     page_candidates = [


### PR DESCRIPTION
## Summary
- remove OFFLINE_MODE import in `_render_fallback`
- reload page module in validation page render test so `ui` patch takes effect

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688abb4bd7088320be4c2f42009708e5