### PR TITLE
Add nicegui to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -50,3 +50,4 @@ streamlit-aggrid>=1.1.7
 streamlit-autorefresh
 gtts
 streamlit-javascript
+nicegui


### PR DESCRIPTION
## Summary
- add `nicegui` alongside other Streamlit UI packages

## Testing
- `pip install nicegui`
- `pip install streamlit sqlalchemy`
- `pip install networkx streamlit-javascript`
- `pytest -q` *(fails: 13 failed, 64 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688abb442558832085e4d765a028602d