### PR TITLE
Gracefully handle missing NiceGUI

### DIFF
--- a/transcendental_resonance_frontend/__main__.py
+++ b/transcendental_resonance_frontend/__main__.py
@@ -1,10 +1,16 @@
 """Entry point for ``python -m transcendental_resonance_frontend``."""
 
-from nicegui import ui
+try:
+    from nicegui import ui  # type: ignore
+except Exception:  # pragma: no cover - nicegui optional
+    ui = None
 
 
 def run() -> None:
     """Launch the NiceGUI interface."""
+    if ui is None:
+        print("NiceGUI is required to run the frontend. Please install it via 'pip install nicegui'.")
+        return
     ui.label("Loading UI...")
     from .src.main import run_app
     run_app()

--- a/transcendental_resonance_frontend/src/utils/api.py
+++ b/transcendental_resonance_frontend/src/utils/api.py
@@ -10,7 +10,16 @@ import asyncio
 
 import httpx
 import websockets
-from nicegui import ui
+
+try:
+    from nicegui import ui  # type: ignore
+except Exception:  # pragma: no cover - nicegui optional
+    class _UIStub:
+        def notify(self, *args, **kwargs) -> None:
+            """Fallback notify that does nothing."""
+            return None
+
+    ui = _UIStub()  # type: ignore
 
 # Honor offline mode for development/testing
 OFFLINE_MODE = os.getenv("OFFLINE_MODE", "0") == "1"

--- a/transcendental_resonance_frontend/src/utils/loading_overlay.py
+++ b/transcendental_resonance_frontend/src/utils/loading_overlay.py
@@ -2,7 +2,39 @@
 
 from __future__ import annotations
 
-from nicegui import ui
+try:
+    from nicegui import ui  # type: ignore
+except Exception:  # pragma: no cover - nicegui optional
+    class _Dummy:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def props(self, *_args, **_kwargs):
+            return self
+
+        def open(self):  # type: ignore
+            pass
+
+        def close(self):  # type: ignore
+            pass
+
+    class _UIStub:
+        def dialog(self, *args, **kwargs):
+            return _Dummy()
+
+        def card(self, *args, **kwargs):
+            return _Dummy()
+
+        def spinner(self, *args, **kwargs):
+            return _Dummy()
+
+    ui = _UIStub()  # type: ignore
 
 from .api import on_request_start, on_request_end
 
@@ -12,6 +44,7 @@ class LoadingOverlay:
 
     def __init__(self) -> None:
         self._count = 0
+        self._visible = False
         self._dialog = ui.dialog().props("persistent")
         with self._dialog:
             with ui.card():
@@ -22,13 +55,15 @@ class LoadingOverlay:
 
     def _on_start(self) -> None:
         self._count += 1
-        if not self._dialog.open:
+        if not self._visible:
             self._dialog.open()
+            self._visible = True
 
     def _on_end(self) -> None:
         self._count = max(0, self._count - 1)
-        if self._count == 0 and self._dialog.open:
+        if self._count == 0 and self._visible:
             self._dialog.close()
+            self._visible = False
 
 
 __all__ = ["LoadingOverlay"]

--- a/transcendental_resonance_frontend/src/utils/styles.py
+++ b/transcendental_resonance_frontend/src/utils/styles.py
@@ -2,7 +2,17 @@
 
 from typing import Dict, Optional
 
-from nicegui import ui
+try:
+    from nicegui import ui  # type: ignore
+except Exception:  # pragma: no cover - nicegui optional
+    class _UIStub:
+        def run_javascript(self, *args, **kwargs):
+            return None
+
+        def add_head_html(self, *args, **kwargs):
+            return None
+
+    ui = _UIStub()  # type: ignore
 
 # Theme palettes. The default "dark" theme matches the original neon aesthetic.
 THEMES: Dict[str, Dict[str, str]] = {


### PR DESCRIPTION
## Summary
- add fallback stubs when NiceGUI isn't installed
- avoid crashes by checking for NiceGUI in the entry point
- manage dialog visibility without relying on NiceGUI internals

## Testing
- `pytest transcendental_resonance_frontend/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_688abb4352f48320ab4711755921835d