### PR TITLE
Fix profile render flow

### DIFF
--- a/transcendental_resonance_frontend/pages/profile.py
+++ b/transcendental_resonance_frontend/pages/profile.py
@@ -26,21 +26,20 @@ inject_modern_styles()
 
 
 def _render_profile(username: str) -> None:
+    data = {**DEFAULT_USER, "username": username}
     if _load_profile is None:
         st.error("Profile services unavailable")
-        return
-    try:
-        user, followers, following = _load_profile(username)
-    except Exception as exc:
-        st.error(f"Profile fetch failed: {exc}")
-        return
-    st.image("https://placehold.co/120x120", width=120)
-    st.markdown(f"### {user.get('username', username)}")
-    st.write(user.get("bio", ""))
-    st.markdown(
-        f"**Followers:** {len(followers.get('followers', []))}  \
-        **Following:** {len(following.get('following', []))}"
-    )
+    else:
+        try:
+            user, followers, following = _load_profile(username)
+            data = {
+                **user,
+                "followers": len(followers.get("followers", [])),
+                "following": len(following.get("following", [])),
+            }
+        except Exception as exc:  # pragma: no cover - runtime fetch may fail
+            st.warning(f"Profile fetch failed: {exc}, using placeholder")
+    render_profile(data)
     if dispatch_route is not None and st.button("Follow/Unfollow", key="follow"):
         with st.spinner("Updating..."):
             try:

--- a/transcendental_resonance_frontend/pages/validation.py
+++ b/transcendental_resonance_frontend/pages/validation.py
@@ -6,7 +6,9 @@
 import streamlit as st
 from modern_ui import inject_modern_styles
 from streamlit_helpers import safe_container
-from ui import render_validation_ui
+
+render_validation_ui = None
+
 
 inject_modern_styles()
 
@@ -22,6 +24,11 @@ def main(main_container=None) -> None:
     """Render the validation UI inside a container safely."""
     if main_container is None:
         main_container = st
+
+    global render_validation_ui
+    if render_validation_ui is None:
+        from ui import render_validation_ui as _render
+        render_validation_ui = _render
 
     container_ctx = safe_container(main_container)
 


### PR DESCRIPTION
## Summary
- simplify profile page rendering
- load validation UI lazily to enable monkeypatching in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688abb1d673483209b3e31f0b07bf447