### PR TITLE
Add Streamlit fallbacks to NiceGUI pages

### DIFF
--- a/transcendental_resonance_frontend/src/pages/ai_assist_page.py
+++ b/transcendental_resonance_frontend/src/pages/ai_assist_page.py
@@ -3,7 +3,11 @@
 # Legal & Ethical Safeguards
 """AI assistance for VibeNodes."""
 
-from nicegui import ui
+try:
+    from nicegui import ui
+except Exception:  # pragma: no cover - fallback to Streamlit
+    ui = None  # type: ignore
+    import streamlit as st
 
 from utils.api import api_call, TOKEN
 from utils.styles import get_theme
@@ -40,3 +44,8 @@ async def ai_assist_page(vibenode_id: int):
         ui.button('Get AI Help', on_click=get_ai_response).classes('w-full').style(
             f'background: {THEME["primary"]}; color: {THEME["text"]};'
         )
+
+if ui is None:
+    def ai_assist_page(*_a, **_kw):
+        """Fallback when NiceGUI is unavailable."""
+        st.info('AI assist requires NiceGUI.')

--- a/transcendental_resonance_frontend/src/pages/debug_panel_page.py
+++ b/transcendental_resonance_frontend/src/pages/debug_panel_page.py
@@ -6,7 +6,11 @@
 from __future__ import annotations
 
 import json
-from nicegui import ui
+try:
+    from nicegui import ui
+except Exception:  # pragma: no cover - fallback to Streamlit
+    ui = None  # type: ignore
+    import streamlit as st
 
 from utils.api import TOKEN
 from utils.styles import get_theme
@@ -68,4 +72,9 @@ async def debug_panel_page() -> None:
                 ui.button("Invoke", on_click=send).style(
                     f"background: {theme['primary']}; color: {theme['text']};"
                 )
+
+if ui is None:
+    def debug_panel_page(*_a, **_kw):
+        """Fallback debug panel when NiceGUI is unavailable."""
+        st.warning('Debug panel requires NiceGUI.')
 

--- a/transcendental_resonance_frontend/src/pages/events_page.py
+++ b/transcendental_resonance_frontend/src/pages/events_page.py
@@ -5,7 +5,11 @@
 # Legal & Ethical Safeguards
 """
 
-from nicegui import ui
+try:
+    from nicegui import ui
+except Exception:  # pragma: no cover - fallback to Streamlit
+    ui = None  # type: ignore
+    import streamlit as st
 
 from utils.api import api_call, TOKEN, BACKEND_URL
 import httpx
@@ -121,3 +125,8 @@ async def events_page():
                         )
 
         await refresh_events()
+
+if ui is None:
+    def events_page(*_a, **_kw):
+        """Fallback events page when NiceGUI is unavailable."""
+        st.info('Events page requires NiceGUI.')

--- a/transcendental_resonance_frontend/src/pages/explore_page.py
+++ b/transcendental_resonance_frontend/src/pages/explore_page.py
@@ -2,7 +2,11 @@
 # Intellectual Property & Artistic Inspiration
 # Legal & Ethical Safeguards
 
-from nicegui import ui
+try:
+    from nicegui import ui
+except Exception:  # pragma: no cover - fallback to Streamlit
+    ui = None  # type: ignore
+    import streamlit as st
 from utils.api import TOKEN, api_call
 from utils.layout import page_container, navigation_bar
 from utils.features import skeleton_loader
@@ -80,3 +84,9 @@ async def explore_page() -> None:
                 loading["value"] = False
 
         ui.timer(1.0, lambda: ui.run_async(check_scroll()))
+
+if ui is None:
+    def explore_page(*_a, **_kw):
+        """Fallback explore page when NiceGUI is unavailable."""
+        st.info('Explore page requires NiceGUI.')
+

--- a/transcendental_resonance_frontend/src/pages/feed_page.py
+++ b/transcendental_resonance_frontend/src/pages/feed_page.py
@@ -5,7 +5,11 @@
 # Legal & Ethical Safeguards
 """
 
-from nicegui import ui
+try:
+    from nicegui import ui
+except Exception:  # pragma: no cover - fallback to Streamlit
+    ui = None  # type: ignore
+    import streamlit as st
 
 from utils.api import TOKEN, api_call
 from utils.layout import page_container, navigation_bar
@@ -124,3 +128,9 @@ async def feed_page() -> None:
         ui.button(icon='add', on_click=post_dialog.open).props(
             'fab fixed bottom-right'
         )
+
+if ui is None:
+    def feed_page(*_a, **_kw):
+        """Fallback feed page when NiceGUI is unavailable."""
+        st.info('Feed requires NiceGUI.')
+

--- a/transcendental_resonance_frontend/src/pages/forks_page.py
+++ b/transcendental_resonance_frontend/src/pages/forks_page.py
@@ -3,7 +3,11 @@
 # Legal & Ethical Safeguards
 """Page to list universe forks and submit votes."""
 
-from nicegui import ui
+try:
+    from nicegui import ui
+except Exception:  # pragma: no cover - fallback to Streamlit
+    ui = None  # type: ignore
+    import streamlit as st
 
 from utils.api import api_call, TOKEN
 from utils.styles import get_theme
@@ -54,4 +58,10 @@ async def forks_page() -> None:
                         ui.label(f"Consensus: {f.get('consensus')}").classes('text-sm')
 
         await refresh_forks()
+
+if ui is None:
+    def forks_page(*_a, **_kw):
+        """Fallback forks page when NiceGUI is unavailable."""
+        st.info('Forks page requires NiceGUI.')
+
 

--- a/transcendental_resonance_frontend/src/pages/groups_page.py
+++ b/transcendental_resonance_frontend/src/pages/groups_page.py
@@ -3,7 +3,11 @@
 # Legal & Ethical Safeguards
 """Group management page."""
 
-from nicegui import ui
+try:
+    from nicegui import ui
+except Exception:  # pragma: no cover - fallback to Streamlit
+    ui = None  # type: ignore
+    import streamlit as st
 
 from utils.api import api_call, TOKEN, get_group_recommendations
 from utils.styles import get_theme
@@ -96,3 +100,9 @@ async def groups_page():
                             ui.label(desc).classes('text-sm')
 
         await load_suggestions()
+
+if ui is None:
+    def groups_page(*_a, **_kw):
+        """Fallback groups page when NiceGUI is unavailable."""
+        st.info('Groups page requires NiceGUI.')
+

--- a/transcendental_resonance_frontend/src/pages/login_page.py
+++ b/transcendental_resonance_frontend/src/pages/login_page.py
@@ -3,7 +3,11 @@
 # Legal & Ethical Safeguards
 """Login and registration pages for Transcendental Resonance."""
 
-from nicegui import ui
+try:
+    from nicegui import ui
+except Exception:  # pragma: no cover - fallback to Streamlit
+    ui = None  # type: ignore
+    import streamlit as st
 
 from utils.api import api_call, set_token
 from utils.styles import get_theme
@@ -82,3 +86,13 @@ async def register_page():
         ui.label('Back to Login').classes('text-center cursor-pointer').on_click(
             lambda: ui.open(login_page)
         )
+
+if ui is None:
+    def login_page():
+        """Fallback login page when NiceGUI is unavailable."""
+        st.title('Transcendental Resonance')
+        st.warning('NiceGUI not installed; limited functionality.')
+
+    def register_page():
+        """Fallback registration page when NiceGUI is unavailable."""
+        st.info('Registration not available without NiceGUI.')

--- a/transcendental_resonance_frontend/src/pages/messages_page.py
+++ b/transcendental_resonance_frontend/src/pages/messages_page.py
@@ -4,7 +4,11 @@
 """Messaging system page."""
 
 from components.emoji_toolbar import emoji_toolbar
-from nicegui import ui
+try:
+    from nicegui import ui
+except Exception:  # pragma: no cover - fallback to Streamlit
+    ui = None  # type: ignore
+    import streamlit as st
 
 from utils.api import TOKEN, api_call, listen_ws
 from utils.layout import navigation_bar, page_container
@@ -135,4 +139,10 @@ async def messages_page():
                 ui.notify("Realtime updates unavailable", color="warning")
 
         ui.run_async(start_ws())
+
+if ui is None:
+    def messages_page(*_a, **_kw):
+        """Fallback messages page when NiceGUI is unavailable."""
+        st.info('Messages page requires NiceGUI.')
+
 

--- a/transcendental_resonance_frontend/src/pages/moderation_dashboard_page.py
+++ b/transcendental_resonance_frontend/src/pages/moderation_dashboard_page.py
@@ -5,7 +5,11 @@
 
 from __future__ import annotations
 
-from nicegui import ui
+try:
+    from nicegui import ui
+except Exception:  # pragma: no cover - fallback to Streamlit
+    ui = None  # type: ignore
+    import streamlit as st
 
 from utils.api import TOKEN, api_call, listen_ws
 from utils.layout import page_container, navigation_bar
@@ -70,3 +74,9 @@ async def moderation_dashboard_page() -> None:
 
         ws_task = listen_ws(handle_event)
         ui.context.client.on_disconnect(lambda: ws_task.cancel())
+
+if ui is None:
+    def moderation_dashboard_page(*_a, **_kw):
+        """Fallback moderation dashboard when NiceGUI is unavailable."""
+        st.info('Moderation dashboard requires NiceGUI.')
+

--- a/transcendental_resonance_frontend/src/pages/moderation_page.py
+++ b/transcendental_resonance_frontend/src/pages/moderation_page.py
@@ -1,6 +1,10 @@
 """Content moderation panel for reviewing flagged posts."""
 
-from nicegui import ui
+try:
+    from nicegui import ui
+except Exception:  # pragma: no cover - fallback to Streamlit
+    ui = None  # type: ignore
+    import streamlit as st
 
 from utils.api import TOKEN, api_call, listen_ws
 from utils.layout import page_container, navigation_bar
@@ -51,3 +55,9 @@ async def moderation_page() -> None:
 
         ws_task = listen_ws(handle_event)
         ui.context.client.on_disconnect(lambda: ws_task.cancel())
+
+if ui is None:
+    def moderation_page(*_a, **_kw):
+        """Fallback moderation page when NiceGUI is unavailable."""
+        st.info('Moderation page requires NiceGUI.')
+

--- a/transcendental_resonance_frontend/src/pages/music_page.py
+++ b/transcendental_resonance_frontend/src/pages/music_page.py
@@ -3,7 +3,11 @@
 # Legal & Ethical Safeguards
 """Interactive music generation page."""
 
-from nicegui import ui
+try:
+    from nicegui import ui
+except Exception:  # pragma: no cover - fallback to Streamlit
+    ui = None  # type: ignore
+    import streamlit as st
 
 from utils.api import api_call, TOKEN
 from utils.styles import get_theme
@@ -54,3 +58,9 @@ async def music_page():
             f'background: {THEME["primary"]}; color: {THEME["text"]};'
         )
         download_link
+
+if ui is None:
+    def music_page(*_a, **_kw):
+        """Fallback music page when NiceGUI is unavailable."""
+        st.info('Music page requires NiceGUI.')
+

--- a/transcendental_resonance_frontend/src/pages/network_analysis_page.py
+++ b/transcendental_resonance_frontend/src/pages/network_analysis_page.py
@@ -5,7 +5,11 @@
 
 import json
 
-from nicegui import ui
+try:
+    from nicegui import ui
+except Exception:  # pragma: no cover - fallback to Streamlit
+    ui = None  # type: ignore
+    import streamlit as st
 from utils.api import TOKEN, api_call
 from utils.layout import page_container, navigation_bar
 from utils.styles import get_theme
@@ -105,3 +109,9 @@ async def network_page():
 
         await refresh_network()
         ui.timer(10, lambda: ui.run_async(refresh_network()))
+
+if ui is None:
+    def network_page(*_a, **_kw):
+        """Fallback network page when NiceGUI is unavailable."""
+        st.info('Network analysis page requires NiceGUI.')
+

--- a/transcendental_resonance_frontend/src/pages/notifications_page.py
+++ b/transcendental_resonance_frontend/src/pages/notifications_page.py
@@ -3,7 +3,11 @@
 # Legal & Ethical Safeguards
 """User notifications page."""
 
-from nicegui import ui
+try:
+    from nicegui import ui
+except Exception:  # pragma: no cover - fallback to Streamlit
+    ui = None  # type: ignore
+    import streamlit as st
 from utils.api import TOKEN, api_call, listen_ws
 from utils.layout import page_container, navigation_bar
 from utils.styles import get_theme
@@ -58,3 +62,9 @@ async def notifications_page():
 
         ws_task = listen_ws(handle_event)
         ui.context.client.on_disconnect(lambda: ws_task.cancel())
+
+if ui is None:
+    def notifications_page(*_a, **_kw):
+        """Fallback notifications page when NiceGUI is unavailable."""
+        st.info('Notifications page requires NiceGUI.')
+

--- a/transcendental_resonance_frontend/src/pages/profile_page.py
+++ b/transcendental_resonance_frontend/src/pages/profile_page.py
@@ -4,7 +4,11 @@
 # Intellectual Property & Artistic Inspiration
 # Legal & Ethical Safeguards
 
-from nicegui import ui
+try:
+    from nicegui import ui
+except Exception:  # pragma: no cover - fallback to Streamlit
+    ui = None  # type: ignore
+    import streamlit as st
 from utils.api import (
     TOKEN,
     api_call,
@@ -205,3 +209,9 @@ async def profile_page(username: str | None = None):
                             ui.label(bio).classes('text-sm')
 
         await load_suggestions()
+
+if ui is None:
+    def profile_page(*_a, **_kw):
+        """Fallback profile page when NiceGUI is unavailable."""
+        st.info('Profile page requires NiceGUI.')
+

--- a/transcendental_resonance_frontend/src/pages/proposals_page.py
+++ b/transcendental_resonance_frontend/src/pages/proposals_page.py
@@ -3,7 +3,11 @@
 # Legal & Ethical Safeguards
 """Governance proposals page."""
 
-from nicegui import ui
+try:
+    from nicegui import ui
+except Exception:  # pragma: no cover - fallback to Streamlit
+    ui = None  # type: ignore
+    import streamlit as st
 
 from utils.api import api_call, TOKEN
 from utils.styles import get_theme
@@ -75,3 +79,9 @@ async def proposals_page():
                             ui.button('No', on_click=vote_no).style('background: red; color: white;')
 
         await refresh_proposals()
+
+if ui is None:
+    def proposals_page(*_a, **_kw):
+        """Fallback proposals page when NiceGUI is unavailable."""
+        st.info('Proposals page requires NiceGUI.')
+

--- a/transcendental_resonance_frontend/src/pages/recommendations_page.py
+++ b/transcendental_resonance_frontend/src/pages/recommendations_page.py
@@ -3,7 +3,11 @@
 # Legal & Ethical Safeguards
 """Recommendations discovery page."""
 
-from nicegui import ui
+try:
+    from nicegui import ui
+except Exception:  # pragma: no cover - fallback to Streamlit
+    ui = None  # type: ignore
+    import streamlit as st
 
 from utils.api import api_call, TOKEN
 from utils.styles import get_theme
@@ -69,3 +73,9 @@ async def recommendations_page():
                             )
 
         await refresh_recs()
+
+if ui is None:
+    def recommendations_page(*_a, **_kw):
+        """Fallback recommendations page when NiceGUI is unavailable."""
+        st.info('Recommendations page requires NiceGUI.')
+

--- a/transcendental_resonance_frontend/src/pages/status_page.py
+++ b/transcendental_resonance_frontend/src/pages/status_page.py
@@ -3,7 +3,11 @@
 # Legal & Ethical Safeguards
 """System status metrics page."""
 
-from nicegui import ui
+try:
+    from nicegui import ui
+except Exception:  # pragma: no cover - fallback to Streamlit
+    ui = None  # type: ignore
+    import streamlit as st
 from utils.api import TOKEN, api_call
 from utils.layout import page_container, navigation_bar
 from utils.styles import get_theme
@@ -44,3 +48,9 @@ async def status_page():
 
         await refresh_status()
         ui.timer(5, lambda: ui.run_async(refresh_status()))
+
+if ui is None:
+    def status_page(*_a, **_kw):
+        """Fallback status page when NiceGUI is unavailable."""
+        st.info('Status page requires NiceGUI.')
+

--- a/transcendental_resonance_frontend/src/pages/system_insights_page.py
+++ b/transcendental_resonance_frontend/src/pages/system_insights_page.py
@@ -3,7 +3,11 @@
 # Legal & Ethical Safeguards
 """Detailed system insights metrics page."""
 
-from nicegui import ui
+try:
+    from nicegui import ui
+except Exception:  # pragma: no cover - fallback to Streamlit
+    ui = None  # type: ignore
+    import streamlit as st
 from utils.api import TOKEN, api_call
 from utils.layout import page_container, navigation_bar
 from utils.styles import get_theme
@@ -45,3 +49,9 @@ async def system_insights_page():
 
         await refresh_metrics()
         ui.timer(10, lambda: ui.run_async(refresh_metrics()))
+
+if ui is None:
+    def system_insights_page(*_a, **_kw):
+        """Fallback insights page when NiceGUI is unavailable."""
+        st.info('System insights page requires NiceGUI.')
+

--- a/transcendental_resonance_frontend/src/pages/upload_page.py
+++ b/transcendental_resonance_frontend/src/pages/upload_page.py
@@ -3,7 +3,11 @@
 # Legal & Ethical Safeguards
 """Media upload page."""
 
-from nicegui import ui
+try:
+    from nicegui import ui
+except Exception:  # pragma: no cover - fallback to Streamlit
+    ui = None  # type: ignore
+    import streamlit as st
 import asyncio
 import contextlib
 
@@ -76,3 +80,9 @@ async def upload_page():
         ui.upload(on_upload=lambda e: ui.run_async(handle_avatar_upload(e))) \
             .props('label=Choose avatar image') \
             .classes('w-full mb-4')
+
+if ui is None:
+    def upload_page(*_a, **_kw):
+        """Fallback upload page when NiceGUI is unavailable."""
+        st.info('Upload page requires NiceGUI.')
+

--- a/transcendental_resonance_frontend/src/pages/validator_graph_page.py
+++ b/transcendental_resonance_frontend/src/pages/validator_graph_page.py
@@ -5,7 +5,11 @@
 
 import json
 
-from nicegui import ui
+try:
+    from nicegui import ui
+except Exception:  # pragma: no cover - fallback to Streamlit
+    ui = None  # type: ignore
+    import streamlit as st
 from utils.api import TOKEN, api_call
 from utils.layout import page_container, navigation_bar
 from utils.styles import get_theme
@@ -130,3 +134,9 @@ async def validator_graph_page():
         )
         filter_input.on("change", lambda _: ui.run_async(refresh_graph()))
         await refresh_graph()
+
+if ui is None:
+    def validator_graph_page(*_a, **_kw):
+        """Fallback validator graph page when NiceGUI is unavailable."""
+        st.info('Validator graph page requires NiceGUI.')
+

--- a/transcendental_resonance_frontend/src/pages/vibenodes_page.py
+++ b/transcendental_resonance_frontend/src/pages/vibenodes_page.py
@@ -3,14 +3,17 @@
 # Legal & Ethical Safeguards
 """VibeNodes creation and listing."""
 
-from nicegui import ui
+try:
+    from nicegui import ui
+except Exception:  # pragma: no cover - fallback to Streamlit
+    ui = None  # type: ignore
+    import streamlit as st
 
 import asyncio
 import contextlib
 
 from components.emoji_toolbar import emoji_toolbar
 from components.media_renderer import render_media_block
-from nicegui import ui
 
 from utils.api import TOKEN, api_call, listen_ws
 from utils.features import skeleton_loader
@@ -335,4 +338,10 @@ async def vibenodes_page():
                 ui.notify("Realtime updates unavailable", color="warning")
 
         ui.run_async(start_ws())
+
+if ui is None:
+    def vibenodes_page(*_a, **_kw):
+        """Fallback vibenodes page when NiceGUI is unavailable."""
+        st.info('VibeNodes page requires NiceGUI.')
+
 

--- a/transcendental_resonance_frontend/src/pages/video_chat_page.py
+++ b/transcendental_resonance_frontend/src/pages/video_chat_page.py
@@ -7,7 +7,11 @@ from __future__ import annotations
 
 import json
 
-from nicegui import ui
+try:
+    from nicegui import ui
+except Exception:  # pragma: no cover - fallback to Streamlit
+    ui = None  # type: ignore
+    import streamlit as st
 
 from utils.api import TOKEN, WS_CONNECTION, connect_ws
 from utils.layout import navigation_bar, page_container
@@ -138,5 +142,11 @@ async def video_chat_page() -> None:
         ui.label("Note: Video chat is unavailable when offline.").classes(
             "text-xs opacity-75 mt-2"
         )
+
+if ui is None:
+    def video_chat_page(*_a, **_kw):
+        """Fallback video chat page when NiceGUI is unavailable."""
+        st.info('Video chat page requires NiceGUI.')
+
 
 


### PR DESCRIPTION
## Summary
- wrap `from nicegui import ui` imports in try/except across page modules
- implement simple Streamlit fallbacks for each page when NiceGUI is absent

## Testing
- `make test` *(fails: ModuleNotFoundError and other test collection errors)*

------
https://chatgpt.com/codex/tasks/task_e_688abb52708083208623e3cac68cd6cb