### PR TITLE
Fix fallback for ROOT_DIR import

### DIFF
--- a/modern_ui_components.py
+++ b/modern_ui_components.py
@@ -9,7 +9,12 @@ import importlib
 import streamlit as st
 from typing import Optional, Dict
 from pathlib import Path
-from utils.paths import ROOT_DIR, PAGES_DIR
+try:
+    # Prefer the shared path constants if available
+    from utils.paths import ROOT_DIR, PAGES_DIR  # type: ignore
+except Exception:  # pragma: no cover - fallback for isolated execution
+    ROOT_DIR = Path(__file__).resolve().parents[2]
+    PAGES_DIR = ROOT_DIR / "pages"
 from uuid import uuid4
 from streamlit_helpers import safe_container
 


### PR DESCRIPTION
## Summary
- handle missing `utils.paths` module gracefully by creating a fallback

## Testing
- `pytest -k modern_ui_components -q`
- `pytest -k pages_unique -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688abe827d4c8320a42d5cae45d910d1