### PR TITLE
Fix modern_ui_components missing paths fallback

### DIFF
--- a/modern_ui_components.py
+++ b/modern_ui_components.py
@@ -9,7 +9,12 @@ import importlib
 import streamlit as st
 from typing import Optional, Dict
 from pathlib import Path
-from utils.paths import ROOT_DIR, PAGES_DIR
+try:
+    from utils.paths import ROOT_DIR, PAGES_DIR
+except Exception:  # pragma: no cover - fallback for missing package
+    # Minimal fallback when utils.paths is unavailable
+    ROOT_DIR = Path(__file__).resolve().parent
+    PAGES_DIR = ROOT_DIR / "pages"
 from uuid import uuid4
 from streamlit_helpers import safe_container
 


### PR DESCRIPTION
## Summary
- handle missing `utils.paths` by falling back to local definitions

## Testing
- `pytest -k modern_ui_components -q`

------
https://chatgpt.com/codex/tasks/task_e_688abe827d4c8320a42d5cae45d910d1