### PR TITLE
Enhance dashboard with shadcn UI

### DIFF
--- a/streamlit_helpers.py
+++ b/streamlit_helpers.py
@@ -15,6 +15,10 @@ from contextlib import nullcontext
 
 import streamlit as st
 try:
+    import streamlit_shadcn_ui as ui
+except Exception:  # pragma: no cover - optional dependency
+    ui = None
+try:
     from modern_ui import inject_modern_styles
 except Exception:  # pragma: no cover - gracefully handle missing/invalid module
     def inject_modern_styles(*_a, **_k):
@@ -64,7 +68,25 @@ def header(title: str, *, layout: str = "centered") -> None:
         "<style>.app-container{padding:1rem 2rem;}" "</style>",
         unsafe_allow_html=True,
     )
-    st.header(title)
+    if ui is not None:
+        ui.element("h1", title)
+    else:
+        st.header(title)
+
+
+def render_post_card(post_data: dict) -> None:
+    """Render a simple Instagram-style post card using shadcn components."""
+    if ui is None:
+        st.image(post_data.get("image", ""))
+        st.write(post_data.get("text", ""))
+        st.caption(f"❤️ {post_data.get('likes', 0)}")
+        return
+
+    with ui.card(key=f"post_{hash(post_data.get('text', ''))}"):
+        if post_data.get("image"):
+            ui.image(post_data["image"], className="rounded-md")
+        ui.element("p", post_data.get("text", ""))
+        ui.badge(f"❤ {post_data.get('likes', 0)}", className="bg-pink-500")
 
 
 def safe_apply_theme(theme: str) -> None:
@@ -189,6 +211,19 @@ def safe_container(container: Any) -> ContextManager:
     return nullcontext()
 
 
+def inject_instagram_styles() -> None:
+    """Inject lightweight CSS tweaks for an Instagram-like aesthetic."""
+    st.markdown(
+        """
+        <style>
+        body { background: #FAFAFA; }
+        .shadcn-card { border-radius: 12px; box-shadow: 0 2px 4px rgba(0,0,0,0.05); }
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
 __all__ = [
     "alert",
     "header",
@@ -198,4 +233,6 @@ __all__ = [
     "safe_container",
     "inject_global_styles",
     "BOX_CSS",
+    "render_post_card",
+    "inject_instagram_styles",
 ]

--- a/ui.py
+++ b/ui.py
@@ -8,6 +8,7 @@ Example:
 import os
 import time
 import streamlit as st  # ensure Streamlit is imported early
+st.set_page_config(layout="wide")
 
 if not hasattr(st, "experimental_page"):
     def _noop_experimental_page(*_args, **_kwargs):
@@ -195,6 +196,8 @@ from streamlit_helpers import (
     header,
     theme_selector,
     safe_container,
+    render_post_card,
+    inject_instagram_styles,
 )
 
 try:
@@ -637,9 +640,15 @@ def render_modern_music_page():
 
 def render_modern_social_page():
     render_title_bar("👥", "Social Network")
-    st.markdown("😀 @alice #hello")
-    st.markdown("🔥 Trending: #resonance #ai")
-    st.success("Social feed placeholder loaded")
+    posts = [
+        {"image": "https://placekitten.com/400/300", "text": "Cute kitten", "likes": 5},
+        {"image": "https://placekitten.com/300/300", "text": "Another cat", "likes": 3},
+        {"image": "https://placekitten.com/500/300", "text": "More cats", "likes": 8},
+    ]
+    cols = st.columns(3)
+    for col, post in zip(cols * (len(posts) // 3 + 1), posts):
+        with col:
+            render_post_card(post)
 
 
 def render_modern_chat_page() -> None:
@@ -1377,9 +1386,9 @@ def main() -> None:
     try:
         st.set_page_config(
             page_title="superNova_2177",
-            layout="wide",
             initial_sidebar_state="collapsed",
         )
+        inject_instagram_styles()
         render_top_bar()
         # Inject keyboard shortcuts for quick navigation
         st.markdown(


### PR DESCRIPTION
## Summary
- integrate `streamlit_shadcn_ui` helpers
- add `render_post_card` and `inject_instagram_styles` utilities
- inject Instagram-like styles and use shadcn cards in social feed
- set wide layout on startup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ac685ee108320babe305dfb46e9de