### PR TITLE
Refactor Shadcn UI integration

### DIFF
--- a/streamlit_helpers.py
+++ b/streamlit_helpers.py
@@ -21,9 +21,11 @@ import streamlit as st
 # ① Try NiceGUI → ② try streamlit-shadcn-ui → ③ fall back to plain Streamlit
 try:  # NiceGUI available?
     from nicegui import ui  # type: ignore
+    shadcn = None
 except Exception:  # noqa: BLE001
     try:  # streamlit-shadcn-ui available?
-        import streamlit_shadcn_ui as ui  # type: ignore
+        import streamlit_shadcn_ui as shadcn  # type: ignore
+        ui = shadcn
     except Exception:  # noqa: BLE001
         from contextlib import nullcontext
         import html
@@ -74,6 +76,7 @@ except Exception:  # noqa: BLE001
                 return _DummyElement()
 
         ui = _DummyUI()  # type: ignore
+        shadcn = None
 
 
 # ──────────────────────────────────────────────────────────────────────────────

--- a/ui.py
+++ b/ui.py
@@ -22,10 +22,10 @@ if not hasattr(st, "experimental_page"):
 # Legal & Ethical Safeguards
 
 try:
-    import streamlit_shadcn_ui as ui  # type: ignore
+    import streamlit_shadcn_ui as shadcn  # type: ignore
 except Exception:  # pragma: no cover - optional dependency or missing at runtime
     import types
-    ui = types.SimpleNamespace()
+    shadcn = types.SimpleNamespace()
 
 from datetime import datetime, timezone
 import asyncio
@@ -223,7 +223,7 @@ class _UIWrapper:
         return _StreamlitTabs(labels)
 
 
-ui = _UIWrapper()
+ui_wrapper = _UIWrapper()
 
 
 
@@ -1701,7 +1701,7 @@ def main() -> None:
         # Center content area — dynamic page loading
         with center_col:
             # Main navigation tabs for common sections
-            with ui.tabs(["Validation", "Voting", "Agents"]) as tabs:
+            with ui_wrapper.tabs(["Validation", "Voting", "Agents"]) as tabs:
                 selected = tabs.active
                 if selected != display_choice:
                     try:


### PR DESCRIPTION
## Summary
- import streamlit_shadcn_ui as `shadcn`
- create `ui_wrapper` instance to avoid clobbering the library
- update tab calls to use `ui_wrapper`
- expose `shadcn` in helpers while keeping dynamic `ui`

## Testing
- `make test`
- `make lint` *(fails: streamlit-test is not a valid Python package name)*

------
https://chatgpt.com/codex/tasks/task_e_688ade0351ac8320b9d353472a19020f