### PR TITLE
Integrate shadcn-ui feed helpers

### DIFF
--- a/streamlit_helpers.py
+++ b/streamlit_helpers.py
@@ -18,12 +18,12 @@ import streamlit as st
 # ──────────────────────────────────────────────────────────────────────────────
 # UI-backend detection
 # ──────────────────────────────────────────────────────────────────────────────
-# ① Try NiceGUI → ② try streamlit-shadcn-ui → ③ fall back to plain Streamlit
-try:  # NiceGUI available?
-    from nicegui import ui  # type: ignore
+# Prefer streamlit-shadcn-ui and fall back to NiceGUI or plain Streamlit
+try:  # streamlit-shadcn-ui available?
+    import streamlit_shadcn_ui as ui  # type: ignore
 except Exception:  # noqa: BLE001
-    try:  # streamlit-shadcn-ui available?
-        import streamlit_shadcn_ui as ui  # type: ignore
+    try:  # NiceGUI available?
+        from nicegui import ui  # type: ignore
     except Exception:  # noqa: BLE001
         from contextlib import nullcontext
         import html
@@ -160,6 +160,14 @@ def render_post_card(post_data: dict[str, Any]) -> None:
         ui.badge(f"❤️ {likes}").classes("bg-pink-500")
 
 
+def render_instagram_grid(posts: list[dict[str, Any]], *, cols: int = 3) -> None:
+    """Display posts in a responsive grid using ``render_post_card``."""
+    columns = st.columns(cols)
+    for i, post in enumerate(posts):
+        with columns[i % cols]:
+            render_post_card(post)
+
+
 # ──────────────────────────────────────────────────────────────────────────────
 # Theme helpers
 # ──────────────────────────────────────────────────────────────────────────────
@@ -294,6 +302,18 @@ def inject_instagram_styles() -> None:
         .shadcn-card {
             border-radius: 12px;
             box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+            background: #fff;
+        }
+        .shadcn-badge {
+            border-radius: 999px;
+            background: #fff;
+            padding: 0.25rem 0.5rem;
+            box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+        }
+        .shadcn-btn {
+            border-radius: 999px;
+            padding: 0.25rem 0.75rem;
+            box-shadow: 0 1px 2px rgba(0,0,0,0.05);
         }
         </style>
         """,
@@ -314,6 +334,7 @@ __all__ = [
     "alert",
     "header",
     "render_post_card",
+    "render_instagram_grid",
     "apply_theme",
     "theme_selector",
     "centered_container",

--- a/ui.py
+++ b/ui.py
@@ -259,6 +259,7 @@ from streamlit_helpers import (
     theme_selector,
     safe_container,
     render_post_card,
+    render_instagram_grid,
     inject_instagram_styles,
 )
 
@@ -707,10 +708,7 @@ def render_modern_social_page():
         {"image": "https://placekitten.com/300/300", "text": "Another cat", "likes": 3},
         {"image": "https://placekitten.com/500/300", "text": "More cats", "likes": 8},
     ]
-    cols = st.columns(3)
-    for col, post in zip(cols * (len(posts) // 3 + 1), posts):
-        with col:
-            render_post_card(post)
+    render_instagram_grid(posts, cols=3)
 
 
 def render_modern_chat_page() -> None:
@@ -973,10 +971,7 @@ def run_analysis(validations, *, layout: str = "force"):
         result = analyze_validation_integrity(validations)
 
     header("Validations")
-    cols = st.columns(3)
-    for i, entry in enumerate(validations):
-        with cols[i % 3]:
-            render_post_card(entry)
+    render_instagram_grid(validations, cols=3)
 
     consensus = result.get("consensus_score")
     if consensus is not None:
@@ -1430,14 +1425,6 @@ def main() -> None:
 
     # Global CSS for cards / clean background
     st.markdown(
-        """<style>
-        body, .stApp {background:#FAFAFA;}
-        .sn-card {border-radius:12px;box-shadow:0 2px 6px rgba(0,0,0,0.1);}
-        </style>""",
-        unsafe_allow_html=True,
-    )
-
-    st.markdown(  # ← << duplicated block begins here (delete this one)
         """<style>
         body, .stApp {background:#FAFAFA;}
         .sn-card {border-radius:12px;box-shadow:0 2px 6px rgba(0,0,0,0.1);}


### PR DESCRIPTION
## Summary
- use streamlit-shadcn-ui as primary UI backend
- add helper to render responsive post grids
- add instagram style CSS
- display social posts and validations using new grid helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688adde7b60c8320a7b5735c78fc9509