### PR TITLE
Insert guest/demo accounts on first run

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ This project depends on libraries such as `fastapi`, `pydantic-settings`, `struc
    .\venv\Scripts\activate
    ```
 4. You're ready to run the demo commands shown in [Quick Start](#-quick-start).
+5. On first launch the application seeds `harmonizers.db` with an `admin`,
+   `guest`, and `demo_user` account so the UI has sample profiles ready.
 
 ### Extras
 

--- a/ui.py
+++ b/ui.py
@@ -1850,6 +1850,20 @@ def ensure_database_exists() -> bool:
                         """
                     )
                 )
+                conn.execute(
+                    text(
+                        "INSERT INTO harmonizers (username, email, hashed_password, bio,"
+                        " is_active, is_admin, is_genesis, consent_given)"
+                        " VALUES ('guest','guest@example.com','x','Guest account',1,0,0,1);"
+                    )
+                )
+                conn.execute(
+                    text(
+                        "INSERT INTO harmonizers (username, email, hashed_password, bio,"
+                        " is_active, is_admin, is_genesis, consent_given)"
+                        " VALUES ('demo_user','demo@example.com','x','Demo profile',1,0,0,1);"
+                    )
+                )
         return True
     except (OperationalError, sqlite3.Error) as exc:
         logger.error("Database initialization failed: %s", exc)


### PR DESCRIPTION
## Summary
- seed database with guest and demo profiles alongside admin
- note default accounts in setup instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ae709369c8320a1234a2bd5d4091a