### PR TITLE
Add feed renderer demo

### DIFF
--- a/feed_renderer.py
+++ b/feed_renderer.py
@@ -1,0 +1,45 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+"""Simple renderer for a social feed."""
+
+from __future__ import annotations
+
+from typing import Iterable, Dict, Any
+
+import streamlit as st
+
+from streamlit_helpers import render_post_card
+
+# Demo posts used when none are provided
+DEMO_POSTS: list[dict[str, Any]] = [
+    {
+        "image": "https://placekitten.com/400/300",
+        "text": "Look at this cute kitten!",
+        "likes": 5,
+    },
+    {
+        "image": "https://placekitten.com/500/300",
+        "text": "Another adorable cat appears.",
+        "likes": 3,
+    },
+    {
+        "image": "https://placekitten.com/450/300",
+        "text": "Cats everywhere!",
+        "likes": 8,
+    },
+]
+
+
+def render_feed(posts: Iterable[Dict[str, Any]] | None = None) -> None:
+    """Render each post using :func:`render_post_card`."""
+    if posts is None:
+        posts = DEMO_POSTS
+
+    posts = list(posts)
+    if not posts:
+        st.info("No posts to display")
+        return
+
+    for post in posts:
+        render_post_card(post)

--- a/transcendental_resonance_frontend/pages/social.py
+++ b/transcendental_resonance_frontend/pages/social.py
@@ -7,6 +7,7 @@ import streamlit as st
 from modern_ui import inject_modern_styles
 from social_tabs import render_social_tab
 from streamlit_helpers import safe_container
+from feed_renderer import render_feed
 
 inject_modern_styles()
 
@@ -19,6 +20,8 @@ def main(main_container=None) -> None:
     container_ctx = safe_container(main_container)
     with container_ctx:
         render_social_tab()
+        st.divider()
+        render_feed()
 
 
 def render() -> None:


### PR DESCRIPTION
## Summary
- add a basic `feed_renderer` module with sample posts
- display the feed on the Social page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ae6febd4c8320a0ea8c2b64a71462