### PR TITLE
Add chat UI module and integrate into messages page

### DIFF
--- a/chat_ui.py
+++ b/chat_ui.py
@@ -1,0 +1,67 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+"""Reusable chat interface components."""
+
+from __future__ import annotations
+
+import streamlit as st
+
+
+CHAT_CSS = """
+<style>
+.chat-container {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+.chat-bubble {
+    padding: 0.5rem 1rem;
+    border-radius: 1rem;
+    max-width: 80%;
+    word-wrap: break-word;
+}
+.chat-bubble.left {
+    align-self: flex-start;
+    background: #eee;
+}
+.chat-bubble.right {
+    align-self: flex-end;
+    background: #DCF8C6;
+}
+</style>
+"""
+
+
+def render_chat() -> None:
+    """Display a simple chat with messages and call controls."""
+    st.session_state.setdefault("chat_history", [])
+
+    st.markdown(CHAT_CSS, unsafe_allow_html=True)
+
+    messages_tab, calls_tab = st.tabs(["Messages", "Calls"])
+
+    with messages_tab:
+        st.markdown("<div class='chat-container'>", unsafe_allow_html=True)
+        for entry in st.session_state["chat_history"]:
+            sender = entry.get("sender", "")
+            text = entry.get("text", "")
+            cls = "right" if sender == "You" else "left"
+            st.markdown(
+                f"<div class='chat-bubble {cls}'><strong>{sender}:</strong> {text}</div>",
+                unsafe_allow_html=True,
+            )
+        st.markdown("</div>", unsafe_allow_html=True)
+
+        col1, col2 = st.columns([4, 1])
+        with col1:
+            msg = st.text_input("Message", key="chat_msg")
+        with col2:
+            if st.button("Send", key="chat_send") and msg:
+                st.session_state["chat_history"].append({"sender": "You", "text": msg})
+                st.session_state.chat_msg = ""
+                st.experimental_rerun()
+
+    with calls_tab:
+        if st.button("Start Video Call", key="chat_video"):
+            st.toast("Video call integration pending")

--- a/transcendental_resonance_frontend/pages/messages.py
+++ b/transcendental_resonance_frontend/pages/messages.py
@@ -6,6 +6,7 @@
 import streamlit as st
 from modern_ui import inject_modern_styles
 from streamlit_helpers import safe_container, header
+from chat_ui import render_chat
 
 inject_modern_styles()
 
@@ -41,16 +42,9 @@ def _render_conversation_list() -> None:
 
 def _render_chat_panel(user: str) -> None:
     header(f"Chat with {user}")
-    msgs = st.session_state["messages"].setdefault(user, [])
-    for msg in msgs:
-        st.write(f"{msg['sender']}: {msg['text']}")
-    txt = st.text_input("Message", key="msg_input")
-    if st.button("Send", key="send_btn") and txt:
-        msgs.append({"sender": "You", "text": txt})
-        st.session_state.msg_input = ""
-        st.experimental_rerun()
-    if st.button("Start Video Call", key="video_call"):
-        st.toast("Video call integration pending")
+    st.session_state["chat_history"] = st.session_state["messages"].setdefault(user, [])
+    render_chat()
+    st.session_state["messages"][user] = st.session_state.get("chat_history", [])
 
 
 def main(main_container=None) -> None:


### PR DESCRIPTION
## Summary
- create `chat_ui` module with a `render_chat` helper that shows messages and call tabs
- replace chat logic on the messages page with `render_chat`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ae6fdc3a48320999bfadf52530a44