### PR TITLE
Implement light theme CSS injection

### DIFF
--- a/frontend/__init__.py
+++ b/frontend/__init__.py
@@ -1,0 +1,1 @@
+from .light_theme import inject_light_theme

--- a/frontend/light_theme.py
+++ b/frontend/light_theme.py
@@ -1,0 +1,23 @@
+"""Simple light theme CSS injection for Streamlit."""
+
+import streamlit as st
+
+CSS = """
+<style>
+body, .stApp {
+    background: white;
+    font-family: Helvetica, Arial, sans-serif;
+}
+button, .stButton>button {
+    border-radius: 8px;
+}
+</style>
+"""
+
+
+def inject_light_theme() -> None:
+    """Inject the basic light theme CSS if not already added."""
+    if st.session_state.get("_light_theme_injected"):
+        return
+    st.markdown(CSS, unsafe_allow_html=True)
+    st.session_state["_light_theme_injected"] = True

--- a/social_tabs.py
+++ b/social_tabs.py
@@ -3,6 +3,7 @@
 # Legal & Ethical Safeguards
 import asyncio
 import streamlit as st
+from frontend.light_theme import inject_light_theme
 from streamlit_helpers import alert, safe_container, header
 
 
@@ -47,6 +48,9 @@ def _load_profile(username: str) -> tuple[dict, dict, dict]:
             dispatch_route("get_following", {"username": username}, db=db)
         )
     return user, followers, following
+
+
+inject_light_theme()
 
 
 def render_social_tab(main_container=None) -> None:

--- a/transcendental_resonance_frontend/pages/profile.py
+++ b/transcendental_resonance_frontend/pages/profile.py
@@ -4,6 +4,7 @@
 """User identity hub with profile and activity overview."""
 
 import streamlit as st
+from frontend.light_theme import inject_light_theme
 from modern_ui import inject_modern_styles
 from streamlit_helpers import safe_container, header
 from api_key_input import render_api_key_ui
@@ -61,6 +62,7 @@ def _fetch_social(username: str) -> tuple[dict, dict]:
         )
     return followers or {}, following or {}
 
+inject_light_theme()
 inject_modern_styles()
 
 


### PR DESCRIPTION
## Summary
- add a `light_theme` module with basic CSS
- expose `inject_light_theme` via `frontend.__init__`
- inject the light theme on profile page and social tabs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ae70a498c8320ae95a4cd6515165d