### PR TITLE
Enhance profile feed with reactions

### DIFF
--- a/transcendental_resonance_frontend/ui/profile_theme.css
+++ b/transcendental_resonance_frontend/ui/profile_theme.css
@@ -44,13 +44,37 @@
   gap: 0.25rem;
   margin-top: 1rem;
 }
+.feed-item {
+  background: var(--card);
+  border-radius: 12px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.08);
+  overflow: hidden;
+}
 .feed-thumb {
   width: 100%;
-  border-radius: 8px;
+  border-radius: 0;
   transition: transform 0.2s ease;
 }
 .feed-thumb:hover {
   transform: scale(1.03);
+}
+.reactions {
+  display: flex;
+  justify-content: space-around;
+  padding: 0.25rem 0.5rem 0.5rem;
+}
+.reaction-btn {
+  background: var(--card);
+  border: 1px solid rgba(0,0,0,0.05);
+  border-radius: 999px;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+.reaction-btn:hover {
+  background: var(--accent);
+  color: #fff;
 }
 @media (max-width: 600px) {
   .profile-container {

--- a/transcendental_resonance_frontend/ui/profile_ui.py
+++ b/transcendental_resonance_frontend/ui/profile_ui.py
@@ -89,9 +89,18 @@ def render_profile(user_data: Optional[Dict[str, object]] = None) -> None:
 
         if feed:
             st.markdown("<div class='feed-grid'>", unsafe_allow_html=True)
-            for src in feed:
+            for i, src in enumerate(feed):
                 st.markdown(
-                    f"<img src='{src}' class='feed-thumb' alt='feed item'>",
+                    f"""
+                    <div class='feed-item'>
+                        <img src='{src}' class='feed-thumb' alt='feed item'>
+                        <div class='reactions'>
+                            <button class='reaction-btn'>❤️</button>
+                            <button class='reaction-btn'>💬</button>
+                            <button class='reaction-btn'>🔄</button>
+                        </div>
+                    </div>
+                    """,
                     unsafe_allow_html=True,
                 )
             st.markdown("</div>", unsafe_allow_html=True)


### PR DESCRIPTION
## Summary
- keep columns layout for avatar and stats
- add reaction buttons under each feed image
- update profile theme to round feed items and style reaction buttons

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ae70b6270832094061d05691bb567