### PR TITLE
Initialize active_user defaults

### DIFF
--- a/social_tabs.py
+++ b/social_tabs.py
@@ -56,12 +56,14 @@ def render_social_tab(main_container=None) -> None:
 
     container_ctx = safe_container(main_container)
     with container_ctx:
+        if "active_user" not in st.session_state:
+            st.session_state["active_user"] = "guest"
         header("Friends & Followers")
         if dispatch_route is None or SessionLocal is None or Harmonizer is None:
             st.info("Social routes not available")
             return
 
-        current_user = st.session_state.get("active_user", "")
+        current_user = st.session_state.get("active_user")
         cols = st.columns(2)
         with cols[0]:
             current_user = st.text_input(

--- a/transcendental_resonance_frontend/pages/profile.py
+++ b/transcendental_resonance_frontend/pages/profile.py
@@ -98,6 +98,8 @@ def main(main_container=None) -> None:
 
     container_ctx = safe_container(main_container)
     with container_ctx:
+        if "active_user" not in st.session_state:
+            st.session_state["active_user"] = "guest"
         # Header with status icon
         header_col, status_col = st.columns([8, 1])
         with header_col:
@@ -106,7 +108,7 @@ def main(main_container=None) -> None:
             render_status_icon()
 
         # Active user editable section
-        current = st.session_state.get("active_user", "guest")
+        current = st.session_state.get("active_user")
         current = st.text_input("Username", value=current, key="profile_user")
         st.session_state["active_user"] = current
         _render_profile(current)


### PR DESCRIPTION
## Summary
- set default session state key `active_user` in `social_tabs.render_social_tab`
- initialize `active_user` in `profile.py` main
- safely read `active_user` from session state

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ae6dca5088320814598b09b284800