### PR TITLE
Attempt fallback when shadcn UI missing

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -22,10 +22,9 @@ if not hasattr(st, "experimental_page"):
 # Legal & Ethical Safeguards
 
 try:
-    import streamlit_shadcn_ui as ui  # type: ignore
+    import streamlit_shadcn_ui as _shadcn_ui  # type: ignore
 except Exception:  # pragma: no cover - optional dependency or missing at runtime
-    import types
-    ui = types.SimpleNamespace()
+    _shadcn_ui = None
 
 from datetime import datetime, timezone
 import asyncio
@@ -218,12 +217,24 @@ class _StreamlitTabs:
 class _UIWrapper:
     """Namespace providing a ``tabs`` helper compatible with NiceGUI style."""
 
-    @staticmethod
-    def tabs(labels: list[str]) -> _StreamlitTabs:
+    def __init__(self, backend: object | None = None) -> None:
+        self._backend = backend
+
+    def tabs(self, labels: list[str]) -> _StreamlitTabs:
+        if self._backend and hasattr(self._backend, "tabs"):
+            try:
+                return self._backend.tabs(labels)  # type: ignore[return-value]
+            except Exception:  # pragma: no cover - fallback
+                pass
         return _StreamlitTabs(labels)
 
+    def __getattr__(self, name: str):
+        if self._backend is not None:
+            return getattr(self._backend, name)
+        raise AttributeError(name)
 
-ui = _UIWrapper()
+
+ui = _UIWrapper(_shadcn_ui)
 
 
 


### PR DESCRIPTION
## Summary
- fallback gracefully when streamlit_shadcn_ui isn't installed
- delegate to real shadcn package when present via _UIWrapper

## Testing
- `pytest -q` *(fails: unexpected indent in ui.py)*

------
https://chatgpt.com/codex/tasks/task_e_688adc7edfb483208ae7838376d0c08a