### PR TITLE
Handle missing utils.paths with dynamic import

### DIFF
--- a/frontend/ui_layout.py
+++ b/frontend/ui_layout.py
@@ -26,11 +26,14 @@ from typing import Dict, Iterable, Optional
 from uuid import uuid4
 from pathlib import Path
 import os
+import importlib
 import streamlit as st
 from modern_ui_components import SIDEBAR_STYLES
 
 try:
-    from utils.paths import ROOT_DIR, PAGES_DIR
+    _paths = importlib.import_module("utils.paths")
+    ROOT_DIR = _paths.ROOT_DIR
+    PAGES_DIR = _paths.PAGES_DIR
 except Exception:  # pragma: no cover - fallback when utils isn't installed
     ROOT_DIR = Path(__file__).resolve().parents[1]
     PAGES_DIR = ROOT_DIR / "transcendental_resonance_frontend" / "pages"

--- a/modern_ui_components.py
+++ b/modern_ui_components.py
@@ -12,7 +12,9 @@ from contextlib import contextmanager
 from pathlib import Path
 try:
     # Prefer the shared path constants if available
-    from utils.paths import ROOT_DIR, PAGES_DIR  # type: ignore
+    _paths = importlib.import_module("utils.paths")
+    ROOT_DIR = _paths.ROOT_DIR
+    PAGES_DIR = _paths.PAGES_DIR
 except Exception:  # pragma: no cover – fallback for isolated execution
     ROOT_DIR = Path(__file__).resolve().parents[1]          # repo root
     PAGES_DIR = ROOT_DIR / "transcendental_resonance_frontend" / "pages"

--- a/tests/test_modern_ui_paths.py
+++ b/tests/test_modern_ui_paths.py
@@ -1,0 +1,19 @@
+import importlib
+import sys
+from pathlib import Path
+import pytest
+
+pytest.importorskip("streamlit")
+pytestmark = pytest.mark.requires_streamlit
+
+root = Path(__file__).resolve().parents[1]
+if str(root) not in sys.path:
+    sys.path.insert(0, str(root))
+
+
+def test_modern_ui_components_paths_fallback(monkeypatch):
+    sys.modules.pop("utils.paths", None)
+    import modern_ui_components as mui
+    importlib.reload(mui)
+    assert isinstance(mui.ROOT_DIR, Path)
+    assert isinstance(mui.PAGES_DIR, Path)

--- a/tests/test_paths_fallback.py
+++ b/tests/test_paths_fallback.py
@@ -1,0 +1,19 @@
+import importlib
+import sys
+from pathlib import Path
+import pytest
+
+pytest.importorskip("streamlit")
+pytestmark = pytest.mark.requires_streamlit
+
+root = Path(__file__).resolve().parents[1]
+if str(root) not in sys.path:
+    sys.path.insert(0, str(root))
+
+
+def test_ui_layout_paths_fallback(monkeypatch):
+    sys.modules.pop("utils.paths", None)
+    import frontend.ui_layout as ui_layout
+    importlib.reload(ui_layout)
+    assert isinstance(ui_layout.ROOT_DIR, Path)
+    assert isinstance(ui_layout.PAGES_DIR, Path)


### PR DESCRIPTION
## Summary
- load `ROOT_DIR` and `PAGES_DIR` via `importlib` in `modern_ui_components` and `frontend.ui_layout`
- ensure fallback path constants still exist when `utils.paths` is missing
- add regression tests for both modules

## Testing
- `pytest tests/test_modern_ui_paths.py tests/test_paths_fallback.py -q`
- `pytest -q` *(fails: unexpected indent in ui.py)*

------
https://chatgpt.com/codex/tasks/task_e_688adc875e888320831143c734ed71c8