### PR TITLE
Fix header rendering and add theme memory

### DIFF
--- a/transcendental_resonance_frontend/pages/agents.py
+++ b/transcendental_resonance_frontend/pages/agents.py
@@ -1,6 +1,7 @@
 import streamlit as st
 from modern_ui import inject_modern_styles
 from agent_ui import render_agent_insights_tab
+from streamlit_helpers import theme_selector
 
 inject_modern_styles()
 
@@ -12,6 +13,7 @@ def main(main_container=None) -> None:
     If no main_container is provided, uses Streamlit root context.
     """
     container = main_container if main_container is not None else st
+    theme_selector("Theme", key_suffix="agents")
 
     try:
         container.title("🤖 Agents")

--- a/transcendental_resonance_frontend/pages/chat.py
+++ b/transcendental_resonance_frontend/pages/chat.py
@@ -5,7 +5,7 @@
 
 import streamlit as st
 from modern_ui import inject_modern_styles
-from streamlit_helpers import safe_container, header
+from streamlit_helpers import safe_container, header, theme_selector
 from status_indicator import render_status_icon
 
 inject_modern_styles()
@@ -69,6 +69,7 @@ def main(main_container=None) -> None:
     """Render the chat page."""
     if main_container is None:
         main_container = st
+    theme_selector("Theme", key_suffix="chat")
 
     container_ctx = safe_container(main_container)
     with container_ctx:

--- a/transcendental_resonance_frontend/pages/messages.py
+++ b/transcendental_resonance_frontend/pages/messages.py
@@ -5,7 +5,7 @@
 
 import streamlit as st
 from modern_ui import inject_modern_styles
-from streamlit_helpers import safe_container, header
+from streamlit_helpers import safe_container, header, theme_selector
 
 inject_modern_styles()
 
@@ -56,6 +56,7 @@ def _render_chat_panel(user: str) -> None:
 def main(main_container=None) -> None:
     if main_container is None:
         main_container = st
+    theme_selector("Theme", key_suffix="messages")
     _init_state()
     container_ctx = safe_container(main_container)
     with container_ctx:

--- a/transcendental_resonance_frontend/pages/messages_center.py
+++ b/transcendental_resonance_frontend/pages/messages_center.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import asyncio
 import streamlit as st
 from modern_ui import inject_modern_styles
-from streamlit_helpers import safe_container, header
+from streamlit_helpers import safe_container, header, theme_selector
 from transcendental_resonance_frontend.src.utils import api
 from status_indicator import render_status_icon
 
@@ -73,6 +73,7 @@ def main(main_container=None) -> None:
     """Render the Messages / Chat Center page."""
     if main_container is None:
         main_container = st
+    theme_selector("Theme", key_suffix="msg_center")
 
     container_ctx = safe_container(main_container)
     with container_ctx:

--- a/transcendental_resonance_frontend/pages/profile.py
+++ b/transcendental_resonance_frontend/pages/profile.py
@@ -5,7 +5,7 @@
 
 import streamlit as st
 from modern_ui import inject_modern_styles
-from streamlit_helpers import safe_container, header
+from streamlit_helpers import safe_container, header, theme_selector
 from api_key_input import render_api_key_ui
 from social_tabs import _load_profile
 from transcendental_resonance_frontend.ui.profile_ui import (
@@ -95,6 +95,7 @@ def _render_profile(username: str) -> None:
 def main(main_container=None) -> None:
     if main_container is None:
         main_container = st
+    theme_selector("Theme", key_suffix="profile")
 
     container_ctx = safe_container(main_container)
     with container_ctx:

--- a/transcendental_resonance_frontend/pages/resonance_music.py
+++ b/transcendental_resonance_frontend/pages/resonance_music.py
@@ -14,7 +14,13 @@ from pathlib import Path
 import requests
 import streamlit as st
 from modern_ui import inject_modern_styles
-from streamlit_helpers import alert, centered_container, safe_container, header
+from streamlit_helpers import (
+    alert,
+    centered_container,
+    safe_container,
+    header,
+    theme_selector,
+)
 from streamlit_autorefresh import st_autorefresh
 from status_indicator import render_status_icon, check_backend # Ensure check_backend is imported
 from utils.api import get_resonance_summary, dispatch_route # Import get_resonance_summary and dispatch_route from utils.api
@@ -69,6 +75,7 @@ def main(main_container=None, status_container=None) -> None:
         main_container = st
     if status_container is None:
         status_container = st
+    theme_selector("Theme", key_suffix="music")
 
     # Auto-refresh for backend health check (global, outside main_container)
     st_autorefresh(interval=30000, key="status_ping")

--- a/transcendental_resonance_frontend/pages/social.py
+++ b/transcendental_resonance_frontend/pages/social.py
@@ -6,7 +6,7 @@
 import streamlit as st
 from modern_ui import inject_modern_styles
 from social_tabs import render_social_tab
-from streamlit_helpers import safe_container
+from streamlit_helpers import safe_container, theme_selector
 
 inject_modern_styles()
 
@@ -15,6 +15,7 @@ def main(main_container=None) -> None:
     """Render the social page content within ``main_container``."""
     if main_container is None:
         main_container = st
+    theme_selector("Theme", key_suffix="social")
 
     container_ctx = safe_container(main_container)
     with container_ctx:

--- a/transcendental_resonance_frontend/pages/validation.py
+++ b/transcendental_resonance_frontend/pages/validation.py
@@ -6,7 +6,7 @@
 import importlib
 import streamlit as st
 from modern_ui import inject_modern_styles
-from streamlit_helpers import safe_container
+from streamlit_helpers import safe_container, theme_selector
 
 # --------------------------------------------------------------------
 # Dynamic loader with graceful degradation
@@ -43,6 +43,7 @@ def main(main_container=None) -> None:
     """Render the validation UI inside a safe container."""
     if main_container is None:
         main_container = st
+    theme_selector("Theme", key_suffix="validation")
 
     global render_validation_ui
     # Reload if we initially fell back but the real module may now exist

--- a/transcendental_resonance_frontend/pages/video_chat.py
+++ b/transcendental_resonance_frontend/pages/video_chat.py
@@ -10,7 +10,7 @@ from modern_ui import inject_modern_styles
 
 from ai_video_chat import create_session
 from video_chat_router import ConnectionManager
-from streamlit_helpers import safe_container, header
+from streamlit_helpers import safe_container, header, theme_selector
 
 inject_modern_styles()
 
@@ -33,6 +33,7 @@ manager = ConnectionManager()
 def main(main_container=None) -> None:
     """Render the simple video chat demo."""
     container = main_container if main_container is not None else st
+    theme_selector("Theme", key_suffix="video_chat")
 
     container_ctx = safe_container(container)
     with container_ctx:

--- a/transcendental_resonance_frontend/pages/voting.py
+++ b/transcendental_resonance_frontend/pages/voting.py
@@ -6,7 +6,7 @@
 import streamlit as st
 from modern_ui import inject_modern_styles
 from voting_ui import render_voting_tab
-from streamlit_helpers import safe_container
+from streamlit_helpers import safe_container, theme_selector
 
 inject_modern_styles()
 
@@ -15,6 +15,7 @@ def main(main_container=None) -> None:
     """Render the Governance and Voting page inside ``main_container``."""
     if main_container is None:
         main_container = st
+    theme_selector("Theme", key_suffix="voting")
 
     container_ctx = safe_container(main_container)
     with container_ctx:


### PR DESCRIPTION
## Summary
- sanitize text and add `safe_element` fallback in `streamlit_helpers`
- support emoji-safe headers with graceful fallback
- handle failures in post card rendering
- provide theme selector on social pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688addb0d93c832084219b1982e608bd