### PR TITLE
Fix duplicated CSS injection in ui

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -1437,13 +1437,6 @@ def main() -> None:
         unsafe_allow_html=True,
     )
 
-    st.markdown(  # ← << duplicated block begins here (delete this one)
-        """<style>
-        body, .stApp {background:#FAFAFA;}
-        .sn-card {border-radius:12px;box-shadow:0 2px 6px rgba(0,0,0,0.1);}
-        </style>""",
-        unsafe_allow_html=True,
-    )
 
     try:
         ensure_pages(PAGES, PAGES_DIR)


### PR DESCRIPTION
## Summary
- remove redundant CSS injection block in `main()`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688addc09f6c8320862c1b9cf18a4ec3