### PR TITLE
Initialize DB on launch and seed defaults

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,14 @@
 import streamlit as st
 from ui_utils import render_modern_layout
+from db_models import init_db, seed_default_users
+
+
+def main() -> None:
+    """Launch the Streamlit UI after ensuring the database is ready."""
+    init_db()
+    seed_default_users()
+    render_modern_layout()
 
 
 if __name__ == "__main__":
-    render_modern_layout()
+    main()

--- a/db_models.py
+++ b/db_models.py
@@ -645,3 +645,25 @@ def init_db() -> None:
     """Create all tables defined in this module."""
     Base.metadata.create_all(bind=engine)
 
+
+def seed_default_users() -> None:
+    """Create default Harmonizer accounts if they don't exist."""
+    session = SessionLocal()
+    try:
+        defaults = ["guest", "demo_user"]
+        for username in defaults:
+            exists = session.query(Harmonizer).filter_by(username=username).first()
+            if not exists:
+                hashed = hashlib.sha256(username.encode()).hexdigest()
+                user = Harmonizer(
+                    username=username,
+                    email=f"{username}@example.com",
+                    hashed_password=hashed,
+                    bio="Default user",
+                )
+                session.add(user)
+        session.commit()
+    finally:
+        session.close()
+
+


### PR DESCRIPTION
## Summary
- initialize the database when launching the Streamlit UI
- seed guest/demo accounts if they don't exist

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ae6de2b5c8320ac64a26f8da47e86