### PR TITLE
Enhance post card reactions and grid info

### DIFF
--- a/streamlit_helpers.py
+++ b/streamlit_helpers.py
@@ -169,13 +169,18 @@ def render_post_card(post_data: dict[str, Any]) -> None:
             st.image(img, use_column_width=True)
         st.write(text)
         st.caption(f"❤️ {likes}")
+        st.markdown(
+            "<div style='color:var(--text-color);font-size:1.2em;'>❤️ 🔁 💬</div>",
+            unsafe_allow_html=True,
+        )
         return
 
     with ui.card().classes("w-full p-4 mb-4"):
         if img:
             ui.image(img).classes("rounded-md mb-2 w-full")
         ui.element("p", text).classes("mb-1")
-        ui.badge(f"❤️ {likes}").classes("bg-pink-500")
+        ui.badge(f"❤️ {likes}").classes("bg-pink-500 mb-1")
+        ui.element("div", "❤️ 🔁 💬").classes("text-center text-lg")
 
 
 def render_instagram_grid(posts: list[dict[str, Any]], *, cols: int = 3) -> None:
@@ -183,7 +188,11 @@ def render_instagram_grid(posts: list[dict[str, Any]], *, cols: int = 3) -> None
     columns = st.columns(cols)
     for i, post in enumerate(posts):
         with columns[i % cols]:
-            render_post_card(post)
+            username = post.get("username") or post.get("user", "")
+            caption = post.get("caption") or post.get("text", "")
+            if username:
+                st.markdown(f"**{html.escape(username)}**")
+            render_post_card({"image": post.get("image"), "text": caption, "likes": post.get("likes", 0)})
 
 
 # ──────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- show reaction icons under each post
- display username and caption in the grid
- test updates for new reaction element

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ae70fb6c0832098d33ec6b8c2669c