### PR TITLE
Add mock social feed

### DIFF
--- a/streamlit_helpers.py
+++ b/streamlit_helpers.py
@@ -186,6 +186,40 @@ def render_instagram_grid(posts: list[dict[str, Any]], *, cols: int = 3) -> None
             render_post_card(post)
 
 
+def render_mock_feed() -> None:
+    """Render a simple scrolling feed of demo posts."""
+    posts = [
+        (
+            "alice",
+            "https://picsum.photos/seed/alice/400/300",
+            "Enjoying the sunshine!",
+        ),
+        (
+            "bob",
+            "https://picsum.photos/seed/bob/400/300",
+            "Hiking adventures today.",
+        ),
+        (
+            "carol",
+            "https://picsum.photos/seed/carol/400/300",
+            "Coffee time at my favourite spot.",
+        ),
+    ]
+
+    st.markdown(
+        "<div style='max-height: 400px; overflow-y: auto;'>",
+        unsafe_allow_html=True,
+    )
+    with st.container():
+        for username, image, caption in posts:
+            render_post_card({
+                "image": image,
+                "text": f"**{username}**: {caption}",
+                "likes": 0,
+            })
+    st.markdown("</div>", unsafe_allow_html=True)
+
+
 # ──────────────────────────────────────────────────────────────────────────────
 # Theme helpers
 # ──────────────────────────────────────────────────────────────────────────────
@@ -368,6 +402,7 @@ __all__ = [
     "header",
     "render_post_card",
     "render_instagram_grid",
+    "render_mock_feed",
     "apply_theme",
     "theme_selector",
     "centered_container",

--- a/transcendental_resonance_frontend/pages/social.py
+++ b/transcendental_resonance_frontend/pages/social.py
@@ -6,7 +6,7 @@
 import streamlit as st
 from modern_ui import inject_modern_styles
 from social_tabs import render_social_tab
-from streamlit_helpers import safe_container
+from streamlit_helpers import safe_container, render_mock_feed
 
 inject_modern_styles()
 
@@ -19,6 +19,7 @@ def main(main_container=None) -> None:
     container_ctx = safe_container(main_container)
     with container_ctx:
         render_social_tab()
+        render_mock_feed()
 
 
 def render() -> None:


### PR DESCRIPTION
## Summary
- create `render_mock_feed` to show demo posts
- export the new helper
- load feed on the Social page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ae715924c8320b3d89444a03eddd8