### PR TITLE
Refactor UI helpers

### DIFF
--- a/chat_ui.py
+++ b/chat_ui.py
@@ -1,0 +1,62 @@
+"""Common chat UI helpers."""
+
+import streamlit as st
+from modern_ui import inject_modern_styles
+
+inject_modern_styles()
+
+
+def translate_text(text: str, target_lang: str = "en") -> str:
+    """Translate ``text`` to ``target_lang`` if possible."""
+    if not text:
+        return ""
+    try:
+        from deep_translator import GoogleTranslator
+
+        return GoogleTranslator(source="auto", target=target_lang).translate(text)
+    except Exception:
+        return text
+
+
+def render_chat_interface() -> None:
+    """Simple real-time chat using session state."""
+    st.session_state.setdefault("chat_messages", [])
+    language = st.session_state.get("chat_lang", "en")
+    language = st.selectbox("Language", ["en", "es", "ko"], key="chat_lang")
+
+    chat_container = st.container()
+    for entry in st.session_state.chat_messages:
+        chat_container.markdown(
+            f"**{entry['user']}**: {translate_text(entry['text'], language)}"
+        )
+
+    cols = st.columns([4, 1])
+    with cols[0]:
+        msg = st.text_input("Message", key="chat_input")
+    with cols[1]:
+        if st.button("Send", key="send_chat") and msg:
+            st.session_state.chat_messages.append({"user": "You", "text": msg})
+            st.session_state.chat_input = ""
+            st.experimental_rerun()
+
+
+def render_video_call_controls() -> None:
+    """Placeholder video call controls."""
+    if st.button("Start Video Call", key="start_video"):
+        st.toast("Video call placeholder. Integration with WebRTC pending.")
+        st.empty()
+
+
+def render_voice_chat_controls() -> None:
+    """Placeholder voice call controls."""
+    if st.button("Start Voice Call", key="start_voice"):
+        st.toast("Voice call placeholder. Audio streaming integration pending.")
+        st.empty()
+
+
+__all__ = [
+    "translate_text",
+    "render_chat_interface",
+    "render_video_call_controls",
+    "render_voice_chat_controls",
+]

--- a/frontend/ui_layout.py
+++ b/frontend/ui_layout.py
@@ -28,6 +28,7 @@ from pathlib import Path
 import os
 import streamlit as st
 from modern_ui_components import SIDEBAR_STYLES
+from profile_card import render_profile_card as _render_profile_card
 
 try:
     from utils.paths import ROOT_DIR, PAGES_DIR
@@ -55,21 +56,15 @@ def sidebar_container() -> st.delta_generator.DeltaGenerator:
 
 
 def render_profile_card(username: str, avatar_url: str) -> None:
-    """Render a compact profile card with an environment badge."""
-    env = os.getenv("APP_ENV", "development").lower()
-    badge = "🚀 Production" if env.startswith("prod") else "🧪 Development"
-    st.markdown(
-        f"""
-        <div class='glass-card' style='display:flex;align-items:center;gap:0.5rem;'>
-            <img src="{avatar_url}" alt="avatar" width="48" style="border-radius:50%;" />
-            <div>
-                <strong>{username}</strong><br/>
-                <span style='font-size:0.85rem'>{badge}</span>
-            </div>
-        </div>
-        """,
-        unsafe_allow_html=True,
-    )
+    """Proxy to :func:`profile_card.render_profile_card` using this module's ``st``."""
+    import profile_card
+
+    original = profile_card.st
+    profile_card.st = st
+    try:
+        _render_profile_card(username, avatar_url)
+    finally:
+        profile_card.st = original
 
 
 def render_top_bar() -> None:

--- a/profile_card.py
+++ b/profile_card.py
@@ -1,0 +1,25 @@
+"""Minimal profile card component used across pages."""
+
+import os
+import streamlit as st
+
+
+def render_profile_card(username: str, avatar_url: str) -> None:
+    """Render a compact profile card with an environment badge."""
+    env = os.getenv("APP_ENV", "development").lower()
+    badge = "🚀 Production" if env.startswith("prod") else "🧪 Development"
+    st.markdown(
+        f"""
+        <div class='glass-card' style='display:flex;align-items:center;gap:0.5rem;'>
+            <img src="{avatar_url}" alt="avatar" width="48" style="border-radius:50%;" />
+            <div>
+                <strong>{username}</strong><br/>
+                <span style='font-size:0.85rem'>{badge}</span>
+            </div>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
+__all__ = ["render_profile_card"]

--- a/transcendental_resonance_frontend/pages/chat.py
+++ b/transcendental_resonance_frontend/pages/chat.py
@@ -7,62 +7,13 @@ import streamlit as st
 from modern_ui import inject_modern_styles
 from streamlit_helpers import safe_container, header
 from status_indicator import render_status_icon
+from chat_ui import (
+    render_chat_interface,
+    render_video_call_controls,
+    render_voice_chat_controls,
+)
 
 inject_modern_styles()
-
-
-### TRANSLATION_LOGIC
-
-def translate_text(text: str, target_lang: str = "en") -> str:
-    """Translate ``text`` to ``target_lang`` if possible."""
-    if not text:
-        return ""
-    try:
-        from deep_translator import GoogleTranslator
-
-        return GoogleTranslator(source="auto", target=target_lang).translate(text)
-    except Exception:
-        return text
-
-
-### CHAT_INTERFACE
-
-def render_chat_interface() -> None:
-    """Simple real-time chat using session state."""
-    st.session_state.setdefault("chat_messages", [])
-    language = st.session_state.get("chat_lang", "en")
-    language = st.selectbox("Language", ["en", "es", "ko"], key="chat_lang")
-
-    chat_container = st.container()
-    for entry in st.session_state.chat_messages:
-        chat_container.markdown(f"**{entry['user']}**: {translate_text(entry['text'], language)}")
-
-    cols = st.columns([4, 1])
-    with cols[0]:
-        msg = st.text_input("Message", key="chat_input")
-    with cols[1]:
-        if st.button("Send", key="send_chat") and msg:
-            st.session_state.chat_messages.append({"user": "You", "text": msg})
-            st.session_state.chat_input = ""
-            st.experimental_rerun()
-
-
-### VIDEO_CALL
-
-def render_video_call_controls() -> None:
-    """Placeholder video call controls."""
-    if st.button("Start Video Call", key="start_video"):
-        st.toast("Video call placeholder. Integration with WebRTC pending.")
-        st.empty()
-
-
-### VOICE_CHAT
-
-def render_voice_chat_controls() -> None:
-    """Placeholder voice call controls."""
-    if st.button("Start Voice Call", key="start_voice"):
-        st.toast("Voice call placeholder. Audio streaming integration pending.")
-        st.empty()
 
 
 def main(main_container=None) -> None:

--- a/transcendental_resonance_frontend/pages/messages_center.py
+++ b/transcendental_resonance_frontend/pages/messages_center.py
@@ -95,7 +95,7 @@ def main(main_container=None) -> None:
                 st.session_state.msg_input = ""
                 st.experimental_rerun()
         st.divider()
-        from .chat import (
+        from chat_ui import (
             render_video_call_controls,
             render_voice_chat_controls,
         )


### PR DESCRIPTION
## Summary
- move chat helpers into new `chat_ui` module
- create `profile_card` module for compact profile badge
- import `render_profile_card` from new module in `ui_layout`
- use `chat_ui` helpers in chat-related pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ae715f2188320a87146bfb02b8651