### PR TITLE
Add active user helper for pages

### DIFF
--- a/social_tabs.py
+++ b/social_tabs.py
@@ -3,7 +3,7 @@
 # Legal & Ethical Safeguards
 import asyncio
 import streamlit as st
-from streamlit_helpers import alert, safe_container, header
+from streamlit_helpers import alert, safe_container, header, ensure_active_user
 
 
 def safe_markdown(text: str, **kwargs) -> None:
@@ -21,6 +21,8 @@ try:
 except Exception:  # pragma: no cover - optional
     SessionLocal = None  # type: ignore
     Harmonizer = None  # type: ignore
+
+ensure_active_user()
 
 
 def _run_async(coro):

--- a/streamlit_helpers.py
+++ b/streamlit_helpers.py
@@ -360,6 +360,11 @@ def inject_global_styles() -> None:
     inject_modern_styles()
 
 
+def ensure_active_user() -> str:
+    """Ensure ``st.session_state['active_user']`` is initialized."""
+    return st.session_state.setdefault("active_user", "guest")
+
+
 # ──────────────────────────────────────────────────────────────────────────────
 # Public symbols
 # ──────────────────────────────────────────────────────────────────────────────
@@ -375,5 +380,6 @@ __all__ = [
     "tabs_nav",
     "inject_global_styles",
     "inject_instagram_styles",
+    "ensure_active_user",
     "BOX_CSS",
 ]

--- a/transcendental_resonance_frontend/pages/profile.py
+++ b/transcendental_resonance_frontend/pages/profile.py
@@ -5,7 +5,7 @@
 
 import streamlit as st
 from modern_ui import inject_modern_styles
-from streamlit_helpers import safe_container, header
+from streamlit_helpers import safe_container, header, ensure_active_user
 from api_key_input import render_api_key_ui
 from social_tabs import _load_profile
 from transcendental_resonance_frontend.ui.profile_ui import (
@@ -62,6 +62,7 @@ def _fetch_social(username: str) -> tuple[dict, dict]:
     return followers or {}, following or {}
 
 inject_modern_styles()
+ensure_active_user()
 
 
 def _render_profile(username: str) -> None:


### PR DESCRIPTION
## Summary
- add `ensure_active_user()` to `streamlit_helpers`
- use the new helper in `profile.py` and `social_tabs.py`
- export the helper via `__all__`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ae72c68f483208b909504dc892b24