### PR TITLE
Add guest and demo users

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -1840,13 +1840,39 @@ def ensure_database_exists() -> bool:
                 conn.execute(
                     text(
                         """
-                        INSERT INTO harmonizers
+                        INSERT OR IGNORE INTO harmonizers
                             (username, email, hashed_password, bio,
                              is_active, is_admin, is_genesis, consent_given)
                         VALUES
                             ('admin', 'admin@supernova.dev', 'hashed_password_here',
                              'Default admin user for superNova_2177',
                              1, 1, 1, 1);
+                        """
+                    )
+                )
+                conn.execute(
+                    text(
+                        """
+                        INSERT OR IGNORE INTO harmonizers
+                            (username, email, hashed_password, bio,
+                             is_active, is_admin, is_genesis, consent_given)
+                        VALUES
+                            ('guest', 'guest@supernova.dev', 'hashed_password_here',
+                             'Guest user',
+                             1, 0, 0, 1);
+                        """
+                    )
+                )
+                conn.execute(
+                    text(
+                        """
+                        INSERT OR IGNORE INTO harmonizers
+                            (username, email, hashed_password, bio,
+                             is_active, is_admin, is_genesis, consent_given)
+                        VALUES
+                            ('demo_user', 'demo@supernova.dev', 'hashed_password_here',
+                             'Demo profile for showcasing features',
+                             1, 0, 0, 1);
                         """
                     )
                 )


### PR DESCRIPTION
## Summary
- create demo and guest users when initializing the database
- insert default users with `INSERT OR IGNORE`
- update unit test to verify all default users

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ae72d57dc8320bf185aec4190bda8