### PR TITLE
Add light theme helper

### DIFF
--- a/modern_ui.py
+++ b/modern_ui.py
@@ -65,6 +65,28 @@ def inject_modern_styles() -> None:
     st.markdown(SIDEBAR_STYLES, unsafe_allow_html=True)
     st.session_state["modern_styles_injected"] = True
 
+
+def inject_light_theme() -> None:
+    """Inject a minimalist light theme for broad compatibility."""
+
+    if st.session_state.get("_light_theme_injected"):
+        logger.debug("Light theme already injected; skipping")
+        return
+
+    css = """
+    <style>
+    body, .stApp {
+        background: #ffffff;
+        font-family: Helvetica, Arial, sans-serif;
+    }
+    button, .stButton > button {
+        border-radius: 0.5rem;
+    }
+    </style>
+    """
+    st.markdown(css, unsafe_allow_html=True)
+    st.session_state["_light_theme_injected"] = True
+
 def inject_premium_styles() -> None:
     """Backward compatible alias for :func:`inject_modern_styles`."""
     inject_modern_styles()
@@ -228,6 +250,7 @@ def close_card_container() -> None:
 __all__ = [
     "render_lottie_animation",
     "inject_modern_styles",
+    "inject_light_theme",
     "inject_premium_styles",
     "render_modern_header",
     "render_validation_card",

--- a/ui.py
+++ b/ui.py
@@ -268,16 +268,19 @@ from streamlit_helpers import (
     safe_container,
     render_post_card,
     render_instagram_grid,
-    inject_instagram_styles,
 )
 
 try:
     from modern_ui import (
         inject_modern_styles,
+        inject_light_theme,
         render_stats_section,
     )
 except Exception:  # pragma: no cover - gracefully handle missing/invalid module
     def inject_modern_styles(*_a, **_k):
+        return None
+
+    def inject_light_theme(*_a, **_k):
         return None
 
     def render_stats_section(*_a, **_k):
@@ -1425,9 +1428,9 @@ def main() -> None:
         # Older Streamlit builds (or re-runs) may raise – that’s OK.
         pass
 
-    # Lightweight “Instagram-style” aesthetic (harmless if helper absent)
+    # Simple light theme fallback
     try:
-        inject_instagram_styles()
+        inject_light_theme()
     except Exception:  # pragma: no cover
         pass
 
@@ -1477,7 +1480,7 @@ def main() -> None:
         return
 
     try:
-        inject_instagram_styles()
+        inject_light_theme()
 
         render_top_bar()
         # Inject keyboard shortcuts for quick navigation


### PR DESCRIPTION
## Summary
- add `inject_light_theme` helper for a minimalist bright look
- export new helper from `modern_ui`
- use the light theme in `ui.py` instead of the old Instagram style

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ae72dfa008320a363e109b8208964