### PR TITLE
Add username and reactions to post cards

### DIFF
--- a/streamlit_helpers.py
+++ b/streamlit_helpers.py
@@ -161,21 +161,45 @@ def header(title: str, *, layout: str = "centered") -> None:
 def render_post_card(post_data: dict[str, Any]) -> None:
     """Instagram-style post card that degrades gracefully."""
     img = post_data.get("image", "")
-    text = post_data.get("text", "")
+    caption = post_data.get("text", "")
     likes = post_data.get("likes", 0)
+    user = (
+        post_data.get("user")
+        or post_data.get("username")
+        or post_data.get("author")
+        or ""
+    )
 
     if ui is None:
+        parts = [
+            "<div class='sn-card' style='background:#fff;"
+            "padding:1rem;margin-bottom:1rem;"
+            "border-radius:12px;box-shadow:0 2px 6px rgba(0,0,0,0.1);'>"
+        ]
         if img:
-            st.image(img, use_column_width=True)
-        st.write(text)
-        st.caption(f"❤️ {likes}")
+            parts.append(
+                f"<img src='{html.escape(img)}' style='width:100%;"
+                "border-radius:8px;margin-bottom:.5rem;'/>"
+            )
+        if user:
+            parts.append(f"<strong>{html.escape(user)}</strong>")
+        if caption:
+            parts.append(
+                f"<p style='margin:0.25rem 0'>{html.escape(caption)}</p>"
+            )
+        parts.append(f"<div style='font-size:1.2rem;'>❤️ {likes} 🔁 💬</div>")
+        parts.append("</div>")
+        st.markdown("".join(parts), unsafe_allow_html=True)
         return
 
     with ui.card().classes("w-full p-4 mb-4"):
         if img:
             ui.image(img).classes("rounded-md mb-2 w-full")
-        ui.element("p", text).classes("mb-1")
-        ui.badge(f"❤️ {likes}").classes("bg-pink-500")
+        if user:
+            ui.element("strong", user).classes("block mb-1")
+        if caption:
+            ui.element("p", caption).classes("mb-1 text-sm")
+        ui.element("div", f"❤️ {likes} 🔁 💬").classes("text-lg")
 
 
 def render_instagram_grid(posts: list[dict[str, Any]], *, cols: int = 3) -> None:

--- a/tests/test_render_post_card.py
+++ b/tests/test_render_post_card.py
@@ -18,7 +18,7 @@ import streamlit_helpers as sh
 
 def test_render_post_card_uses_ui_components(monkeypatch):
     card_called = {}
-    badge_called = {}
+    captured = []
 
     class DummyCard:
         def __enter__(self):
@@ -30,39 +30,36 @@ def test_render_post_card_uses_ui_components(monkeypatch):
             card_called['cls'] = cls
             return self
 
-    def dummy_badge(text):
-        badge_called['text'] = text
-        return types.SimpleNamespace(classes=lambda cls: badge_called.setdefault('cls', cls))
-
     dummy_ui = types.SimpleNamespace(
         card=lambda: DummyCard(),
-        image=lambda *a, **k: types.SimpleNamespace(classes=lambda *b, **c: None),
-        element=lambda *a, **k: types.SimpleNamespace(classes=lambda *b, **c: None),
-        badge=dummy_badge,
+        image=lambda img, **k: types.SimpleNamespace(classes=lambda cls: captured.append(("img", img))),
+        element=lambda tag, content: types.SimpleNamespace(classes=lambda cls: captured.append((tag, content))),
     )
 
     monkeypatch.setattr(sh, "ui", dummy_ui)
     monkeypatch.setattr(sh, "st", types.SimpleNamespace())
 
-    sh.render_post_card({"text": "Hello", "likes": 4})
+    sh.render_post_card({"image": "pic.png", "text": "Hello", "likes": 4, "user": "alice"})
 
     assert card_called.get('entered')
-    assert badge_called.get('text') == "❤️ 4"
+    assert ("img", "pic.png") in captured
+    assert ("div", "❤️ 4 🔁 💬") in captured
 
 
 def test_render_post_card_plain_streamlit(monkeypatch):
     captured = {}
     dummy_st = types.SimpleNamespace(
-        image=lambda img, use_column_width=True: captured.setdefault("image", img),
-        write=lambda text: captured.setdefault("write", text),
-        caption=lambda text: captured.setdefault("caption", text),
+        markdown=lambda html, unsafe_allow_html=True: captured.setdefault("html", html),
     )
 
     monkeypatch.setattr(sh, "ui", None)
     monkeypatch.setattr(sh, "st", dummy_st)
 
-    sh.render_post_card({"image": "img.png", "text": "Hi", "likes": 7})
+    sh.render_post_card({"image": "img.png", "text": "Hi", "likes": 7, "user": "bob"})
 
-    assert captured["image"] == "img.png"
-    assert captured["write"] == "Hi"
-    assert captured["caption"] == "❤️ 7"
+    html_out = captured["html"]
+    assert "img.png" in html_out
+    assert "Hi" in html_out
+    assert "bob" in html_out
+    assert "❤️ 7" in html_out
+    assert "border-radius" in html_out


### PR DESCRIPTION
## Summary
- expand `render_post_card` to show usernames, captions and emoji reactions
- output styled HTML fallback when shadcn-ui is unavailable
- update tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ae72eb9148320ad411740e8a8d705