### PR TITLE
Add feed renderer and sample page

### DIFF
--- a/feed_renderer.py
+++ b/feed_renderer.py
@@ -1,0 +1,17 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+"""Utilities for displaying a simple mock social feed."""
+
+from streamlit_helpers import render_post_card
+
+
+def render_mock_feed() -> None:
+    """Render a short feed of sample posts using ``render_post_card``."""
+    sample_posts = [
+        ("alice", "https://placekitten.com/400/300", "Cute kitten!"),
+        ("bob", "https://placebear.com/400/300", "Bear with me."),
+        ("carol", "https://placekitten.com/401/301", "Another kitty."),
+    ]
+    for username, image, caption in sample_posts:
+        render_post_card({"user": username, "image": image, "text": caption})

--- a/pages/feed.py
+++ b/pages/feed.py
@@ -1,0 +1,8 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
+from transcendental_resonance_frontend.pages.feed import main
+
+if __name__ == "__main__":
+    main()

--- a/transcendental_resonance_frontend/pages/__init__.py
+++ b/transcendental_resonance_frontend/pages/__init__.py
@@ -8,5 +8,6 @@ __all__ = [
     "chat",
     "social",
     "profile",
+    "feed",
 ]
 

--- a/transcendental_resonance_frontend/pages/feed.py
+++ b/transcendental_resonance_frontend/pages/feed.py
@@ -1,0 +1,23 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+"""Simple page showcasing a mock social feed."""
+
+import streamlit as st
+from modern_ui import inject_modern_styles
+from streamlit_helpers import safe_container
+from feed_renderer import render_mock_feed
+
+inject_modern_styles()
+
+
+def main(main_container=None) -> None:
+    """Render the mock feed within ``main_container``."""
+    container = main_container if main_container is not None else st
+    with safe_container(container):
+        render_mock_feed()
+
+
+def render() -> None:
+    """Wrapper to keep page loading consistent."""
+    main()


### PR DESCRIPTION
## Summary
- add `feed_renderer` for mock social feed posts
- expose new feed page under `transcendental_resonance_frontend/pages`
- hook feed page into page registry
- add stub page in root `pages/`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ae731b4f483209f93650489f8cbab