### PR TITLE
Ensure active_user defaults

### DIFF
--- a/social_tabs.py
+++ b/social_tabs.py
@@ -54,6 +54,7 @@ def render_social_tab(main_container=None) -> None:
     if main_container is None:
         main_container = st
 
+    st.session_state.setdefault("active_user", "guest")
     container_ctx = safe_container(main_container)
     with container_ctx:
         header("Friends & Followers")

--- a/transcendental_resonance_frontend/pages/profile.py
+++ b/transcendental_resonance_frontend/pages/profile.py
@@ -96,6 +96,7 @@ def main(main_container=None) -> None:
     if main_container is None:
         main_container = st
 
+    st.session_state.setdefault("active_user", "guest")
     container_ctx = safe_container(main_container)
     with container_ctx:
         # Header with status icon


### PR DESCRIPTION
## Summary
- initialize `active_user` session key in social tabs
- initialize `active_user` session key in the Transcendental Resonance profile page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ae74398e4832086bf778f82089f87