### PR TITLE
Modularize profile and chat UI

### DIFF
--- a/transcendental_resonance_frontend/pages/messages.py
+++ b/transcendental_resonance_frontend/pages/messages.py
@@ -1,73 +1,17 @@
 # STRICTLY A SOCIAL MEDIA PLATFORM
 # Intellectual Property & Artistic Inspiration
 # Legal & Ethical Safeguards
-"""Unified messages and chat center."""
+"""Messages and chat page wrapping reusable chat UI."""
+
+from __future__ import annotations
 
 import streamlit as st
-from modern_ui import inject_modern_styles
-from streamlit_helpers import safe_container, header
 
-inject_modern_styles()
-
-DUMMY_CONVOS = [
-    {"user": "Alice", "preview": "Hey there!"},
-    {"user": "Bob", "preview": "Let's catch up."},
-]
-
-
-def _init_state() -> None:
-    st.session_state.setdefault("conversations", DUMMY_CONVOS)
-    st.session_state.setdefault(
-        "messages", {c["user"]: [] for c in st.session_state["conversations"]}
-    )
-    if "active_chat" not in st.session_state:
-        st.session_state["active_chat"] = DUMMY_CONVOS[0]["user"] if DUMMY_CONVOS else ""
-
-
-def _render_conversation_list() -> None:
-    users = [c["user"] for c in st.session_state["conversations"]]
-    active = st.session_state.get("active_chat")
-    if active not in users and users:
-        active = users[0]
-    col1, col2 = st.columns([1, 3])
-    with col1:
-        selected = st.radio("", users, index=users.index(active)) if users else ""
-        st.session_state["active_chat"] = selected
-    with col2:
-        st.write("Recent")
-        if users:
-            st.write(st.session_state["conversations"][users.index(selected)]["preview"])
-
-
-def _render_chat_panel(user: str) -> None:
-    header(f"Chat with {user}")
-    msgs = st.session_state["messages"].setdefault(user, [])
-    for msg in msgs:
-        st.write(f"{msg['sender']}: {msg['text']}")
-    txt = st.text_input("Message", key="msg_input")
-    if st.button("Send", key="send_btn") and txt:
-        msgs.append({"sender": "You", "text": txt})
-        st.session_state.msg_input = ""
-        st.experimental_rerun()
-    if st.button("Start Video Call", key="video_call"):
-        st.toast("Video call integration pending")
+from transcendental_resonance_frontend.ui.chat_ui import render_chat_ui
 
 
 def main(main_container=None) -> None:
-    if main_container is None:
-        main_container = st
-    _init_state()
-    container_ctx = safe_container(main_container)
-    with container_ctx:
-        header("✉️ Messages")
-        if not st.session_state["conversations"]:
-            st.info("No conversations yet")
-            return
-        user = st.session_state.get("active_chat")
-        _render_conversation_list()
-        st.divider()
-        if user:
-            _render_chat_panel(user)
+    render_chat_ui(main_container)
 
 
 def render() -> None:

--- a/transcendental_resonance_frontend/pages/profile.py
+++ b/transcendental_resonance_frontend/pages/profile.py
@@ -8,9 +8,9 @@ from modern_ui import inject_modern_styles
 from streamlit_helpers import safe_container, header
 from api_key_input import render_api_key_ui
 from social_tabs import _load_profile
-from transcendental_resonance_frontend.ui.profile_ui import (
+from transcendental_resonance_frontend.ui.profile_card import (
     DEFAULT_USER,
-    render_profile,
+    render_profile_card,
 )
 from status_indicator import render_status_icon
 
@@ -78,7 +78,7 @@ def _render_profile(username: str) -> None:
             }
         except Exception as exc:  # pragma: no cover - runtime fetch may fail
             st.warning(f"Profile fetch failed: {exc}, using placeholder")
-    render_profile(data)
+    render_profile_card(data)
     if dispatch_route is not None and st.button("Follow/Unfollow", key="follow"):
         with st.spinner("Updating..."):
             try:
@@ -144,7 +144,7 @@ def main(main_container=None) -> None:
             "profile_data",
             {**DEFAULT_USER, "username": username},
         )
-        render_profile(data)
+        render_profile_card(data)
 
 
 

--- a/transcendental_resonance_frontend/ui/__init__.py
+++ b/transcendental_resonance_frontend/ui/__init__.py
@@ -1,0 +1,10 @@
+"""UI helper exports."""
+from .profile_card import render_profile_card, inject_profile_styles, DEFAULT_USER
+from .chat_ui import render_chat_ui
+
+__all__ = [
+    "render_profile_card",
+    "inject_profile_styles",
+    "DEFAULT_USER",
+    "render_chat_ui",
+]

--- a/transcendental_resonance_frontend/ui/chat_ui.py
+++ b/transcendental_resonance_frontend/ui/chat_ui.py
@@ -1,0 +1,80 @@
+"""Reusable chat UI components."""
+from __future__ import annotations
+
+import streamlit as st
+from modern_ui import inject_modern_styles
+from streamlit_helpers import safe_container, header
+
+inject_modern_styles()
+
+DUMMY_CONVOS = [
+    {"user": "Alice", "preview": "Hey there!"},
+    {"user": "Bob", "preview": "Let's catch up."},
+]
+
+
+def init_chat_state() -> None:
+    """Initialize session state for chat."""
+    st.session_state.setdefault("conversations", DUMMY_CONVOS)
+    st.session_state.setdefault(
+        "messages", {c["user"]: [] for c in st.session_state["conversations"]}
+    )
+    if "active_chat" not in st.session_state:
+        st.session_state["active_chat"] = DUMMY_CONVOS[0]["user"] if DUMMY_CONVOS else ""
+
+
+def render_conversation_list() -> None:
+    """Display the list of conversations and allow selection."""
+    users = [c["user"] for c in st.session_state["conversations"]]
+    active = st.session_state.get("active_chat")
+    if active not in users and users:
+        active = users[0]
+    col1, col2 = st.columns([1, 3])
+    with col1:
+        selected = st.radio("", users, index=users.index(active)) if users else ""
+        st.session_state["active_chat"] = selected
+    with col2:
+        st.write("Recent")
+        if users:
+            st.write(st.session_state["conversations"][users.index(selected)]["preview"])
+
+
+def render_chat_panel(user: str) -> None:
+    """Render chat messages and input box for ``user``."""
+    header(f"Chat with {user}")
+    msgs = st.session_state["messages"].setdefault(user, [])
+    for msg in msgs:
+        st.write(f"{msg['sender']}: {msg['text']}")
+    txt = st.text_input("Message", key="msg_input")
+    if st.button("Send", key="send_btn") and txt:
+        msgs.append({"sender": "You", "text": txt})
+        st.session_state.msg_input = ""
+        st.experimental_rerun()
+    if st.button("Start Video Call", key="video_call"):
+        st.toast("Video call integration pending")
+
+
+def render_chat_ui(main_container=None) -> None:
+    """Render the full chat UI."""
+    if main_container is None:
+        main_container = st
+    init_chat_state()
+    container_ctx = safe_container(main_container)
+    with container_ctx:
+        header("✉️ Messages")
+        if not st.session_state["conversations"]:
+            st.info("No conversations yet")
+            return
+        user = st.session_state.get("active_chat")
+        render_conversation_list()
+        st.divider()
+        if user:
+            render_chat_panel(user)
+
+
+__all__ = [
+    "render_chat_ui",
+    "init_chat_state",
+    "render_conversation_list",
+    "render_chat_panel",
+]

--- a/transcendental_resonance_frontend/ui/profile_card.py
+++ b/transcendental_resonance_frontend/ui/profile_card.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import streamlit as st
+
+_PROFILE_CSS_PATH = Path(__file__).resolve().parent / "profile_theme.css"
+
+DEFAULT_USER = {
+    "username": "JaneDoe",
+    "bio": "Dreaming across dimensions and sharing vibes.",
+    "followers": 128,
+    "following": 75,
+    "posts": 34,
+    "avatar_url": "https://placehold.co/150x150",  # placeholder avatar
+    "website": "https://example.com",
+    "location": "Wonderland",
+    "feed": [f"https://placehold.co/300x300?text=Post+{i}" for i in range(1, 7)],
+}
+
+
+def inject_profile_styles() -> None:
+    """Load profile-specific CSS styles if not already injected."""
+    if st.session_state.get("_profile_css_injected"):
+        return
+    try:
+        css = _PROFILE_CSS_PATH.read_text()
+        st.markdown(f"<style>{css}</style>", unsafe_allow_html=True)
+        st.session_state["_profile_css_injected"] = True
+    except Exception as exc:  # pragma: no cover - file may be missing
+        st.warning(f"Failed to load profile styles: {exc}")
+
+
+def _stats_item(label: str, value: int | str) -> str:
+    return f"<div class='item'><strong>{value}</strong><span>{label}</span></div>"
+
+
+def render_profile_card(user_data: Optional[Dict[str, object]] = None) -> None:
+    """Render a visual profile card with a small gallery."""
+    inject_profile_styles()
+    data = user_data or DEFAULT_USER
+
+    feed: List[str] = list(data.get("feed", []))
+    stats_html = "".join(
+        [
+            _stats_item("Followers", data.get("followers", 0)),
+            _stats_item("Following", data.get("following", 0)),
+            _stats_item("Posts", data.get("posts", 0)),
+        ]
+    )
+
+    with st.container():
+        st.markdown("<div class='profile-container'>", unsafe_allow_html=True)
+        col1, col2 = st.columns([1, 3])
+        with col1:
+            st.markdown(
+                f"<img class='profile-pic' src='{data.get('avatar_url')}' alt='avatar'>",
+                unsafe_allow_html=True,
+            )
+        with col2:
+            st.markdown(
+                f"<p class='username'>{data.get('username')}</p>",
+                unsafe_allow_html=True,
+            )
+            bio = data.get("bio")
+            if bio:
+                st.markdown(f"<p class='bio'>{bio}</p>", unsafe_allow_html=True)
+            st.markdown(f"<div class='stats'>{stats_html}</div>", unsafe_allow_html=True)
+            website = data.get("website")
+            location = data.get("location")
+            extra = []
+            if website:
+                extra.append(
+                    f"<span>🔗 <a href='{website}' target='_blank'>{website}</a></span>"
+                )
+            if location:
+                extra.append(f"<span>📍 {location}</span>")
+            if extra:
+                st.markdown("<div class='extra'>" + " | ".join(extra) + "</div>", unsafe_allow_html=True)
+
+        if feed:
+            st.markdown("<div class='feed-grid'>", unsafe_allow_html=True)
+            for src in feed:
+                st.markdown(
+                    f"<img src='{src}' class='feed-thumb' alt='feed item'>",
+                    unsafe_allow_html=True,
+                )
+            st.markdown("</div>", unsafe_allow_html=True)
+        st.markdown("</div>", unsafe_allow_html=True)
+
+
+__all__ = ["render_profile_card", "inject_profile_styles", "DEFAULT_USER"]

--- a/transcendental_resonance_frontend/ui/profile_ui.py
+++ b/transcendental_resonance_frontend/ui/profile_ui.py
@@ -1,101 +1,18 @@
-# STRICTLY A SOCIAL MEDIA PLATFORM
-# Intellectual Property & Artistic Inspiration
-# Legal & Ethical Safeguards
-"""Modern Streamlit profile component resembling popular social apps."""
-
+"""Backwards compatibility wrapper for profile card UI."""
 from __future__ import annotations
 
-from pathlib import Path
-from typing import Dict, List, Optional
+from .profile_card import (
+    DEFAULT_USER,
+    inject_profile_styles,
+    render_profile_card,
+)
 
-import streamlit as st
+# Alias for old function name
+render_profile = render_profile_card
 
-
-_PROFILE_CSS_PATH = Path(__file__).resolve().parent / "profile_theme.css"
-
-
-DEFAULT_USER = {
-    "username": "JaneDoe",
-    "bio": "Dreaming across dimensions and sharing vibes.",
-    "followers": 128,
-    "following": 75,
-    "posts": 34,
-    "avatar_url": "https://placehold.co/150x150",  # placeholder avatar
-    "website": "https://example.com",
-    "location": "Wonderland",
-    "feed": [
-        f"https://placehold.co/300x300?text=Post+{i}" for i in range(1, 7)
-    ],
-}
-
-
-def inject_profile_styles() -> None:
-    """Load profile-specific CSS styles if not already injected."""
-    if st.session_state.get("_profile_css_injected"):
-        return
-
-    try:
-        css = _PROFILE_CSS_PATH.read_text()
-        st.markdown(f"<style>{css}</style>", unsafe_allow_html=True)
-        st.session_state["_profile_css_injected"] = True
-    except Exception as exc:  # pragma: no cover - file may be missing
-        st.warning(f"Failed to load profile styles: {exc}")
-
-
-def _stats_item(label: str, value: int | str) -> str:
-    return f"<div class='item'><strong>{value}</strong><span>{label}</span></div>"
-
-
-def render_profile(user_data: Optional[Dict[str, object]] = None) -> None:
-    """Render a visual profile card with a small gallery."""
-    inject_profile_styles()
-    data = user_data or DEFAULT_USER
-
-    feed: List[str] = list(data.get("feed", []))
-    stats_html = "".join(
-        [
-            _stats_item("Followers", data.get("followers", 0)),
-            _stats_item("Following", data.get("following", 0)),
-            _stats_item("Posts", data.get("posts", 0)),
-        ]
-    )
-
-    with st.container():
-        st.markdown("<div class='profile-container'>", unsafe_allow_html=True)
-        col1, col2 = st.columns([1, 3])
-        with col1:
-            st.markdown(
-                f"<img class='profile-pic' src='{data.get('avatar_url')}' alt='avatar'>",
-                unsafe_allow_html=True,
-            )
-        with col2:
-            st.markdown(
-                f"<p class='username'>{data.get('username')}</p>",
-                unsafe_allow_html=True,
-            )
-            bio = data.get("bio")
-            if bio:
-                st.markdown(f"<p class='bio'>{bio}</p>", unsafe_allow_html=True)
-            st.markdown(f"<div class='stats'>{stats_html}</div>", unsafe_allow_html=True)
-            website = data.get("website")
-            location = data.get("location")
-            extra = []
-            if website:
-                extra.append(f"<span>🔗 <a href='{website}' target='_blank'>{website}</a></span>")
-            if location:
-                extra.append(f"<span>📍 {location}</span>")
-            if extra:
-                st.markdown("<div class='extra'>" + " | ".join(extra) + "</div>", unsafe_allow_html=True)
-
-        if feed:
-            st.markdown("<div class='feed-grid'>", unsafe_allow_html=True)
-            for src in feed:
-                st.markdown(
-                    f"<img src='{src}' class='feed-thumb' alt='feed item'>",
-                    unsafe_allow_html=True,
-                )
-            st.markdown("</div>", unsafe_allow_html=True)
-        st.markdown("</div>", unsafe_allow_html=True)
-
-
-__all__ = ["render_profile", "inject_profile_styles"]
+__all__ = [
+    "render_profile_card",
+    "render_profile",
+    "inject_profile_styles",
+    "DEFAULT_USER",
+]


### PR DESCRIPTION
## Summary
- create `profile_card` and move rendering logic there
- expose new `chat_ui` module for messages page
- update profile and messages pages to use new components
- keep backwards compatibility via `profile_ui`
- centralize UI exports in `transcendental_resonance_frontend.ui`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ae7327b488320bb5e252f5d02d1a0