### PR TITLE
Add guest and demo user seeds

### DIFF
--- a/tests/test_ui_database.py
+++ b/tests/test_ui_database.py
@@ -41,7 +41,10 @@ def load_ui(monkeypatch):
             count = cur.fetchone()[0]
             if count == 0:
                 conn.execute(
-                    "INSERT INTO harmonizers (username, email, is_admin) VALUES ('admin','admin@supernova.dev',1)"
+                    "INSERT INTO harmonizers (username, email, is_admin) VALUES"
+                    " ('admin','admin@supernova.dev',1),"
+                    " ('guest','guest@supernova.dev',0),"
+                    " ('demo_user','demo@supernova.dev',0)"
                 )
             conn.commit()
             conn.close()
@@ -80,8 +83,16 @@ def test_ensure_database_exists_creates_table_and_default_admin(tmp_path, monkey
     conn = sqlite3.connect(db_path)
     cur = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='harmonizers'")
     assert cur.fetchone() is not None
-    row = conn.execute("SELECT username, email, is_admin FROM harmonizers").fetchone()
-    assert row == ("admin", "admin@supernova.dev", 1)
+    rows = conn.execute(
+        "SELECT username, email, is_admin FROM harmonizers ORDER BY id"
+    ).fetchall()
+    assert (
+        ("admin", "admin@supernova.dev", 1)
+        in rows
+        and ("guest", "guest@supernova.dev", 0) in rows
+        and ("demo_user", "demo@supernova.dev", 0) in rows
+    )
+    assert len(rows) == 3
     conn.close()
 
 

--- a/ui.py
+++ b/ui.py
@@ -1846,7 +1846,13 @@ def ensure_database_exists() -> bool:
                         VALUES
                             ('admin', 'admin@supernova.dev', 'hashed_password_here',
                              'Default admin user for superNova_2177',
-                             1, 1, 1, 1);
+                             1, 1, 1, 1),
+                            ('guest', 'guest@supernova.dev', 'hashed_password_here',
+                             'Guest user account',
+                             1, 0, 0, 1),
+                            ('demo_user', 'demo@supernova.dev', 'hashed_password_here',
+                             'Demo user account',
+                             1, 0, 0, 1);
                         """
                     )
                 )


### PR DESCRIPTION
## Summary
- seed default guest and demo users in `ensure_database_exists`
- update database test helper and expectations for multiple users

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ae7461ed083208e09a625411c7ae9