### PR TITLE
Add mock feed renderer

### DIFF
--- a/feed_renderer.py
+++ b/feed_renderer.py
@@ -10,6 +10,7 @@ from typing import Iterable, Dict, Any
 import streamlit as st
 
 from streamlit_helpers import render_post_card
+from modern_ui_components import shadcn_card
 
 # Demo posts used when none are provided
 DEMO_POSTS: list[dict[str, Any]] = [
@@ -43,3 +44,17 @@ def render_feed(posts: Iterable[Dict[str, Any]] | None = None) -> None:
 
     for post in posts:
         render_post_card(post)
+
+
+def render_mock_feed(posts: list[dict]) -> None:
+    """Display ``posts`` using simple Shadcn cards."""
+    if not posts:
+        st.info("No posts to display")
+        return
+
+    for post in posts:
+        with shadcn_card():
+            if post.get("image"):
+                st.image(post["image"], use_column_width=True)
+            if post.get("text"):
+                st.markdown(post["text"])

--- a/transcendental_resonance_frontend/pages/profile.py
+++ b/transcendental_resonance_frontend/pages/profile.py
@@ -14,6 +14,7 @@ from transcendental_resonance_frontend.ui.profile_ui import (
     render_profile,
 )
 from status_indicator import render_status_icon
+from feed_renderer import render_mock_feed, DEMO_POSTS
 
 
 try:
@@ -150,6 +151,8 @@ def main(main_container=None) -> None:
             {**DEFAULT_USER, "username": username},
         )
         render_profile(data)
+        st.subheader("Recent Posts")
+        render_mock_feed(DEMO_POSTS)
 
 
 


### PR DESCRIPTION
## Summary
- implement `render_mock_feed` in `feed_renderer.py`
- show recent posts on profile page with `render_mock_feed`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688aee95259083208c2ebec8e0a90f75