### PR TITLE
Refactor feed and profile UI helpers

### DIFF
--- a/feed_renderer.py
+++ b/feed_renderer.py
@@ -5,36 +5,45 @@
 
 from __future__ import annotations
 
-from typing import Iterable, Dict, Any
+from typing import Iterable, Dict, Any, List
+from dataclasses import dataclass
+import random
 
 import streamlit as st
 
 from streamlit_helpers import render_post_card
 
-# Demo posts used when none are provided
-DEMO_POSTS: list[dict[str, Any]] = [
-    {
-        "image": "https://placekitten.com/400/300",
-        "text": "Look at this cute kitten!",
-        "likes": 5,
-    },
-    {
-        "image": "https://placekitten.com/500/300",
-        "text": "Another adorable cat appears.",
-        "likes": 3,
-    },
-    {
-        "image": "https://placekitten.com/450/300",
-        "text": "Cats everywhere!",
-        "likes": 8,
-    },
-]
+
+@dataclass
+class Post:
+    """Simple post structure for demo feeds."""
+
+    username: str
+    image: str
+    caption: str
+    reactions: Dict[str, int]
+
+
+def generate_demo_posts() -> List[Dict[str, Any]]:
+    """Return a few placeholder posts with random reactions."""
+    users = ["Alice", "Bob", "Carol"]
+    demo: List[Dict[str, Any]] = []
+    for idx, user in enumerate(users, start=1):
+        demo.append(
+            {
+                "username": user,
+                "image": f"https://placehold.co/600x400?text=Post+{idx}",
+                "text": f"Demo caption {idx}",
+                "likes": random.randint(1, 9),
+            }
+        )
+    return demo
 
 
 def render_feed(posts: Iterable[Dict[str, Any]] | None = None) -> None:
     """Render each post using :func:`render_post_card`."""
     if posts is None:
-        posts = DEMO_POSTS
+        posts = generate_demo_posts()
 
     posts = list(posts)
     if not posts:
@@ -43,3 +52,6 @@ def render_feed(posts: Iterable[Dict[str, Any]] | None = None) -> None:
 
     for post in posts:
         render_post_card(post)
+
+__all__ = ["render_feed", "generate_demo_posts", "Post"]
+

--- a/frontend/ui_layout.py
+++ b/frontend/ui_layout.py
@@ -28,6 +28,8 @@ from pathlib import Path
 import os
 import importlib
 import streamlit as st
+
+from profile_card import render_profile_card
 from modern_ui_components import SIDEBAR_STYLES
 
 try:
@@ -55,24 +57,6 @@ def main_container() -> st.delta_generator.DeltaGenerator:
 def sidebar_container() -> st.delta_generator.DeltaGenerator:
     """Return the sidebar container."""
     return st.sidebar
-
-
-def render_profile_card(username: str, avatar_url: str) -> None:
-    """Render a compact profile card with an environment badge."""
-    env = os.getenv("APP_ENV", "development").lower()
-    badge = "🚀 Production" if env.startswith("prod") else "🧪 Development"
-    st.markdown(
-        f"""
-        <div class='glass-card' style='display:flex;align-items:center;gap:0.5rem;'>
-            <img src="{avatar_url}" alt="avatar" width="48" style="border-radius:50%;" />
-            <div>
-                <strong>{username}</strong><br/>
-                <span style='font-size:0.85rem'>{badge}</span>
-            </div>
-        </div>
-        """,
-        unsafe_allow_html=True,
-    )
 
 
 def render_top_bar() -> None:

--- a/profile_card.py
+++ b/profile_card.py
@@ -1,0 +1,31 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+"""Reusable profile card component."""
+
+from __future__ import annotations
+
+import os
+import streamlit as st
+
+
+def render_profile_card(username: str, avatar_url: str) -> None:
+    """Render a compact profile card with an environment badge."""
+    env = os.getenv("APP_ENV", "development").lower()
+    badge = "🚀 Production" if env.startswith("prod") else "🧪 Development"
+    st.markdown(
+        f"""
+        <div class='glass-card' style='display:flex;align-items:center;gap:0.5rem;'>
+            <img src="{avatar_url}" alt="avatar" width="48" style="border-radius:50%;" />
+            <div>
+                <strong>{username}</strong><br/>
+                <span style='font-size:0.85rem'>{badge}</span>
+            </div>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
+__all__ = ["render_profile_card"]
+

--- a/tests/test_profile_card.py
+++ b/tests/test_profile_card.py
@@ -9,13 +9,13 @@ root = Path(__file__).resolve().parents[1]
 if str(root) not in sys.path:
     sys.path.insert(0, str(root))
 
-import frontend.ui_layout as ui_layout
+import profile_card
 
 
 def test_render_profile_card_includes_env_badge(monkeypatch):
     captured = {}
     dummy_st = types.SimpleNamespace(markdown=lambda html, **k: captured.setdefault('html', html))
-    monkeypatch.setattr(ui_layout, 'st', dummy_st)
+    monkeypatch.setattr(profile_card, 'st', dummy_st)
     monkeypatch.setenv('APP_ENV', 'production')
-    ui_layout.render_profile_card('User', 'avatar.png')
+    profile_card.render_profile_card('User', 'avatar.png')
     assert '🚀 Production' in captured.get('html', '')


### PR DESCRIPTION
## Summary
- refactor profile card into its own module for reuse
- add sample feed generator using `render_post_card`
- expose feed renderer and profile card helpers for other modules
- adjust tests for new helper locations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688aee29a4c883209fe3308feed09451