### PR TITLE
Ensure light theme on all pages

### DIFF
--- a/transcendental_resonance_frontend/pages/agents.py
+++ b/transcendental_resonance_frontend/pages/agents.py
@@ -1,8 +1,10 @@
 import streamlit as st
+from frontend.light_theme import inject_light_theme
 from modern_ui import inject_modern_styles
 from agent_ui import render_agent_insights_tab
 from streamlit_helpers import theme_selector
 
+inject_light_theme()
 inject_modern_styles()
 
 

--- a/transcendental_resonance_frontend/pages/chat.py
+++ b/transcendental_resonance_frontend/pages/chat.py
@@ -4,6 +4,7 @@
 """Chat page with text, video, and voice features."""
 
 import streamlit as st
+from frontend.light_theme import inject_light_theme
 from modern_ui import inject_modern_styles
 from streamlit_helpers import safe_container, header, theme_selector
 from status_indicator import render_status_icon
@@ -13,6 +14,7 @@ from chat_ui import (
     render_voice_chat_controls,
 )
 
+inject_light_theme()
 inject_modern_styles()
 
 

--- a/transcendental_resonance_frontend/pages/feed.py
+++ b/transcendental_resonance_frontend/pages/feed.py
@@ -12,6 +12,7 @@ from typing import List, Dict, Any
 import random
 import streamlit as st
 
+from frontend.light_theme import inject_light_theme
 from modern_ui import inject_modern_styles
 from streamlit_helpers import theme_selector, safe_container
 
@@ -158,6 +159,7 @@ def _init_state() -> None:
 # Page entrypoints
 # ──────────────────────────────────────────────────────────────────────────────
 
+inject_light_theme()
 inject_modern_styles()
 
 

--- a/transcendental_resonance_frontend/pages/messages.py
+++ b/transcendental_resonance_frontend/pages/messages.py
@@ -6,7 +6,10 @@
 from __future__ import annotations
 
 import streamlit as st
+from frontend.light_theme import inject_light_theme
 from transcendental_resonance_frontend.ui.chat_ui import render_chat_ui
+
+inject_light_theme()
 
 
 def main(main_container=None) -> None:

--- a/transcendental_resonance_frontend/pages/messages_center.py
+++ b/transcendental_resonance_frontend/pages/messages_center.py
@@ -7,11 +7,13 @@ from __future__ import annotations
 
 import asyncio
 import streamlit as st
+from frontend.light_theme import inject_light_theme
 from modern_ui import inject_modern_styles
 from streamlit_helpers import safe_container, header, theme_selector
 from transcendental_resonance_frontend.src.utils import api
 from status_indicator import render_status_icon
 
+inject_light_theme()
 inject_modern_styles()
 
 # Temporary in-memory conversation store

--- a/transcendental_resonance_frontend/pages/resonance_music.py
+++ b/transcendental_resonance_frontend/pages/resonance_music.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 import requests
 import streamlit as st
+from frontend.light_theme import inject_light_theme
 from modern_ui import inject_modern_styles
 from streamlit_helpers import (
     alert,
@@ -25,6 +26,7 @@ from streamlit_autorefresh import st_autorefresh
 from status_indicator import render_status_icon, check_backend # Ensure check_backend is imported
 from utils.api import get_resonance_summary, dispatch_route # Import get_resonance_summary and dispatch_route from utils.api
 
+inject_light_theme()
 inject_modern_styles()
 
 # BACKEND_URL is defined in utils.api, but we keep it here for direct requests calls if needed

--- a/transcendental_resonance_frontend/pages/social.py
+++ b/transcendental_resonance_frontend/pages/social.py
@@ -4,11 +4,13 @@
 """Friends & Followers page."""
 
 import streamlit as st
+from frontend.light_theme import inject_light_theme
 from modern_ui import inject_modern_styles
 from social_tabs import render_social_tab
 from streamlit_helpers import safe_container, render_mock_feed, theme_selector
 from feed_renderer import render_feed
 
+inject_light_theme()
 inject_modern_styles()
 
 

--- a/transcendental_resonance_frontend/pages/validation.py
+++ b/transcendental_resonance_frontend/pages/validation.py
@@ -5,6 +5,7 @@
 
 import importlib
 import streamlit as st
+from frontend.light_theme import inject_light_theme
 from modern_ui import inject_modern_styles
 from streamlit_helpers import safe_container, theme_selector
 
@@ -25,6 +26,7 @@ def _load_render_ui():
 render_validation_ui = _load_render_ui()
 
 # Inject modern global styles (safe when running in classic Streamlit)
+inject_light_theme()
 inject_modern_styles()
 
 # --------------------------------------------------------------------

--- a/transcendental_resonance_frontend/pages/video_chat.py
+++ b/transcendental_resonance_frontend/pages/video_chat.py
@@ -6,12 +6,14 @@ import asyncio
 import json
 
 import streamlit as st
+from frontend.light_theme import inject_light_theme
 from modern_ui import inject_modern_styles
 
 from ai_video_chat import create_session
 from video_chat_router import ConnectionManager
 from streamlit_helpers import safe_container, header, theme_selector
 
+inject_light_theme()
 inject_modern_styles()
 
 

--- a/transcendental_resonance_frontend/pages/voting.py
+++ b/transcendental_resonance_frontend/pages/voting.py
@@ -4,10 +4,12 @@
 """Governance and voting page."""
 
 import streamlit as st
+from frontend.light_theme import inject_light_theme
 from modern_ui import inject_modern_styles
 from voting_ui import render_voting_tab
 from streamlit_helpers import safe_container, theme_selector
 
+inject_light_theme()
 inject_modern_styles()
 
 


### PR DESCRIPTION
## Summary
- import `inject_light_theme` from `frontend.light_theme`
- call `inject_light_theme()` before any other UI setup on every page module

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and test failures)*

------
https://chatgpt.com/codex/tasks/task_e_688af51bab948320a20d4d933810294c