### PR TITLE
Fix active_user init with helper

### DIFF
--- a/social_tabs.py
+++ b/social_tabs.py
@@ -4,7 +4,13 @@
 import asyncio
 import streamlit as st
 from frontend.light_theme import inject_light_theme
-from streamlit_helpers import alert, safe_container, header, get_active_user
+from streamlit_helpers import (
+    alert,
+    safe_container,
+    header,
+    get_active_user,
+    ensure_active_user,
+)
 
 
 
@@ -60,12 +66,9 @@ def render_social_tab(main_container=None) -> None:
     """Render basic social interactions."""
     if main_container is None:
         main_container = st
-
-    st.session_state.setdefault("active_user", "guest")
+    ensure_active_user()
     container_ctx = safe_container(main_container)
     with container_ctx:
-        if "active_user" not in st.session_state:
-            st.session_state["active_user"] = "guest"
         header("Friends & Followers")
         if dispatch_route is None or SessionLocal is None or Harmonizer is None:
             st.info("Social routes not available")

--- a/transcendental_resonance_frontend/pages/profile.py
+++ b/transcendental_resonance_frontend/pages/profile.py
@@ -6,7 +6,13 @@
 import streamlit as st
 from frontend.light_theme import inject_light_theme
 from modern_ui import inject_modern_styles
-from streamlit_helpers import safe_container, header, theme_selector, get_active_user
+from streamlit_helpers import (
+    safe_container,
+    header,
+    theme_selector,
+    get_active_user,
+    ensure_active_user,
+)
 from api_key_input import render_api_key_ui
 from social_tabs import _load_profile
 from transcendental_resonance_frontend.ui.profile_card import (
@@ -99,12 +105,9 @@ def main(main_container=None) -> None:
     if main_container is None:
         main_container = st
     theme_selector("Theme", key_suffix="profile")
-
-    st.session_state.setdefault("active_user", "guest")
+    ensure_active_user()
     container_ctx = safe_container(main_container)
     with container_ctx:
-        if "active_user" not in st.session_state:
-            st.session_state["active_user"] = "guest"
         # Header with status icon
         header_col, status_col = st.columns([8, 1])
         with header_col:


### PR DESCRIPTION
## Summary
- add ensure_active_user import usage
- call ensure_active_user instead of manual checks

## Testing
- `pytest -q` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'toast')*

------
https://chatgpt.com/codex/tasks/task_e_688af51ab0908320a104639489831ce0