### PR TITLE
Ensure DB ready in social/profile pages

### DIFF
--- a/social_tabs.py
+++ b/social_tabs.py
@@ -19,10 +19,21 @@ except Exception:  # pragma: no cover - optional dependency
     dispatch_route = None  # type: ignore
 
 try:
-    from db_models import SessionLocal, Harmonizer
+    from db_models import (
+        SessionLocal,
+        Harmonizer,
+        init_db,
+        seed_default_users,
+    )
 except Exception:  # pragma: no cover - optional
     SessionLocal = None  # type: ignore
     Harmonizer = None  # type: ignore
+
+    def init_db() -> None:  # type: ignore
+        pass
+
+    def seed_default_users() -> None:  # type: ignore
+        pass
 
 ensure_active_user()
 
@@ -60,6 +71,9 @@ def render_social_tab(main_container=None) -> None:
     """Render basic social interactions."""
     if main_container is None:
         main_container = st
+
+    init_db()
+    seed_default_users()
 
     st.session_state.setdefault("active_user", "guest")
     container_ctx = safe_container(main_container)

--- a/streamlit_helpers.py
+++ b/streamlit_helpers.py
@@ -225,6 +225,7 @@ def render_post_card(post_data: dict[str, Any]) -> None:
     """Instagram-style post card that degrades gracefully."""
     img = sanitize_text(post_data.get("image", "")) if post_data.get("image") else ""
     text = sanitize_text(post_data.get("text", ""))
+    user = sanitize_text(post_data.get("user", ""))
     likes = post_data.get("likes", 0)
     try:
         likes = int(likes)
@@ -232,14 +233,15 @@ def render_post_card(post_data: dict[str, Any]) -> None:
         likes = 0
 
     if ui is None:
+        html_parts = []
         if img:
-            st.image(img, use_column_width=True)
-        st.write(text)
-        st.caption(f"❤️ {likes}")
-        st.markdown(
-            "<div style='color:var(--text-color);font-size:1.2em;'>❤️ 🔁 💬</div>",
-            unsafe_allow_html=True,
-        )
+            html_parts.append(f"<img src='{html.escape(img)}' style='width:100%;border-radius:0.375rem'>")
+        if user:
+            html_parts.append(f"<p><strong>{html.escape(user)}</strong></p>")
+        if text:
+            html_parts.append(f"<p>{html.escape(text)}</p>")
+        html_parts.append(f"<div style='color:var(--text-color);font-size:1.2em;'>❤️ {likes} 🔁 💬</div>")
+        st.markdown("".join(html_parts), unsafe_allow_html=True)
         return
 
     try:
@@ -247,8 +249,9 @@ def render_post_card(post_data: dict[str, Any]) -> None:
             if img:
                 ui.image(img).classes("rounded-md mb-2 w-full")
             safe_element("p", text).classes("mb-1") if hasattr(ui, "element") else st.markdown(text)
-            ui.badge(f"❤️ {likes}").classes("bg-pink-500 mb-1")
-            ui.element("div", "❤️ 🔁 💬").classes("text-center text-lg")
+            if hasattr(ui, "badge"):
+                ui.badge(f"❤️ {likes}").classes("bg-pink-500 mb-1")
+            ui.element("div", f"❤️ {likes} 🔁 💬").classes("text-center text-lg")
     except Exception as exc:  # noqa: BLE001
         st.toast(f"Post card failed: {exc}", icon="⚠️")
         if img:

--- a/transcendental_resonance_frontend/pages/profile.py
+++ b/transcendental_resonance_frontend/pages/profile.py
@@ -29,10 +29,21 @@ except Exception:  # pragma: no cover - optional dependency
     dispatch_route = None  # type: ignore
 
 try:  # Optional DB access for follow/unfollow
-    from db_models import SessionLocal, Harmonizer
+    from db_models import (
+        SessionLocal,
+        Harmonizer,
+        init_db,
+        seed_default_users,
+    )
 except Exception:  # pragma: no cover - optional dependency
     SessionLocal = None  # type: ignore
     Harmonizer = None  # type: ignore
+
+    def init_db() -> None:  # type: ignore
+        pass
+
+    def seed_default_users() -> None:  # type: ignore
+        pass
 
 import asyncio
 
@@ -98,6 +109,8 @@ def _render_profile(username: str) -> None:
 def main(main_container=None) -> None:
     if main_container is None:
         main_container = st
+    init_db()
+    seed_default_users()
     theme_selector("Theme", key_suffix="profile")
 
     st.session_state.setdefault("active_user", "guest")

--- a/ui.py
+++ b/ui.py
@@ -1901,14 +1901,14 @@ def ensure_database_exists() -> bool:
                     text(
                         "INSERT INTO harmonizers (username, email, hashed_password, bio,"
                         " is_active, is_admin, is_genesis, consent_given)"
-                        " VALUES ('guest','guest@example.com','x','Guest account',1,0,0,1);"
+                        " VALUES ('guest','guest@supernova.dev','x','Guest account',1,0,0,1);"
                     )
                 )
                 conn.execute(
                     text(
                         "INSERT INTO harmonizers (username, email, hashed_password, bio,"
                         " is_active, is_admin, is_genesis, consent_given)"
-                        " VALUES ('demo_user','demo@example.com','x','Demo profile',1,0,0,1);"
+                        " VALUES ('demo_user','demo@supernova.dev','x','Demo profile',1,0,0,1);"
                     )
                 )
 


### PR DESCRIPTION
## Summary
- guarantee database initialization for social tab & profile page
- seed guest and demo users so standalone pages work
- adjust default emails for guest/demo in UI helpers
- improve post card rendering for tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688af51a8a8c8320a660a51f805fc135