### PR TITLE
Add beta mode toggle and AI remix feature

### DIFF
--- a/docs/streamlit_ui_extension_example.md
+++ b/docs/streamlit_ui_extension_example.md
@@ -18,6 +18,16 @@ with centered_container():
 Running this example will render a page with the standard header, a theme switcher
 radio button and a centered content area.
 
+The theme selector stores the chosen light or dark mode in `st.session_state` and
+persists the value in the browser query string. Reloading the page keeps your
+selection intact.
+
+`render_top_bar()` now includes a **Beta Mode** toggle. When enabled, the flag is
+saved to `st.session_state['beta_mode']` and experimental features become
+available. For example, the VibeNodes page shows an **AI Remix** button on each
+post that calls `/vibenodes/{id}/remix` and displays the generated remix in a
+modal dialog.
+
 The Streamlit app also supports a lightweight health check for CI or uptime
 monitors. Visiting `/?healthz=1` responds with `ok` and stops execution. This
 serves as a simple fallback when the built-in `/healthz` route isn't available,

--- a/frontend/ui_layout.py
+++ b/frontend/ui_layout.py
@@ -76,7 +76,7 @@ def render_profile_card(username: str, avatar_url: str) -> None:
 
 
 def render_top_bar() -> None:
-    """Render a translucent top bar with a logo, search input, and avatar."""
+    """Render a translucent top bar with a logo, search input and controls."""
     st.markdown(
         """
         <style>
@@ -102,16 +102,37 @@ def render_top_bar() -> None:
         """,
         unsafe_allow_html=True,
     )
-    st.markdown(
-        """
-        <div class="sn-topbar">
-            <img src="https://placehold.co/32x32?text=SN" width="32" />
-            <input type="text" placeholder="Search..." />
-            <img src="https://placehold.co/32x32" width="32" style="border-radius:50%" />
-        </div>
-        """,
-        unsafe_allow_html=True,
-    )
+
+    with st.container():
+        st.markdown('<div class="sn-topbar">', unsafe_allow_html=True)
+        cols = st.columns([1, 4, 2, 1])
+        logo_col = cols[0] if len(cols) > 0 else st
+        search_col = cols[1] if len(cols) > 1 else st
+        beta_col = cols[2] if len(cols) > 2 else st
+        avatar_col = cols[3] if len(cols) > 3 else st
+        logo_target = logo_col if hasattr(logo_col, "markdown") else st
+        logo_target.markdown(
+            '<img src="https://placehold.co/32x32?text=SN" width="32" />',
+            unsafe_allow_html=True,
+        )
+        search_target = search_col if hasattr(search_col, "text_input") else st
+        search_target.text_input("", placeholder="Search...", key="topbar_search")
+        toggle_target = beta_col if hasattr(beta_col, "toggle") else st
+        beta_enabled = toggle_target.toggle(
+            "Beta Mode",
+            value=st.session_state.get("beta_mode", False),
+        )
+        st.session_state["beta_mode"] = beta_enabled
+        try:
+            st.query_params["beta"] = "1" if beta_enabled else "0"
+        except Exception:
+            st.experimental_set_query_params(beta="1" if beta_enabled else "0")
+        avatar_target = avatar_col if hasattr(avatar_col, "markdown") else st
+        avatar_target.markdown(
+            '<img src="https://placehold.co/32x32" width="32" style="border-radius:50%" />',
+            unsafe_allow_html=True,
+        )
+        st.markdown('</div>', unsafe_allow_html=True)
 
 
 def _render_sidebar_nav(

--- a/streamlit_helpers.py
+++ b/streamlit_helpers.py
@@ -262,7 +262,14 @@ def theme_selector(label: str = "Theme", *, key_suffix: str | None = None) -> st
         key_suffix = "default"
 
     if "theme" not in st.session_state:
-        st.session_state["theme"] = "light"
+        try:
+            params = st.query_params
+        except AttributeError:
+            params = st.experimental_get_query_params()
+        param_theme = params.get("theme", "light")
+        if isinstance(param_theme, list):
+            param_theme = param_theme[0]
+        st.session_state["theme"] = param_theme if str(param_theme).lower() in {"light", "dark"} else "light"
 
     unique_key = f"theme_selector_{key_suffix}"
     current = st.session_state["theme"]
@@ -290,6 +297,10 @@ def theme_selector(label: str = "Theme", *, key_suffix: str | None = None) -> st
         )
     st.session_state["theme"] = choice.lower()
     apply_theme(st.session_state["theme"])
+    try:
+        st.query_params["theme"] = st.session_state["theme"]
+    except Exception:
+        st.experimental_set_query_params(theme=st.session_state["theme"])
     return st.session_state["theme"]
 
 

--- a/transcendental_resonance_frontend/src/pages/vibenodes_page.py
+++ b/transcendental_resonance_frontend/src/pages/vibenodes_page.py
@@ -9,6 +9,11 @@ except Exception:  # pragma: no cover - fallback to Streamlit
     ui = None  # type: ignore
     import streamlit as st
 
+try:  # optional import when NiceGUI is available
+    import streamlit as st  # type: ignore
+except Exception:  # pragma: no cover - streamlit optional
+    st = None  # type: ignore
+
 import asyncio
 import contextlib
 
@@ -173,6 +178,45 @@ async def vibenodes_page():
                         ui.button("Remix", on_click=remix_fn).style(
                             f'background: {THEME["primary"]}; color: {THEME["text"]};'
                         )
+
+                        if st is not None and st.session_state.get("beta_mode"):
+                            async def ai_remix(vn_id=vn["id"]):
+                                resp = await api_call("POST", f"/vibenodes/{vn_id}/remix")
+                                if resp:
+                                    dlg = ui.dialog()
+                                    with dlg:
+                                        with ui.card().classes("w-full p-4"):
+                                            ui.label(resp.get("name", "AI Remix")).classes("text-lg")
+                                            if resp.get("media_url"):
+                                                render_media_block(resp.get("media_url"), resp.get("media_type", ""))
+                                            ui.markdown(safe_markdown(resp.get("description", ""))).classes("text-sm")
+                                            ui.button("Close", on_click=dlg.close).classes("w-full")
+                                    dlg.open()
+
+                            ui.button(
+                                "AI Remix",
+                                on_click=lambda vn_id=vn["id"]: ui.run_async(ai_remix(vn_id)),
+                            ).style(
+                                f'background: {THEME["accent"]}; color: {THEME["background"]};'
+                            )
+
+                        if st is not None and st.session_state.get("beta_mode"):
+                            async def ai_remix(vn_id=vn["id"]):
+                                resp = await api_call("POST", f"/vibenodes/{vn_id}/remix")
+                                if resp:
+                                    dlg = ui.dialog()
+                                    with dlg:
+                                        with ui.card().classes("w-full p-4"):
+                                            ui.label(resp.get("name", "AI Remix")).classes("text-lg")
+                                            if resp.get("media_url"):
+                                                render_media_block(resp.get("media_url"), resp.get("media_type", ""))
+                                            ui.markdown(safe_markdown(resp.get("description", ""))).classes("text-sm")
+                                            ui.button("Close", on_click=dlg.close).classes("w-full")
+                                    dlg.open()
+
+                            ui.button("AI Remix", on_click=lambda vn_id=vn["id"]: ui.run_async(ai_remix(vn_id))).style(
+                                f'background: {THEME["accent"]}; color: {THEME["background"]};'
+                            )
 
         async def refresh_vibenodes():
             params = {}


### PR DESCRIPTION
## Summary
- add Beta Mode toggle to top bar
- persist theme choice in query params
- show AI Remix button in VibeNodes page when Beta Mode enabled
- update documentation for theme persistence and beta features

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688aeba16ebc83209ec03765b0a31d9c