### PR TITLE
Add active user helper and update references

### DIFF
--- a/social_tabs.py
+++ b/social_tabs.py
@@ -4,7 +4,13 @@
 import asyncio
 import streamlit as st
 from frontend.light_theme import inject_light_theme
-from streamlit_helpers import alert, safe_container, header, get_active_user
+from streamlit_helpers import (
+    alert,
+    safe_container,
+    header,
+    get_active_user,
+    ensure_active_user,
+)
 
 
 
@@ -61,17 +67,16 @@ def render_social_tab(main_container=None) -> None:
     if main_container is None:
         main_container = st
 
-    st.session_state.setdefault("active_user", "guest")
+    get_active_user()
     container_ctx = safe_container(main_container)
     with container_ctx:
-        if "active_user" not in st.session_state:
-            st.session_state["active_user"] = "guest"
+        get_active_user()
         header("Friends & Followers")
         if dispatch_route is None or SessionLocal is None or Harmonizer is None:
             st.info("Social routes not available")
             return
 
-        current_user = st.session_state.get("active_user", "guest")
+        current_user = get_active_user()
 
         cols = st.columns(2)
         with cols[0]:

--- a/transcendental_resonance_frontend/pages/profile.py
+++ b/transcendental_resonance_frontend/pages/profile.py
@@ -6,7 +6,13 @@
 import streamlit as st
 from frontend.light_theme import inject_light_theme
 from modern_ui import inject_modern_styles
-from streamlit_helpers import safe_container, header, theme_selector, get_active_user
+from streamlit_helpers import (
+    safe_container,
+    header,
+    theme_selector,
+    get_active_user,
+    ensure_active_user,
+)
 from api_key_input import render_api_key_ui
 from social_tabs import _load_profile
 from transcendental_resonance_frontend.ui.profile_card import (
@@ -100,11 +106,9 @@ def main(main_container=None) -> None:
         main_container = st
     theme_selector("Theme", key_suffix="profile")
 
-    st.session_state.setdefault("active_user", "guest")
+    get_active_user()
     container_ctx = safe_container(main_container)
     with container_ctx:
-        if "active_user" not in st.session_state:
-            st.session_state["active_user"] = "guest"
         # Header with status icon
         header_col, status_col = st.columns([8, 1])
         with header_col:
@@ -113,7 +117,7 @@ def main(main_container=None) -> None:
             render_status_icon()
 
         # Active user editable section
-        current = st.session_state.get("active_user", "guest")
+        current = get_active_user()
         current = st.text_input("Username", value=current, key="profile_user")
         st.session_state["active_user"] = current
         _render_profile(current)

--- a/ui.py
+++ b/ui.py
@@ -1901,14 +1901,14 @@ def ensure_database_exists() -> bool:
                     text(
                         "INSERT INTO harmonizers (username, email, hashed_password, bio,"
                         " is_active, is_admin, is_genesis, consent_given)"
-                        " VALUES ('guest','guest@example.com','x','Guest account',1,0,0,1);"
+                        " VALUES ('guest','guest@supernova.dev','x','Guest account',1,0,0,1);"
                     )
                 )
                 conn.execute(
                     text(
                         "INSERT INTO harmonizers (username, email, hashed_password, bio,"
                         " is_active, is_admin, is_genesis, consent_given)"
-                        " VALUES ('demo_user','demo@example.com','x','Demo profile',1,0,0,1);"
+                        " VALUES ('demo_user','demo@supernova.dev','x','Demo profile',1,0,0,1);"
                     )
                 )
 


### PR DESCRIPTION
## Summary
- provide a `get_active_user` helper in `streamlit_helpers`
- switch `social_tabs` and profile page to use the helper
- update fallback HTML rendering for posts
- align default emails in `ui.ensure_database_exists`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688af517566883208142f822a4bc35d6