### PR TITLE
Fix indentation in social tab

### DIFF
--- a/db_models.py
+++ b/db_models.py
@@ -725,9 +725,9 @@ def seed_default_users() -> None:
             exists = session.query(Harmonizer).filter_by(username=username).first()
             if not exists:
                 hashed = hashlib.sha256(username.encode()).hexdigest()
-                email = f"{username}@supernova.dev"
+                email = f"{username}@example.com"
                 if username == "demo_user":
-                    email = "demo@supernova.dev"
+                    email = "demo@example.com"
                 user = Harmonizer(
                     username=username,
                     email=email,

--- a/social_tabs.py
+++ b/social_tabs.py
@@ -77,13 +77,11 @@ def render_social_tab(main_container=None) -> None:
     """Render basic social interactions."""
     if main_container is None:
         main_container = st
-current_user = get_active_user()
-container_ctx = safe_container(main_container)
-with container_ctx:
-    header("Friends & Followers")
-    # use current_user for any logic here
-
+    current_user = get_active_user()
+    container_ctx = safe_container(main_container)
+    with container_ctx:
         header("Friends & Followers")
+
         if dispatch_route is None or SessionLocal is None or Harmonizer is None:
             st.info("Social routes not available")
             return


### PR DESCRIPTION
## Summary
- indent everything inside the `with container_ctx:` block
- remove redundant header
- use `example.com` addresses in seeded users for consistency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688afdc967e483209798f9a1824e40f3