### PR TITLE
Add torch dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -52,3 +52,4 @@ streamlit-autorefresh
 gtts
 streamlit-javascript
 nicegui
+torch>=2.0


### PR DESCRIPTION
## Summary
- add PyTorch >=2.0 to `requirements.txt`

## Testing
- `pip install -r requirements.txt` *(fails: Operation cancelled)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_688afdb926e0832081026798f0699096