### PR TITLE
Fix default user email domains

### DIFF
--- a/db_models.py
+++ b/db_models.py
@@ -725,9 +725,9 @@ def seed_default_users() -> None:
             exists = session.query(Harmonizer).filter_by(username=username).first()
             if not exists:
                 hashed = hashlib.sha256(username.encode()).hexdigest()
-                email = f"{username}@supernova.dev"
+                email = f"{username}@example.com"
                 if username == "demo_user":
-                    email = "demo@supernova.dev"
+                    email = "demo@example.com"
                 user = Harmonizer(
                     username=username,
                     email=email,


### PR DESCRIPTION
## Summary
- ensure seeded default user emails use `example.com` so tests expect them

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b0334f59083208cdd9e9a7abffabf