### PR TITLE
Implement emoji sanitization

### DIFF
--- a/docs/streamlit_ui_extension_example.md
+++ b/docs/streamlit_ui_extension_example.md
@@ -1,7 +1,9 @@
 # Extending the Streamlit UI
 
 `streamlit_helpers.py` exposes small utilities used by `ui.py` for common tasks.
-Import these helpers in your own modules to keep layouts consistent.
+Import these helpers in your own modules to keep layouts consistent. Header
+labels can include emoji characters and are sanitized automatically to prevent
+HTML injection.
 
 ```python
 import streamlit as st

--- a/streamlit_helpers.py
+++ b/streamlit_helpers.py
@@ -110,6 +110,13 @@ st.markdown(BOX_CSS, unsafe_allow_html=True)
 # ──────────────────────────────────────────────────────────────────────────────
 # Helper components
 # ──────────────────────────────────────────────────────────────────────────────
+
+def sanitize_emoji(text: str) -> str:
+    """Return emoji string safe for HTML rendering."""
+    if not isinstance(text, str):
+        return ""
+    return html.escape(text)
+
 def alert(
     message: str,
     level: Literal["warning", "error", "info"] = "info",
@@ -155,7 +162,8 @@ def header(title: str, *, layout: str = "centered") -> None:
         "<style>.app-container{padding:1rem 2rem;}</style>",
         unsafe_allow_html=True,
     )
-    ui.element("h1", title)
+    safe_title = sanitize_emoji(title)
+    ui.element("h1", safe_title)
 
 
 def render_post_card(post_data: dict[str, Any]) -> None:
@@ -372,6 +380,7 @@ def inject_global_styles() -> None:
 # ──────────────────────────────────────────────────────────────────────────────
 __all__ = [
     "alert",
+    "sanitize_emoji",
     "header",
     "render_post_card",
     "render_instagram_grid",


### PR DESCRIPTION
## Summary
- add `sanitize_emoji` helper to escape emoji strings
- use helper inside `header`
- document emoji support in streamlit UI docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688aebe626e08320b90189c898bf280c