### PR TITLE
Make torch optional

### DIFF
--- a/db_models.py
+++ b/db_models.py
@@ -725,9 +725,9 @@ def seed_default_users() -> None:
             exists = session.query(Harmonizer).filter_by(username=username).first()
             if not exists:
                 hashed = hashlib.sha256(username.encode()).hexdigest()
-                email = f"{username}@supernova.dev"
+                email = f"{username}@example.com"
                 if username == "demo_user":
-                    email = "demo@supernova.dev"
+                    email = "demo@example.com"
                 user = Harmonizer(
                     username=username,
                     email=email,

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,4 +52,3 @@ streamlit-autorefresh
 gtts
 streamlit-javascript
 nicegui
-torch>=2.0

--- a/superNova_2177.py
+++ b/superNova_2177.py
@@ -452,10 +452,20 @@ _safe_import("tqdm", attrs=["tqdm"])
 _safe_import("pandas", alias="pd")
 _safe_import("statsmodels.api", alias="sm")
 _safe_import("pulp", attrs=["LpProblem", "LpMinimize", "LpVariable"])
-_safe_import("torch", alias="torch")
-_safe_import("torch.nn", alias="nn")
-_safe_import("torch.optim", alias="optim")
-_safe_import("torch.utils.data", attrs=["Dataset", "DataLoader"])
+
+# torch is optional. If not installed, related ML features will be disabled.
+try:
+    import torch
+    import torch.nn as nn
+    import torch.optim as optim
+    from torch.utils.data import Dataset, DataLoader
+except ImportError:
+    logging.warning("PyTorch not installed; ML features are disabled.")
+    torch = None
+    nn = None
+    optim = None
+    Dataset = None
+    DataLoader = None
 _safe_import("matplotlib.pyplot", alias="plt")
 _safe_import("scipy.optimize", attrs=["minimize"])
 _safe_import("requests")  # For AI API calls


### PR DESCRIPTION
## Summary
- allow running without PyTorch by catching `ImportError`
- seed default guest/demo users with `example.com` emails
- make `torch` optional in `requirements.txt`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b0494930083208198399a00613431