### PR TITLE
Improve empty label components

### DIFF
--- a/frontend/ui_layout.py
+++ b/frontend/ui_layout.py
@@ -217,7 +217,13 @@ def _render_sidebar_nav(
             )
         else:
             labels = [f"{icon or ''} {label}".strip() for (label, _), icon in zip(opts, icon_list)]
-            choice = st.radio("", labels, index=index, key=key)
+            choice = st.radio(
+                "Navigation",
+                labels,
+                index=index,
+                key=key,
+                label_visibility="collapsed",
+            )
             choice = opts[labels.index(choice)][0]
 
         st.markdown("</div>", unsafe_allow_html=True)

--- a/transcendental_resonance_frontend/pages/messages_center.py
+++ b/transcendental_resonance_frontend/pages/messages_center.py
@@ -143,7 +143,12 @@ def main(main_container=None) -> None:
             # Conversation selector
             with left:
                 st.markdown("**Conversations**")
-                selected = st.radio("", convos, key="selected_convo")
+                selected = st.radio(
+                    "Conversation",
+                    convos,
+                    key="selected_convo",
+                    label_visibility="collapsed",
+                )
 
             # Thread & send box
             with right:

--- a/transcendental_resonance_frontend/ui/chat_ui.py
+++ b/transcendental_resonance_frontend/ui/chat_ui.py
@@ -31,7 +31,16 @@ def render_conversation_list() -> None:
         active = users[0]
     col1, col2 = st.columns([1, 3])
     with col1:
-        selected = st.radio("", users, index=users.index(active)) if users else ""
+        selected = (
+            st.radio(
+                "Conversation",
+                users,
+                index=users.index(active),
+                label_visibility="collapsed",
+            )
+            if users
+            else ""
+        )
         st.session_state["active_chat"] = selected
     with col2:
         st.write("Recent")


### PR DESCRIPTION
## Summary
- make conversation selection label explicit in Messages Center
- clarify sidebar navigation radio label
- show conversation label on chat UI with collapsed label

## Testing
- `pytest -q` *(fails: test_ensure_database_exists_creates_table_and_default_admin)*

------
https://chatgpt.com/codex/tasks/task_e_688b048a665083208f8739dd0b405af8