### PR TITLE
Prefix call control keys by active page

### DIFF
--- a/chat_ui.py
+++ b/chat_ui.py
@@ -97,20 +97,26 @@ def render_chat_interface() -> None:
         st.markdown("</div>", unsafe_allow_html=True)
 
     with calls_tab:
-        render_video_call_controls(key_prefix="chat_")
+        render_video_call_controls()
         st.divider()
-        render_voice_chat_controls(key_prefix="chat_")
+        render_voice_chat_controls()
 
 
-def render_video_call_controls(key_prefix: str = "") -> None:
+def render_video_call_controls(key_prefix: str | None = None) -> None:
     """Placeholder video call controls."""
+    if key_prefix is None:
+        page = st.session_state.get("active_page", "")
+        key_prefix = f"{page}_" if page else ""
     if st.button("Start Video Call", key=f"{key_prefix}start_video"):
         st.toast("Video call placeholder. Integration with WebRTC pending.")
         st.empty()
 
 
-def render_voice_chat_controls(key_prefix: str = "") -> None:
+def render_voice_chat_controls(key_prefix: str | None = None) -> None:
     """Placeholder voice call controls."""
+    if key_prefix is None:
+        page = st.session_state.get("active_page", "")
+        key_prefix = f"{page}_" if page else ""
     if st.button("Start Voice Call", key=f"{key_prefix}start_voice"):
         st.toast("Voice call placeholder. Audio streaming integration pending.")
         st.empty()

--- a/db_models.py
+++ b/db_models.py
@@ -725,9 +725,9 @@ def seed_default_users() -> None:
             exists = session.query(Harmonizer).filter_by(username=username).first()
             if not exists:
                 hashed = hashlib.sha256(username.encode()).hexdigest()
-                email = f"{username}@supernova.dev"
+                email = f"{username}@example.com"
                 if username == "demo_user":
-                    email = "demo@supernova.dev"
+                    email = "demo@example.com"
                 user = Harmonizer(
                     username=username,
                     email=email,

--- a/frontend/ui_layout.py
+++ b/frontend/ui_layout.py
@@ -111,10 +111,11 @@ def render_top_bar() -> None:
             unsafe_allow_html=True,
         )
         search_target = search_col if hasattr(search_col, "text_input") else st
+        page = st.session_state.get("active_page", "global")
         search_target.text_input(
             "Search",
             placeholder="Search...",
-            key=f"topbar_search_{st.session_state.get('active_page', 'global')}",
+            key=f"topbar_search_{page}",
             label_visibility="collapsed",
         )
         toggle_target = beta_col if hasattr(beta_col, "toggle") else st

--- a/transcendental_resonance_frontend/pages/chat.py
+++ b/transcendental_resonance_frontend/pages/chat.py
@@ -22,7 +22,9 @@ def main(main_container=None) -> None:
     """Render the chat page."""
     if main_container is None:
         main_container = st
-    theme_selector("Theme", key_suffix="chat")
+    page = "chat"
+    st.session_state["active_page"] = page
+    theme_selector("Theme", key_suffix=page)
 
     container_ctx = safe_container(main_container)
     with container_ctx:
@@ -33,9 +35,9 @@ def main(main_container=None) -> None:
             render_status_icon()
         render_chat_interface()
         st.divider()
-        render_video_call_controls(key_prefix="chat_")
+        render_video_call_controls(key_prefix=f"{page}_")
         st.divider()
-        render_voice_chat_controls(key_prefix="chat_")
+        render_voice_chat_controls(key_prefix=f"{page}_")
 
 
 def render() -> None:

--- a/transcendental_resonance_frontend/pages/messages_center.py
+++ b/transcendental_resonance_frontend/pages/messages_center.py
@@ -120,6 +120,8 @@ def main(main_container=None) -> None:
     if main_container is None:
         main_container = st
 
+    page = "messages_center"
+    st.session_state["active_page"] = page
     theme_selector("Theme", key_suffix="msg_center")
 
     with safe_container(main_container):
@@ -163,9 +165,9 @@ def main(main_container=None) -> None:
         with tab_calls:
             from .chat import render_video_call_controls, render_voice_chat_controls
 
-            render_video_call_controls(key_prefix="msgcenter_")
+            render_video_call_controls(key_prefix=f"{page}_")
             st.divider()
-            render_voice_chat_controls(key_prefix="msgcenter_")
+            render_voice_chat_controls(key_prefix=f"{page}_")
 
 
 # Streamlit multipage support --------------------------------------------------


### PR DESCRIPTION
## Summary
- track active page in session state
- use active page prefixes when rendering call controls and topbar search
- default call controls to active page prefix if none provided
- fix database seeding emails

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b04859b748320aa74180fe833c854