### PR TITLE
Enhance Streamlit chat UI

### DIFF
--- a/db_models.py
+++ b/db_models.py
@@ -725,9 +725,9 @@ def seed_default_users() -> None:
             exists = session.query(Harmonizer).filter_by(username=username).first()
             if not exists:
                 hashed = hashlib.sha256(username.encode()).hexdigest()
-                email = f"{username}@supernova.dev"
+                email = f"{username}@example.com"
                 if username == "demo_user":
-                    email = "demo@supernova.dev"
+                    email = "demo@example.com"
                 user = Harmonizer(
                     username=username,
                     email=email,

--- a/frontend/ui_layout.py
+++ b/frontend/ui_layout.py
@@ -31,6 +31,28 @@ import streamlit as st
 from modern_ui_components import SIDEBAR_STYLES
 from profile_card import render_profile_card as _render_profile_card
 
+LAYOUT_CSS = """
+<style>
+.insta-card {
+    display: flex;
+    flex-direction: column;
+    background: var(--card);
+    border-radius: 1rem;
+    overflow: hidden;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+    transition: transform .2s ease, box-shadow .2s ease;
+}
+.insta-card img {
+    width: 100%;
+    height: auto;
+}
+.insta-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 8px 20px rgba(0,0,0,0.15);
+}
+</style>
+"""
+
 try:
     _paths = importlib.import_module("utils.paths")
     ROOT_DIR = _paths.ROOT_DIR
@@ -49,6 +71,7 @@ except ImportError:
 
 def main_container() -> st.delta_generator.DeltaGenerator:
     """Return a container for the main content area."""
+    st.markdown(LAYOUT_CSS, unsafe_allow_html=True)
     return st.container()
 
 

--- a/modern_ui.py
+++ b/modern_ui.py
@@ -59,6 +59,23 @@ def inject_modern_styles() -> None:
         transform: translateY(-2px);
         box-shadow: 0 4px 12px rgba(0,0,0,0.12);
     }
+    .insta-card {
+        display: flex;
+        flex-direction: column;
+        background: var(--card);
+        border-radius: 1rem;
+        overflow: hidden;
+        box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+        transition: transform .2s ease, box-shadow .2s ease;
+    }
+    .insta-card img {
+        width: 100%;
+        height: auto;
+    }
+    .insta-card:hover {
+        transform: translateY(-4px);
+        box-shadow: 0 8px 24px rgba(0,0,0,0.15);
+    }
     </style>
     """
     st.markdown(css, unsafe_allow_html=True)

--- a/profile_card.py
+++ b/profile_card.py
@@ -12,7 +12,7 @@ def render_profile_card(username: str, avatar_url: str) -> None:
     st.markdown("<div class='glass-card'>", unsafe_allow_html=True)
     col1, col2 = st.columns([1, 3])
     with col1:
-        st.image(avatar_url, width=48)
+        st.image(avatar_url, width=48, use_container_width=True)
     with col2:
         st.markdown(f"**{username}**")
         st.caption(badge)

--- a/transcendental_resonance_frontend/pages/messages_center.py
+++ b/transcendental_resonance_frontend/pages/messages_center.py
@@ -40,6 +40,20 @@ MESSAGE_CSS = """
     align-self: flex-end;
     background: #DCF8C6;
 }
+.msg-row {
+    display: flex;
+    gap: 0.5rem;
+    align-items: flex-end;
+}
+.msg-row.sender {
+    flex-direction: row-reverse;
+}
+.msg-avatar {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    object-fit: cover;
+}
 </style>
 """
 
@@ -74,14 +88,17 @@ def _render_messages(messages: list[dict]) -> None:
         user = entry.get("user", "?")
         text = entry.get("text", "")
         cls = "sender" if user == "You" else "receiver"
+        avatar = entry.get("avatar") or f"https://robohash.org/{user}.png?size=50x50"
 
+        st.markdown(f"<div class='msg-row {cls}'>", unsafe_allow_html=True)
+        st.markdown(f"<img class='msg-avatar' src='{avatar}' />", unsafe_allow_html=True)
         if image := entry.get("image"):
-            st.image(image, width=200)
+            st.image(image, use_container_width=True)
         if video := entry.get("video"):
             st.video(video)
-
         bubble = f"<div class='msg-bubble {cls}'><strong>{user}:</strong> {text}</div>"
         st.markdown(bubble, unsafe_allow_html=True)
+        st.markdown("</div>", unsafe_allow_html=True)
 
     st.markdown("</div>", unsafe_allow_html=True)
 
@@ -150,14 +167,16 @@ def main(main_container=None) -> None:
                 msgs = st.session_state["_conversations"].setdefault(selected, [])
                 _render_messages(msgs)
 
-                col_msg, col_btn = st.columns([4, 1])
+                col_msg, col_send, col_refresh = st.columns([4, 1, 1])
                 with col_msg:
                     msg_input = st.text_input("Message", key="msg_input")
-                with col_btn:
+                with col_send:
                     if st.button("Send", key="send_msg") and msg_input:
                         send_message(selected, msg_input)
                         st.session_state.msg_input = ""
                         st.experimental_rerun()
+                with col_refresh:
+                    st.button("🔄", key="refresh_chat", on_click=st.experimental_rerun)
 
         # ── Calls tab ──────────────────────────────────────────────
         with tab_calls:

--- a/ui.py
+++ b/ui.py
@@ -742,7 +742,7 @@ def render_modern_agents_page():
     cols = st.columns(len(agents))
     for col, name in zip(cols, agents):
         with col:
-            st.image("https://via.placeholder.com/80", width=80)
+            st.image("https://via.placeholder.com/80", width=80, use_container_width=True)
             st.write(name)
             st.line_chart([1, 3, 2, 4])
 


### PR DESCRIPTION
## Summary
- add responsive Instagram-style card CSS for modern UI and layout helpers
- inject layout CSS in main container
- use `use_container_width=True` for images
- display avatars and add refresh control in chat page
- update default emails for seeded users

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b04a03ef4832084feea6071f52179