### PR TITLE
Fix tab navigation and update default emails

### DIFF
--- a/db_models.py
+++ b/db_models.py
@@ -725,9 +725,9 @@ def seed_default_users() -> None:
             exists = session.query(Harmonizer).filter_by(username=username).first()
             if not exists:
                 hashed = hashlib.sha256(username.encode()).hexdigest()
-                email = f"{username}@supernova.dev"
+                email = f"{username}@example.com"
                 if username == "demo_user":
-                    email = "demo@supernova.dev"
+                    email = "demo@example.com"
                 user = Harmonizer(
                     username=username,
                     email=email,

--- a/ui.py
+++ b/ui.py
@@ -1739,7 +1739,7 @@ def main() -> None:
         # Center content area — dynamic page loading
         with center_col:
             # Main navigation tabs for common sections
-            with ui_wrapper.tabs(["Validation", "Voting", "Agents"]) as tabs:
+            with ui.tabs(["Validation", "Voting", "Agents"]) as tabs:
                 selected = tabs.active
                 if selected != display_choice:
                     try:


### PR DESCRIPTION
## Summary
- fix call to `ui.tabs` in main page loader
- seed demo users with example.com addresses to match tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b046f069483208088f242ea7fcded