### PR TITLE
Improve radio labels

### DIFF
--- a/db_models.py
+++ b/db_models.py
@@ -725,9 +725,9 @@ def seed_default_users() -> None:
             exists = session.query(Harmonizer).filter_by(username=username).first()
             if not exists:
                 hashed = hashlib.sha256(username.encode()).hexdigest()
-                email = f"{username}@supernova.dev"
+                email = f"{username}@example.com"
                 if username == "demo_user":
-                    email = "demo@supernova.dev"
+                    email = "demo@example.com"
                 user = Harmonizer(
                     username=username,
                     email=email,

--- a/frontend/ui_layout.py
+++ b/frontend/ui_layout.py
@@ -217,7 +217,13 @@ def _render_sidebar_nav(
             )
         else:
             labels = [f"{icon or ''} {label}".strip() for (label, _), icon in zip(opts, icon_list)]
-            choice = st.radio("", labels, index=index, key=key)
+            choice = st.radio(
+                "Navigation",
+                labels,
+                index=index,
+                key=key,
+                label_visibility="collapsed",
+            )
             choice = opts[labels.index(choice)][0]
 
         st.markdown("</div>", unsafe_allow_html=True)

--- a/transcendental_resonance_frontend/pages/messages_center.py
+++ b/transcendental_resonance_frontend/pages/messages_center.py
@@ -143,7 +143,12 @@ def main(main_container=None) -> None:
             # Conversation selector
             with left:
                 st.markdown("**Conversations**")
-                selected = st.radio("", convos, key="selected_convo")
+                selected = st.radio(
+                    "Select conversation",
+                    convos,
+                    key="selected_convo",
+                    label_visibility="collapsed",
+                )
 
             # Thread & send box
             with right:

--- a/transcendental_resonance_frontend/ui/chat_ui.py
+++ b/transcendental_resonance_frontend/ui/chat_ui.py
@@ -31,7 +31,16 @@ def render_conversation_list() -> None:
         active = users[0]
     col1, col2 = st.columns([1, 3])
     with col1:
-        selected = st.radio("", users, index=users.index(active)) if users else ""
+        selected = (
+            st.radio(
+                "Select conversation",
+                users,
+                index=users.index(active),
+                label_visibility="collapsed",
+            )
+            if users
+            else ""
+        )
         st.session_state["active_chat"] = selected
     with col2:
         st.write("Recent")


### PR DESCRIPTION
## Summary
- add hidden label to sidebar navigation radio button
- add hidden labels to conversation selection radios
- seed example.com addresses by default to match tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b046483448320a672e1123104fba8