### PR TITLE
Fix VerifiedScientificModel docstrings

### DIFF
--- a/agent_core.py
+++ b/agent_core.py
@@ -242,6 +242,11 @@ class RemixAgent:
         and voter engagement. ``proposal_type`` of ``system_parameter_change``
         is treated as more important than ``general`` proposals. ``engagement_score``
         should be ``0`` to ``1`` and typically uses the quorum fraction.
+
+        citation_uri: https://en.wikipedia.org/wiki/Supermajority_vote
+        assumptions: engagement correlates with decision quality
+        validation_notes: heuristic interpolation between quorum and supermajority
+        approximation: heuristic
         """
 
         base = float(self.config.GOV_QUORUM_THRESHOLD)


### PR DESCRIPTION
## Summary
- ensure dynamic supermajority threshold docstring lists verification fields

## Testing
- `pytest -q`
- `pytest tests/test_ui_database.py::test_ensure_database_exists_creates_table_and_default_admin -q`

------
https://chatgpt.com/codex/tasks/task_e_688c1600dfbc8320a96bd259438f7a38