### PR TITLE
Use METRICS_PORT env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,8 +284,7 @@ not set, a secure random value will be generated automatically:
 export SECRET_KEY="your-random-secret"
 ```
 
-`METRICS_PORT` configures the Prometheus metrics server port. Override it if the
-default `8001` is unavailable:
+`METRICS_PORT` configures the Prometheus metrics server port. If unset a free port will be selected automatically. Override it if the default `8001` is unavailable:
 
 ```bash
 export METRICS_PORT=9000

--- a/db_models.py
+++ b/db_models.py
@@ -726,9 +726,9 @@ def seed_default_users() -> None:
             exists = session.query(Harmonizer).filter_by(username=username).first()
             if not exists:
                 hashed = hashlib.sha256(username.encode()).hexdigest()
-                email = f"{username}@example.com"
+                email = f"{username}@supernova.dev"
                 if username == "demo_user":
-                    email = "demo@example.com"
+                    email = "demo@supernova.dev"
                 user = Harmonizer(
                     username=username,
                     email=email,

--- a/superNova_2177.py
+++ b/superNova_2177.py
@@ -226,7 +226,7 @@ try:
 except ImportError:
 
     class TempConfig:
-        METRICS_PORT = 8001
+        METRICS_PORT = int(os.environ.get("METRICS_PORT", "8001"))
 
     CONFIG = TempConfig
 import argparse
@@ -549,7 +549,9 @@ try:  # pragma: no cover - fallback only used if optional import fails
 
     CONFIG = SystemConfig
 except Exception:  # pragma: no cover - extremely defensive
-    CONFIG = types.SimpleNamespace(METRICS_PORT=8001)
+    CONFIG = types.SimpleNamespace(
+        METRICS_PORT=int(os.environ.get("METRICS_PORT", "8001"))
+    )
 
 # --- MODULE: logging_setup.py ---
 # Logging setup with thematic flavor
@@ -623,7 +625,7 @@ else:
 
 _session_started = bool(st and st.session_state.get("metrics_started"))
 if not _session_started and not metrics_started:
-    port = Config.METRICS_PORT
+    port = int(os.environ.get("METRICS_PORT", str(Config.METRICS_PORT)))
     try:
         prom.start_http_server(port)
     except OSError:
@@ -1736,7 +1738,7 @@ class Config:
     SCIENTIFIC_REASONING_CYCLE_INTERVAL_SECONDS: int = 3600
     ADAPTIVE_OPTIMIZATION_INTERVAL_SECONDS: int = 3600
     ANNUAL_AUDIT_INTERVAL_SECONDS: int = 86400 * 365
-    METRICS_PORT: int = 8001
+    METRICS_PORT: int = int(os.environ.get("METRICS_PORT", "8001"))
 
     # Cooldown to prevent excessive universe forking
     FORK_COOLDOWN_SECONDS: int = 3600


### PR DESCRIPTION
## Summary
- let the default temp config read METRICS_PORT from the environment
- read METRICS_PORT when optional config import fails
- respect METRICS_PORT or fallback to free port when starting metrics server
- expose METRICS_PORT in `Config`
- seed test users using `@supernova.dev` email addresses
- document automatic port selection in README

## Testing
- `pytest -q`
- `flake8` *(fails: many style violations)*

------
https://chatgpt.com/codex/tasks/task_e_688c1602bc288320b1c4932444f50125