### PR TITLE
Fix radio labels and default user emails

### DIFF
--- a/db_models.py
+++ b/db_models.py
@@ -726,9 +726,9 @@ def seed_default_users() -> None:
             exists = session.query(Harmonizer).filter_by(username=username).first()
             if not exists:
                 hashed = hashlib.sha256(username.encode()).hexdigest()
-                email = f"{username}@example.com"
+                email = f"{username}@supernova.dev"
                 if username == "demo_user":
-                    email = "demo@example.com"
+                    email = "demo@supernova.dev"
                 user = Harmonizer(
                     username=username,
                     email=email,

--- a/frontend/ui_layout.py
+++ b/frontend/ui_layout.py
@@ -232,7 +232,7 @@ def _render_sidebar_nav(
                     st.sidebar.link_button(label, url=url, icon=icon)
         elif USE_OPTION_MENU and option_menu is not None:
             choice = option_menu(
-                menu_title=None,
+                menu_title="Choose",
                 options=[label for label, _ in opts],
                 icons=[icon or "dot" for icon in icon_list],
                 orientation="vertical",

--- a/transcendental_resonance_frontend/ui/chat_ui.py
+++ b/transcendental_resonance_frontend/ui/chat_ui.py
@@ -33,7 +33,7 @@ def render_conversation_list() -> None:
     with col1:
         selected = (
             st.radio(
-                "Conversation",
+                "Conversations",
                 users,
                 index=users.index(active),
                 label_visibility="collapsed",


### PR DESCRIPTION
## Summary
- update sidebar `option_menu` title
- label chat conversation selector
- seed default users with `@supernova.dev` emails

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688c1605874c83209af4face37f6fd49