### PR TITLE
Fix chat radio label and default email

### DIFF
--- a/db_models.py
+++ b/db_models.py
@@ -726,9 +726,9 @@ def seed_default_users() -> None:
             exists = session.query(Harmonizer).filter_by(username=username).first()
             if not exists:
                 hashed = hashlib.sha256(username.encode()).hexdigest()
-                email = f"{username}@example.com"
+                email = f"{username}@supernova.dev"
                 if username == "demo_user":
-                    email = "demo@example.com"
+                    email = "demo@supernova.dev"
                 user = Harmonizer(
                     username=username,
                     email=email,

--- a/transcendental_resonance_frontend/pages/messages_center.py
+++ b/transcendental_resonance_frontend/pages/messages_center.py
@@ -163,8 +163,7 @@ def main(main_container=None) -> None:
             with left:
                 st.markdown("**Conversations**")
                 selected = st.radio(
-                    "Conversations",
-
+                    "Conversation",
                     convos,
                     key="selected_convo",
                     label_visibility="collapsed",


### PR DESCRIPTION
## Summary
- adjust the conversation selector radio button label
- seed demo users with `@supernova.dev` emails

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688c194983648320a0b83457504fcd21