### PR TITLE
Fix chat control duplication

### DIFF
--- a/db_models.py
+++ b/db_models.py
@@ -726,9 +726,9 @@ def seed_default_users() -> None:
             exists = session.query(Harmonizer).filter_by(username=username).first()
             if not exists:
                 hashed = hashlib.sha256(username.encode()).hexdigest()
-                email = f"{username}@example.com"
+                email = f"{username}@supernova.dev"
                 if username == "demo_user":
-                    email = "demo@example.com"
+                    email = "demo@supernova.dev"
                 user = Harmonizer(
                     username=username,
                     email=email,

--- a/transcendental_resonance_frontend/pages/chat.py
+++ b/transcendental_resonance_frontend/pages/chat.py
@@ -8,11 +8,7 @@ from frontend.light_theme import inject_light_theme
 from modern_ui import inject_modern_styles
 from streamlit_helpers import safe_container, header, theme_selector
 from status_indicator import render_status_icon
-from chat_ui import (
-    render_chat_interface,
-    render_video_call_controls,
-    render_voice_chat_controls,
-)
+from chat_ui import render_chat_interface
 
 inject_light_theme()
 inject_modern_styles()
@@ -34,10 +30,6 @@ def main(main_container=None) -> None:
         with status_col:
             render_status_icon()
         render_chat_interface()
-        st.divider()
-        render_video_call_controls(key_prefix=f"{page}_")
-        st.divider()
-        render_voice_chat_controls(key_prefix=f"{page}_")
 
 
 def render() -> None:


### PR DESCRIPTION
## Summary
- simplify chat page controls to avoid duplicate keys
- use supernova.dev emails for default users so tests pass

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c194ae0948320be204dd92dd52162