### PR TITLE
Add missing disclaimers to select modules

### DIFF
--- a/annual_audit.py
+++ b/annual_audit.py
@@ -1,3 +1,6 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
 import asyncio
 import logging
 

--- a/profile_card.py
+++ b/profile_card.py
@@ -1,3 +1,6 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
 """Minimal profile card component used across pages."""
 
 import os

--- a/social/profile_ui_hook.py
+++ b/social/profile_ui_hook.py
@@ -1,3 +1,6 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
 from __future__ import annotations
 
 from typing import Any, Dict, TYPE_CHECKING


### PR DESCRIPTION
## Summary
- prepend standard disclaimer header to `profile_card.py`
- prepend standard disclaimer header to `annual_audit.py`
- prepend standard disclaimer header to `social/profile_ui_hook.py`
- verify patch monitor passes

## Testing
- `pytest -q`
- `PYTHONPATH=. python scripts/patch_monitor_hook.py`

------
https://chatgpt.com/codex/tasks/task_e_688c194b39848320bb8a3aca5fda7e29