### PR TITLE
Fix default emails and alias ui_wrapper

### DIFF
--- a/db_models.py
+++ b/db_models.py
@@ -726,9 +726,9 @@ def seed_default_users() -> None:
             exists = session.query(Harmonizer).filter_by(username=username).first()
             if not exists:
                 hashed = hashlib.sha256(username.encode()).hexdigest()
-                email = f"{username}@example.com"
+                email = f"{username}@supernova.dev"
                 if username == "demo_user":
-                    email = "demo@example.com"
+                    email = "demo@supernova.dev"
                 user = Harmonizer(
                     username=username,
                     email=email,

--- a/ui.py
+++ b/ui.py
@@ -51,6 +51,7 @@ except ImportError:
             raise AttributeError(name)
 
     ui = _UIWrapper(_shadcn_ui)
+    ui_wrapper = ui
 
 
 from datetime import datetime, timezone
@@ -272,6 +273,9 @@ except ImportError:
 # Ensure `ui.tabs` is present—even if streamlit_helpers imported an incomplete ui
 if not hasattr(ui, "tabs"):
     ui.tabs = _UIWrapper().tabs  # type: ignore[attr-defined]
+
+# Alias used by older code paths
+ui_wrapper = ui
 
 
 


### PR DESCRIPTION
## Summary
- add `ui_wrapper` alias for UI helpers in `ui.py`
- standardize seed emails in `db_models.py` to `supernova.dev`
- ensure project tests pass

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c195222708320b655ddce9be0e57c