### PR TITLE
Fix indentation in social tab

### DIFF
--- a/social_tabs.py
+++ b/social_tabs.py
@@ -83,8 +83,6 @@ def render_social_tab(main_container=None) -> None:
     container_ctx = safe_container(main_container)
     with container_ctx:
         header("Friends & Followers")
-
-
         if dispatch_route is None or SessionLocal is None or Harmonizer is None:
             st.info("Social routes not available")
             return


### PR DESCRIPTION
## Summary
- fix indentation in `social_tabs.py`
- remove two stray blank lines

## Testing
- `make lint` *(fails: streamlit-test is not a valid Python package name)*
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688c1de4694083208fbf7560aeaffe02