### PR TITLE
Make layouts responsive

### DIFF
--- a/chat_ui.py
+++ b/chat_ui.py
@@ -86,7 +86,7 @@ def render_chat_interface() -> None:
         st.markdown("</div>", unsafe_allow_html=True)
 
         st.markdown("<div class='chat-input-row'>", unsafe_allow_html=True)
-        col1, col2 = st.columns([4, 1])
+        col1, col2 = st.columns([0.8, 0.2])
         with col1:
             msg = st.text_input(
                 "Message",

--- a/frontend/ui_layout.py
+++ b/frontend/ui_layout.py
@@ -109,6 +109,12 @@ def render_top_bar() -> None:
             background: rgba(30, 30, 30, 0.6);
             backdrop-filter: blur(8px);
         }
+        @media (max-width: 600px) {
+            .sn-topbar {
+                flex-direction: column;
+                align-items: stretch;
+            }
+        }
         .sn-topbar input {
             flex: 1;
             padding: 0.25rem 0.5rem;
@@ -123,7 +129,7 @@ def render_top_bar() -> None:
 
     with st.container():
         st.markdown('<div class="sn-topbar">', unsafe_allow_html=True)
-        cols = st.columns([1, 4, 2, 1])
+        cols = st.columns([0.125, 0.5, 0.25, 0.125])
         logo_col = cols[0] if len(cols) > 0 else st
         search_col = cols[1] if len(cols) > 1 else st
         beta_col = cols[2] if len(cols) > 2 else st

--- a/profile_card.py
+++ b/profile_card.py
@@ -13,7 +13,7 @@ def render_profile_card(username: str, avatar_url: str) -> None:
     badge = "🚀 Production" if env.startswith("prod") else "🧪 Development"
 
     st.markdown("<div class='glass-card'>", unsafe_allow_html=True)
-    col1, col2 = st.columns([1, 3])
+    col1, col2 = st.columns([0.25, 0.75])
     with col1:
         st.image(avatar_url, width=48, use_container_width=True)
     with col2:

--- a/transcendental_resonance_frontend/pages/chat.py
+++ b/transcendental_resonance_frontend/pages/chat.py
@@ -24,7 +24,7 @@ def main(main_container=None) -> None:
 
     container_ctx = safe_container(main_container)
     with container_ctx:
-        header_col, status_col = st.columns([8, 1])
+        header_col, status_col = st.columns([0.8, 0.2])
         with header_col:
             header("💬 Chat")
         with status_col:

--- a/transcendental_resonance_frontend/ui/chat_ui.py
+++ b/transcendental_resonance_frontend/ui/chat_ui.py
@@ -29,7 +29,7 @@ def render_conversation_list() -> None:
     active = st.session_state.get("active_chat")
     if active not in users and users:
         active = users[0]
-    col1, col2 = st.columns([1, 3])
+    col1, col2 = st.columns([0.25, 0.75])
     with col1:
         selected = (
             st.radio(

--- a/transcendental_resonance_frontend/ui/profile_card.py
+++ b/transcendental_resonance_frontend/ui/profile_card.py
@@ -52,7 +52,7 @@ def render_profile_card(user_data: Optional[Dict[str, object]] = None) -> None:
 
     with st.container():
         st.markdown("<div class='profile-container'>", unsafe_allow_html=True)
-        col1, col2 = st.columns([1, 3])
+        col1, col2 = st.columns([0.25, 0.75])
         with col1:
             st.markdown(
                 f"<img class='profile-pic' src='{data.get('avatar_url')}' alt='avatar'>",


### PR DESCRIPTION
## Summary
- add media query to top bar
- use fractional column widths across cards and chat
- update chat page column layout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c26a3a7c88320b56958a57ccde9ac