### PR TITLE
Add CSS transitions and theme toggle

### DIFF
--- a/frontend/theme.py
+++ b/frontend/theme.py
@@ -12,12 +12,14 @@ import streamlit as st
 
 @dataclass(frozen=True)
 class ColorTheme:
-    """Simple container for theme colors."""
+    """Simple container for theme colors and common tokens."""
 
     bg: str
     card: str
     accent: str
     text_muted: str
+    radius: str = "0.5rem"
+    transition: str = "0.3s ease"
 
 
 LIGHT_THEME = ColorTheme(
@@ -52,6 +54,22 @@ def get_global_css(dark: bool = True) -> str:
     --card: {theme.card};
     --accent: {theme.accent};
     --text-muted: {theme.text_muted};
+    --radius: {theme.radius};
+    --transition: {theme.transition};
+}}
+
+.fade-in {{
+    opacity: 0;
+    animation: fade-in var(--transition) forwards;
+}}
+
+.rounded {{
+    border-radius: var(--radius);
+}}
+
+@keyframes fade-in {{
+    from {{ opacity: 0; }}
+    to {{ opacity: 1; }}
 }}
 </style>
 """

--- a/streamlit_helpers.py
+++ b/streamlit_helpers.py
@@ -525,6 +525,39 @@ def theme_selector(label: str = "Theme", *, key_suffix: str | None = None) -> st
 
     return chosen
 
+
+def theme_toggle(label: str = "Dark Mode", *, key_suffix: str | None = None) -> str:
+    """Switch between light and dark themes using a toggle widget."""
+
+    inject_modern_styles()
+
+    if key_suffix is None:
+        key_suffix = "default"
+
+    theme_key = f"theme_{key_suffix}"
+    toggle_key = f"theme_toggle_{key_suffix}"
+
+    current = st.session_state.get(theme_key, "light")
+    st.markdown("<div class='fade-in rounded'>", unsafe_allow_html=True)
+    is_dark = st.toggle(label, value=current == "dark", key=toggle_key)
+    st.markdown("</div>", unsafe_allow_html=True)
+
+    chosen = "dark" if is_dark else "light"
+    st.session_state[theme_key] = chosen
+    st.session_state["theme"] = chosen
+
+    apply_theme(chosen)
+
+    try:
+        st.query_params["theme"] = chosen
+    except Exception:
+        try:
+            st.experimental_set_query_params(theme=chosen)
+        except Exception:
+            pass
+
+    return chosen
+
 def centered_container(max_width: str = "900px") -> "st.delta_generator.DeltaGenerator":  # type: ignore
     """Return a container with standardized width constraints."""
     st.markdown(
@@ -614,6 +647,7 @@ __all__ = [
     "sanitize_text",
     "apply_theme",
     "theme_selector",
+    "theme_toggle",
     "get_active_user",
     "centered_container",
     "safe_container",

--- a/transcendental_resonance_frontend/pages/agents.py
+++ b/transcendental_resonance_frontend/pages/agents.py
@@ -6,7 +6,7 @@ import streamlit as st
 from frontend.light_theme import inject_light_theme
 from modern_ui import inject_modern_styles
 from agent_ui import render_agent_insights_tab
-from streamlit_helpers import theme_selector
+from streamlit_helpers import theme_toggle
 
 __all__ = ["main", "render"]
 
@@ -21,7 +21,7 @@ def main(main_container=None) -> None:
     If no main_container is provided, uses Streamlit root context.
     """
     container = main_container if main_container is not None else st
-    theme_selector("Theme", key_suffix="agents")
+    theme_toggle("Dark Mode", key_suffix="agents")
 
     try:
         container.title("🤖 Agents")

--- a/transcendental_resonance_frontend/pages/chat.py
+++ b/transcendental_resonance_frontend/pages/chat.py
@@ -6,7 +6,7 @@
 import streamlit as st
 from frontend.light_theme import inject_light_theme
 from modern_ui import inject_modern_styles
-from streamlit_helpers import safe_container, header, theme_selector
+from streamlit_helpers import safe_container, header, theme_toggle
 from status_indicator import render_status_icon
 from chat_ui import render_chat_interface
 
@@ -20,7 +20,7 @@ def main(main_container=None) -> None:
         main_container = st
     page = "chat"
     st.session_state["active_page"] = page
-    theme_selector("Theme", key_suffix=page)
+    theme_toggle("Dark Mode", key_suffix=page)
 
     container_ctx = safe_container(main_container)
     with container_ctx:

--- a/transcendental_resonance_frontend/pages/feed.py
+++ b/transcendental_resonance_frontend/pages/feed.py
@@ -14,7 +14,7 @@ import streamlit as st
 
 from frontend.light_theme import inject_light_theme
 from modern_ui import inject_modern_styles
-from streamlit_helpers import theme_selector, safe_container
+from streamlit_helpers import theme_toggle, safe_container
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Sample data models
@@ -167,7 +167,7 @@ def _page_body() -> None:
     """Render the main feed inside the current container."""
     _init_state()
 
-    theme_selector("Theme", key_suffix="feed")
+    theme_toggle("Dark Mode", key_suffix="feed")
     st.toggle("beta mode", key="beta_mode")
 
     posts: List[Post] = st.session_state["posts"]

--- a/transcendental_resonance_frontend/pages/messages.py
+++ b/transcendental_resonance_frontend/pages/messages.py
@@ -7,13 +7,17 @@ from __future__ import annotations
 
 import streamlit as st
 from frontend.light_theme import inject_light_theme
+from modern_ui import inject_modern_styles
+from streamlit_helpers import theme_toggle
 from transcendental_resonance_frontend.ui.chat_ui import render_chat_ui
 
 inject_light_theme()
+inject_modern_styles()
 
 
 def main(main_container=None) -> None:
     """Render the chat interface inside the given container (or the page itself)."""
+    theme_toggle("Dark Mode", key_suffix="messages")
     render_chat_ui(main_container)
 
 

--- a/transcendental_resonance_frontend/pages/messages_center.py
+++ b/transcendental_resonance_frontend/pages/messages_center.py
@@ -9,7 +9,7 @@ import asyncio
 import streamlit as st
 from frontend.light_theme import inject_light_theme
 from modern_ui import inject_modern_styles
-from streamlit_helpers import safe_container, header, theme_selector
+from streamlit_helpers import safe_container, header, theme_toggle
 from transcendental_resonance_frontend.src.utils import api
 from status_indicator import render_status_icon
 
@@ -140,7 +140,7 @@ def main(main_container=None) -> None:
     page = "messages_center"
     st.session_state["active_page"] = page
     key_prefix = f"{page}_"
-    theme_selector("Theme", key_suffix="msg_center")
+    theme_toggle("Dark Mode", key_suffix="msg_center")
 
     with safe_container(main_container):
         header_col, status_col = st.columns([8, 1])

--- a/transcendental_resonance_frontend/pages/profile.py
+++ b/transcendental_resonance_frontend/pages/profile.py
@@ -9,7 +9,7 @@ from modern_ui import inject_modern_styles
 from streamlit_helpers import (
     safe_container,
     header,
-    theme_selector,
+    theme_toggle,
     get_active_user,
     ensure_active_user,
 )
@@ -118,7 +118,7 @@ def main(main_container=None) -> None:
         main_container = st
     init_db()
     seed_default_users()
-    theme_selector("Theme", key_suffix="profile")
+    theme_toggle("Dark Mode", key_suffix="profile")
     # …inside render_social_tab (or whichever function/file this is)
     get_active_user()                     # make sure the key exists
     container_ctx = safe_container(main_container)

--- a/transcendental_resonance_frontend/pages/resonance_music.py
+++ b/transcendental_resonance_frontend/pages/resonance_music.py
@@ -20,7 +20,7 @@ from streamlit_helpers import (
     centered_container,
     safe_container,
     header,
-    theme_selector,
+    theme_toggle,
 )
 from streamlit_autorefresh import st_autorefresh
 from status_indicator import render_status_icon, check_backend # Ensure check_backend is imported
@@ -77,7 +77,7 @@ def main(main_container=None, status_container=None) -> None:
         main_container = st
     if status_container is None:
         status_container = st
-    theme_selector("Theme", key_suffix="music")
+    theme_toggle("Dark Mode", key_suffix="music")
 
     # Auto-refresh for backend health check (global, outside main_container)
     st_autorefresh(interval=30000, key="status_ping")

--- a/transcendental_resonance_frontend/pages/social.py
+++ b/transcendental_resonance_frontend/pages/social.py
@@ -7,7 +7,7 @@ import streamlit as st
 from frontend.light_theme import inject_light_theme
 from modern_ui import inject_modern_styles
 from social_tabs import render_social_tab
-from streamlit_helpers import safe_container, render_mock_feed, theme_selector
+from streamlit_helpers import safe_container, render_mock_feed, theme_toggle
 from feed_renderer import render_feed
 
 inject_light_theme()
@@ -18,7 +18,7 @@ def main(main_container=None) -> None:
     """Render the social page content within ``main_container``."""
     if main_container is None:
         main_container = st
-    theme_selector("Theme", key_suffix="social")
+    theme_toggle("Dark Mode", key_suffix="social")
 
     container_ctx = safe_container(main_container)
     with container_ctx:

--- a/transcendental_resonance_frontend/pages/validation.py
+++ b/transcendental_resonance_frontend/pages/validation.py
@@ -7,7 +7,7 @@ import importlib
 import streamlit as st
 from frontend.light_theme import inject_light_theme
 from modern_ui import inject_modern_styles
-from streamlit_helpers import safe_container, theme_selector
+from streamlit_helpers import safe_container, theme_toggle
 
 # --------------------------------------------------------------------
 # Dynamic loader with graceful degradation
@@ -45,7 +45,7 @@ def main(main_container=None) -> None:
     """Render the validation UI inside a safe container."""
     if main_container is None:
         main_container = st
-    theme_selector("Theme", key_suffix="validation")
+    theme_toggle("Dark Mode", key_suffix="validation")
 
     global render_validation_ui
     # Reload if we initially fell back but the real module may now exist

--- a/transcendental_resonance_frontend/pages/video_chat.py
+++ b/transcendental_resonance_frontend/pages/video_chat.py
@@ -11,7 +11,7 @@ from modern_ui import inject_modern_styles
 
 from ai_video_chat import create_session
 from video_chat_router import ConnectionManager
-from streamlit_helpers import safe_container, header, theme_selector
+from streamlit_helpers import safe_container, header, theme_toggle
 
 inject_light_theme()
 inject_modern_styles()
@@ -35,7 +35,7 @@ manager = ConnectionManager()
 def main(main_container=None) -> None:
     """Render the simple video chat demo."""
     container = main_container if main_container is not None else st
-    theme_selector("Theme", key_suffix="video_chat")
+    theme_toggle("Dark Mode", key_suffix="video_chat")
 
     container_ctx = safe_container(container)
     with container_ctx:

--- a/transcendental_resonance_frontend/pages/voting.py
+++ b/transcendental_resonance_frontend/pages/voting.py
@@ -7,7 +7,7 @@ import streamlit as st
 from frontend.light_theme import inject_light_theme
 from modern_ui import inject_modern_styles
 from voting_ui import render_voting_tab
-from streamlit_helpers import safe_container, theme_selector
+from streamlit_helpers import safe_container, theme_toggle
 
 inject_light_theme()
 inject_modern_styles()
@@ -17,7 +17,7 @@ def main(main_container=None) -> None:
     """Render the Governance and Voting page inside ``main_container``."""
     if main_container is None:
         main_container = st
-    theme_selector("Theme", key_suffix="voting")
+    theme_toggle("Dark Mode", key_suffix="voting")
 
     container_ctx = safe_container(main_container)
     with container_ctx:


### PR DESCRIPTION
## Summary
- add animation variables and utility classes in `frontend/theme.py`
- implement `theme_toggle` helper with fade-in and rounded styles
- apply modern styles on messages page
- replace theme selectors with toggles across pages

## Testing
- `pytest -q`
- `streamlit run pages/feed.py --server.headless=true --server.port=8501` (starts without error)

------
https://chatgpt.com/codex/tasks/task_e_688c27bf5da08320af4687bc44ecfee4