### PR TITLE
Use FontAwesome icons throughout UI

### DIFF
--- a/frontend/ui_layout.py
+++ b/frontend/ui_layout.py
@@ -130,7 +130,7 @@ def render_top_bar() -> None:
         avatar_col = cols[3] if len(cols) > 3 else st
         logo_target = logo_col if hasattr(logo_col, "markdown") else st
         logo_target.markdown(
-            '<img src="https://placehold.co/32x32?text=SN" width="32" />',
+            '<i class="fa-solid fa-rocket fa-lg"></i>',
             unsafe_allow_html=True,
         )
         search_target = search_col if hasattr(search_col, "text_input") else st
@@ -152,7 +152,7 @@ def render_top_bar() -> None:
             st.experimental_set_query_params(beta="1" if beta_enabled else "0")
         avatar_target = avatar_col if hasattr(avatar_col, "markdown") else st
         avatar_target.markdown(
-            '<img src="https://placehold.co/32x32" width="32" style="border-radius:50%" />',
+            '<i class="fa-solid fa-user-circle fa-lg"></i>',
             unsafe_allow_html=True,
         )
         st.markdown('</div>', unsafe_allow_html=True)
@@ -276,12 +276,12 @@ def render_title_bar(icon: str, label: str) -> None:
     )
 
 
-def show_preview_badge(text: str = "🚧 Preview Mode") -> None:
+def show_preview_badge(text: str = "Preview Mode") -> None:
     """Overlay a badge used when a fallback or WIP page is shown."""
     st.markdown(
         f"<div style='position:fixed; top:1rem; right:1rem; background:#ffc107; "
         f"color:#000; padding:0.25rem 0.5rem; border-radius:4px; z-index:1000;'>"
-        f"{text}</div>",
+        f"<i class='fa-solid fa-triangle-exclamation'></i> {text}</div>",
         unsafe_allow_html=True,
     )
 

--- a/modern_ui.py
+++ b/modern_ui.py
@@ -42,6 +42,7 @@ def inject_modern_styles() -> None:
     css = """
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <script type="module" src="/static/lucide-react.min.js"></script>
     <style>
     body, .stApp {

--- a/modern_ui_components.py
+++ b/modern_ui_components.py
@@ -157,6 +157,8 @@ def _icon_html(name: str) -> str:
     """Return HTML for an icon."""
     if not name:
         return ""
+    if name.startswith("fa"):
+        return f"<i class='{name}'></i>"
     if HAS_LUCIDE:
         return f"<i class='icon' data-lucide='{name}'></i>"
     return name

--- a/ui.py
+++ b/ui.py
@@ -185,12 +185,21 @@ def normalize_choice(choice: str) -> str:
     """Return the canonical label for ``choice`` ignoring case."""
     return _PAGE_LABELS.get(choice.lower(), choice)
 
-# Icons used in the navigation bar. Must be single-character emojis or
+# Icons used in the navigation bar. Accepts Font Awesome classes or
 # valid Bootstrap icon codes prefixed with ``"bi bi-"``.
-# Emoji icons for sidebar navigation in alphabetical page order.
 # Agents, Chat, Messages, Profile, Resonance Music, Social, Validation,
 # Video Chat, Voting
-NAV_ICONS = ["🤖", "💬", "✉️", "👤", "🎵", "👥", "✅", "🎥", "📊"]
+NAV_ICONS = [
+    "fa-solid fa-robot",
+    "fa-solid fa-comments",
+    "fa-solid fa-envelope",
+    "fa-solid fa-user",
+    "fa-solid fa-music",
+    "fa-solid fa-users",
+    "fa-solid fa-check",
+    "fa-solid fa-video",
+    "fa-solid fa-chart-bar",
+]
 
 
 # Toggle verbose output via ``UI_DEBUG_PRINTS``
@@ -1245,7 +1254,17 @@ def render_validation_ui(
         page_paths = {
             label: f"/pages/{mod}.py" for label, mod in PAGES.items()
         }
-        NAV_ICONS = ["🤖", "💬", "✉️", "👤", "🎵", "👥", "✅", "🎥", "📊"]
+        NAV_ICONS = [
+            "fa-solid fa-robot",
+            "fa-solid fa-comments",
+            "fa-solid fa-envelope",
+            "fa-solid fa-user",
+            "fa-solid fa-music",
+            "fa-solid fa-users",
+            "fa-solid fa-check",
+            "fa-solid fa-video",
+            "fa-solid fa-chart-bar",
+        ]
 
         # ...
 


### PR DESCRIPTION
## Summary
- load Font Awesome stylesheet with the other global styles
- render `<i>` tags for icons starting with `fa`
- show Font Awesome icons in the top bar and preview badge
- update navigation constants to use Font Awesome classes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c26a9f5a48320aeeb055932ac2824