### PR TITLE
Fix UI placeholder pages and stats section

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -8,3 +8,7 @@ backgroundColor = "#001E26"
 secondaryBackgroundColor = "#002B36"
 textColor = "#E0FFFF"
 font = "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+
+[server]
+# Switch to polling to avoid inotify limits
+fileWatcherType = "poll"

--- a/modern_ui.py
+++ b/modern_ui.py
@@ -178,7 +178,7 @@ def render_validation_card() -> None:
         unsafe_allow_html=True,
     )
 
-def render_stats_section() -> None:
+def render_stats_section(stats: dict | None = None) -> None:
     """Display quick stats using a responsive flexbox layout."""
 
     accent = theme.get_accent_color()
@@ -232,15 +232,26 @@ def render_stats_section() -> None:
         unsafe_allow_html=True,
     )
 
-    stats = [
-        ("🏃‍♂️", "Runs", "0"),
-        ("📝", "Proposals", "12"),
-        ("⚡", "Success Rate", "94%"),
-        ("🎯", "Accuracy", "98.2%"),
-    ]
+    default_stats = {
+        "runs": "0",
+        "proposals": "12",
+        "success_rate": "94%",
+        "accuracy": "98.2%",
+    }
+    if stats is None:
+        stats = default_stats
+    else:
+        default_stats.update(stats)
+        stats = default_stats
 
+    entries = [
+        ("🏃‍♂️", "Runs", stats.get("runs")),
+        ("📝", "Proposals", stats.get("proposals")),
+        ("⚡", "Success Rate", stats.get("success_rate")),
+        ("🎯", "Accuracy", stats.get("accuracy")),
+    ]
     st.markdown("<div class='stats-container'>", unsafe_allow_html=True)
-    for icon, label, value in stats:
+    for icon, label, value in entries:
         st.markdown(
             f"""
             <div class='stats-card'>

--- a/pages/agents.py
+++ b/pages/agents.py
@@ -1,8 +1,26 @@
-# STRICTLY A SOCIAL MEDIA PLATFORM
-# Intellectual Property & Artistic Inspiration
-# Legal & Ethical Safeguards
+import importlib
+import streamlit as st
 
-from transcendental_resonance_frontend.pages.agents import main
+
+def main() -> None:
+    """Load the real agents page if present, otherwise show a placeholder."""
+    try:
+        mod = importlib.import_module(
+            "transcendental_resonance_frontend.pages.agents"
+        )
+        if hasattr(mod, "main"):
+            return mod.main()
+        if hasattr(mod, "render"):
+            return mod.render()
+    except Exception:
+        pass
+    st.header("Agents")
+    st.info("Agents page not available.")
+
+
+def render() -> None:
+    main()
+
 
 if __name__ == "__main__":
     main()

--- a/pages/validation.py
+++ b/pages/validation.py
@@ -1,8 +1,26 @@
-# STRICTLY A SOCIAL MEDIA PLATFORM
-# Intellectual Property & Artistic Inspiration
-# Legal & Ethical Safeguards
-
+import importlib
 import streamlit as st
 
-def main():
-    st.write("Placeholder page.")
+
+def main() -> None:
+    """Load the real validation page if present or show a placeholder."""
+    try:
+        mod = importlib.import_module(
+            "transcendental_resonance_frontend.pages.validation"
+        )
+        if hasattr(mod, "main"):
+            return mod.main()
+        if hasattr(mod, "render"):
+            return mod.render()
+    except Exception:
+        pass
+    st.header("Validation")
+    st.info("Validation page not available.")
+
+
+def render() -> None:
+    main()
+
+
+if __name__ == "__main__":
+    main()

--- a/pages/voting.py
+++ b/pages/voting.py
@@ -1,8 +1,26 @@
-# STRICTLY A SOCIAL MEDIA PLATFORM
-# Intellectual Property & Artistic Inspiration
-# Legal & Ethical Safeguards
+import importlib
+import streamlit as st
 
-from transcendental_resonance_frontend.pages.voting import main
+
+def main() -> None:
+    """Load the real voting page if available or show a placeholder."""
+    try:
+        mod = importlib.import_module(
+            "transcendental_resonance_frontend.pages.voting"
+        )
+        if hasattr(mod, "main"):
+            return mod.main()
+        if hasattr(mod, "render"):
+            return mod.render()
+    except Exception:
+        pass
+    st.header("Voting")
+    st.info("Voting page not available.")
+
+
+def render() -> None:
+    main()
+
 
 if __name__ == "__main__":
     main()

--- a/ui.py
+++ b/ui.py
@@ -319,7 +319,6 @@ try:
     from modern_ui import (
         inject_modern_styles,
         inject_light_theme,
-        render_stats_section,
     )
 except Exception:  # pragma: no cover - gracefully handle missing/invalid module
     def inject_modern_styles(*_a, **_k):
@@ -327,9 +326,6 @@ except Exception:  # pragma: no cover - gracefully handle missing/invalid module
 
     def inject_light_theme(*_a, **_k):
         return None
-
-    def render_stats_section(*_a, **_k):
-        st.info("stats section unavailable")
 
 
 try:
@@ -596,6 +592,7 @@ def load_page_with_fallback(choice: str, module_paths: list[str] | None = None) 
     if last_exc:
         with st.expander("Show error details"):
             st.exception(last_exc)
+    return
 
 
 def _render_fallback(choice: str) -> None:


### PR DESCRIPTION
## Summary
- create standalone placeholders for Agents, Voting and Validation pages
- avoid inotify limit errors by setting Streamlit watcher type to poll
- allow passing stats to `render_stats_section`
- prefer modern_ui_components stats section implementation
- ensure page loader returns after fallback

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c292d1278832093ed4374b373e33d