### PR TITLE
Fix missing pages and stats section

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -8,3 +8,7 @@ backgroundColor = "#001E26"
 secondaryBackgroundColor = "#002B36"
 textColor = "#E0FFFF"
 font = "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+
+[server]
+# Polling watcher avoids hitting the inotify limit on some Linux setups
+fileWatcherType = "poll"

--- a/modern_ui.py
+++ b/modern_ui.py
@@ -178,7 +178,7 @@ def render_validation_card() -> None:
         unsafe_allow_html=True,
     )
 
-def render_stats_section() -> None:
+def render_stats_section(stats: dict | None = None) -> None:
     """Display quick stats using a responsive flexbox layout."""
 
     accent = theme.get_accent_color()
@@ -232,15 +232,23 @@ def render_stats_section() -> None:
         unsafe_allow_html=True,
     )
 
-    stats = [
+    default_entries = [
         ("🏃‍♂️", "Runs", "0"),
         ("📝", "Proposals", "12"),
         ("⚡", "Success Rate", "94%"),
         ("🎯", "Accuracy", "98.2%"),
     ]
+    entries = default_entries
+    if isinstance(stats, dict):
+        entries = [
+            ("🏃‍♂️", "Runs", stats.get("runs", "0")),
+            ("📝", "Proposals", stats.get("proposals", "N/A")),
+            ("⚡", "Success Rate", stats.get("success_rate", "N/A")),
+            ("🎯", "Accuracy", stats.get("accuracy", "N/A")),
+        ]
 
     st.markdown("<div class='stats-container'>", unsafe_allow_html=True)
-    for icon, label, value in stats:
+    for icon, label, value in entries:
         st.markdown(
             f"""
             <div class='stats-card'>

--- a/pages/agents.py
+++ b/pages/agents.py
@@ -2,7 +2,25 @@
 # Intellectual Property & Artistic Inspiration
 # Legal & Ethical Safeguards
 
-from transcendental_resonance_frontend.pages.agents import main
+import importlib
+import streamlit as st
 
-if __name__ == "__main__":
+
+def main() -> None:
+    """Render the Agents page or a simple placeholder."""
+    try:
+        mod = importlib.import_module(
+            "transcendental_resonance_frontend.pages.agents"
+        )
+        mod.main()
+    except Exception:
+        st.info("Agents page not available.")
+
+
+def render() -> None:
+    """Streamlit multipage entrypoint."""
+    main()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
     main()

--- a/pages/validation.py
+++ b/pages/validation.py
@@ -2,7 +2,22 @@
 # Intellectual Property & Artistic Inspiration
 # Legal & Ethical Safeguards
 
+import importlib
 import streamlit as st
 
-def main():
-    st.write("Placeholder page.")
+
+def main() -> None:
+    """Render the Validation page or a simple placeholder."""
+    try:
+        mod = importlib.import_module(
+            "transcendental_resonance_frontend.pages.validation"
+        )
+        mod.main()
+    except Exception:
+        st.info("Validation page not available.")
+
+
+def render() -> None:
+    """Streamlit multipage entrypoint."""
+    main()
+

--- a/pages/voting.py
+++ b/pages/voting.py
@@ -2,7 +2,25 @@
 # Intellectual Property & Artistic Inspiration
 # Legal & Ethical Safeguards
 
-from transcendental_resonance_frontend.pages.voting import main
+import importlib
+import streamlit as st
 
-if __name__ == "__main__":
+
+def main() -> None:
+    """Render the Voting page or a simple placeholder."""
+    try:
+        mod = importlib.import_module(
+            "transcendental_resonance_frontend.pages.voting"
+        )
+        mod.main()
+    except Exception:
+        st.info("Voting page not available.")
+
+
+def render() -> None:
+    """Streamlit multipage entrypoint."""
+    main()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
     main()


### PR DESCRIPTION
## Summary
- add fallback streamlit pages
- update stats section to handle argument
- switch streamlit watcher to poll to avoid inotify limit

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c292fa15083209630a6f7a5bf44ad