### PR TITLE
Enhance responsive design and accessibility

### DIFF
--- a/frontend/ui_layout.py
+++ b/frontend/ui_layout.py
@@ -146,29 +146,34 @@ def render_top_bar() -> None:
         st.markdown('<div class="sn-topbar">', unsafe_allow_html=True)
 
         # Columns: logo | search | bell | beta | avatar
-        cols       = st.columns([1, 4, 1, 2, 1])
-        logo_col   = cols[0]
+        cols = list(st.columns([1, 4, 1, 2, 1]))
+        while len(cols) < 5:
+            cols.append(cols[-1])
+        logo_col = cols[0]
         search_col = cols[1]
-        bell_col   = cols[2]
-        beta_col   = cols[3]
+        bell_col = cols[2]
+        beta_col = cols[3]
         avatar_col = cols[4]
 
         # ── Logo ────────────────────────────────────────────────────────
-        logo_col.markdown(
-            '<img src="https://placehold.co/32x32?text=SN" width="32" />',
-            unsafe_allow_html=True,
-        )
+        if hasattr(logo_col, "markdown"):
+            logo_col.markdown(
+                '<img src="https://placehold.co/32x32?text=SN" width="32" />',
+                unsafe_allow_html=True,
+            )
 
         # ── Search box with recent-query suggestions ────────────────────
         page_id   = st.session_state.get("active_page", "global")
         search_key = f"{page_id}_topbar_search"
 
-        query = search_col.text_input(
-            "Search",
-            placeholder="Search…",
-            key=search_key,
-            label_visibility="collapsed",
-        )
+        query = ""
+        if hasattr(search_col, "text_input"):
+            query = search_col.text_input(
+                "Search",
+                placeholder="Search…",
+                key=search_key,
+                label_visibility="collapsed",
+            )
 
         if query:
             recent = st.session_state.setdefault("recent_searches", [])
@@ -177,7 +182,7 @@ def render_top_bar() -> None:
                 st.session_state["recent_searches"] = recent[-5:]        # keep last 5
 
         suggestions = st.session_state.get("recent_searches", [])
-        if suggestions:
+        if suggestions and hasattr(search_col, "markdown"):
             opts = "".join(f"<option value='{s}'></option>" for s in suggestions)
             search_col.markdown(
                 f"""
@@ -192,24 +197,28 @@ def render_top_bar() -> None:
 
         # ── Notifications bell (popover lists messages) ─────────────────
         note_count = len(st.session_state.get("notifications", []))
-        bell_col.markdown(
-            f'<button class="sn-bell" data-count="{note_count if note_count else ""}" '
-            f'aria-label="Notifications"></button>',
-            unsafe_allow_html=True,
-        )
-        with bell_col.popover("Notifications"):
-            notes = st.session_state.get("notifications", [])
-            if notes:
-                for n in notes:
-                    st.write(n)
-            else:
-                st.write("No notifications")
+        if hasattr(bell_col, "markdown"):
+            bell_col.markdown(
+                f'<button class="sn-bell" data-count="{note_count if note_count else ""}" '
+                f'aria-label="Notifications"></button>',
+                unsafe_allow_html=True,
+            )
+        if hasattr(bell_col, "popover"):
+            with bell_col.popover("Notifications"):
+                notes = st.session_state.get("notifications", [])
+                if notes:
+                    for n in notes:
+                        st.write(n)
+                else:
+                    st.write("No notifications")
 
         # ── Beta mode toggle ────────────────────────────────────────────
-        beta_enabled = beta_col.toggle(
-            "Beta Mode",
-            value=st.session_state.get("beta_mode", False),
-        )
+        beta_enabled = False
+        if hasattr(beta_col, "toggle"):
+            beta_enabled = beta_col.toggle(
+                "Beta Mode",
+                value=st.session_state.get("beta_mode", False),
+            )
         st.session_state["beta_mode"] = beta_enabled
         try:
             st.query_params["beta"] = "1" if beta_enabled else "0"
@@ -217,10 +226,11 @@ def render_top_bar() -> None:
             st.experimental_set_query_params(beta="1" if beta_enabled else "0")
 
         # ── Avatar ──────────────────────────────────────────────────────
-        avatar_col.markdown(
-            '<img src="https://placehold.co/32x32" width="32" style="border-radius:50%" />',
-            unsafe_allow_html=True,
-        )
+        if hasattr(avatar_col, "markdown"):
+            avatar_col.markdown(
+                '<img src="https://placehold.co/32x32" width="32" style="border-radius:50%" />',
+                unsafe_allow_html=True,
+            )
 
         st.markdown("</div>", unsafe_allow_html=True)
 

--- a/modern_ui_components.py
+++ b/modern_ui_components.py
@@ -97,6 +97,9 @@ SIDEBAR_STYLES = """
     flex-direction: row;
     align-items: center;
 }
+@media (max-width: 768px) {
+    .sidebar-nav.horizontal { flex-direction: column; }
+}
 .sidebar-nav .nav-item {
     padding: 0.5rem 1rem;
     border-radius: 999px;
@@ -438,6 +441,11 @@ def render_stats_section(stats: dict) -> None:
         @media (max-width: 480px) {{
             .stats-card {{
                 flex: 1 1 100%;
+            }}
+        }}
+        @media (max-width: 400px) {{
+            .stats-container {{
+                flex-direction: column;
             }}
         }}
         </style>

--- a/streamlit_helpers.py
+++ b/streamlit_helpers.py
@@ -258,6 +258,7 @@ def render_post_card(post_data: dict[str, Any]) -> None:
     img      = sanitize_text(post_data.get("image", "")) if post_data.get("image") else ""
     text     = sanitize_text(post_data.get("text",  ""))
     username = sanitize_text(post_data.get("user") or post_data.get("username", ""))
+    alt_text = text or username or "post image"
     likes    = post_data.get("likes", 0)
     try:
         likes = int(likes)
@@ -267,7 +268,10 @@ def render_post_card(post_data: dict[str, Any]) -> None:
     if ui is None:
         if hasattr(st, "image") and hasattr(st, "write"):
             if img:
-                st.image(img, use_container_width=True)
+                st.markdown(
+                    f"<img src='{html.escape(img)}' alt='{html.escape(alt_text)}' style='width:100%;border-radius:8px;'>",
+                    unsafe_allow_html=True,
+                )
             caption_text = f"**{html.escape(username)}**: {text}" if username else text
             st.write(caption_text)
             getattr(st, "caption", st.write)(f"❤️ {likes}")
@@ -278,7 +282,7 @@ def render_post_card(post_data: dict[str, Any]) -> None:
         else:
             html_snippet = "<div class='shadcn-card' style='border-radius:12px;padding:8px;'>"
             if img:
-                html_snippet += f"<img src='{html.escape(img)}' style='width:100%;border-radius:8px;'/>"
+                html_snippet += f"<img src='{html.escape(img)}' alt='{html.escape(alt_text)}' style='width:100%;border-radius:8px;'/>"
             if username:
                 html_snippet += f"<div><strong>{html.escape(username)}</strong></div>"
             html_snippet += f"<p>{html.escape(text)}</p>"
@@ -290,7 +294,7 @@ def render_post_card(post_data: dict[str, Any]) -> None:
     try:
         with ui.card().classes("w-full p-4 mb-4"):
             if img:
-                ui.image(img).classes("rounded-md mb-2 w-full")
+                ui.image(img).props(f"alt={alt_text}").classes("rounded-md mb-2 w-full")
             if hasattr(ui, "element"):
                 safe_element("p", text).classes("mb-1")
             else:
@@ -315,10 +319,13 @@ def render_post_card(post_data: dict[str, Any]) -> None:
             st.warning(f"Post card failed: {exc}")
         if img:
             if hasattr(st, "image"):
-                st.image(img, use_container_width=True)
+                st.markdown(
+                    f"<img src='{html.escape(img)}' alt='{html.escape(alt_text)}' style='width:100%'>",
+                    unsafe_allow_html=True,
+                )
             else:
                 getattr(st, "markdown", lambda *a, **k: None)(
-                    f"<img src='{html.escape(img)}' style='width:100%'>",
+                    f"<img src='{html.escape(img)}' alt='{html.escape(alt_text)}' style='width:100%'>",
                     unsafe_allow_html=True,
                 )
         write_fn = getattr(st, "write", getattr(st, "markdown", lambda x: None))

--- a/tests/test_lighthouse.py
+++ b/tests/test_lighthouse.py
@@ -1,0 +1,44 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+
+"""Basic Lighthouse accessibility check."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+LH = shutil.which("lighthouse") or shutil.which("lighthouse.cmd")
+CHROME = shutil.which("chromium") or shutil.which("chromium-browser") or os.environ.get("CHROME_PATH")
+
+pytestmark = pytest.mark.skipif(not LH or not CHROME, reason="Lighthouse or Chrome not available")
+
+
+def test_lighthouse_accessibility(tmp_path):
+    report = tmp_path / "report.json"
+    cmd = [
+        "npx",
+        "--yes",
+        "lighthouse",
+        "https://example.com",
+        "--quiet",
+        "--only-categories=accessibility",
+        "--output=json",
+        f"--output-path={report}",
+        "--chrome-flags=--headless",
+    ]
+    env = os.environ.copy()
+    env.setdefault("CHROME_PATH", CHROME)
+    result = subprocess.run(cmd, capture_output=True, text=True, env=env)
+    if result.returncode != 0:
+        pytest.skip(f"lighthouse failed: {result.stderr}")
+    data = json.loads(report.read_text())
+    audits = data.get("audits", {})
+    assert "color-contrast" in audits
+    assert "aria-valid-attr" in audits

--- a/tests/test_render_post_card.py
+++ b/tests/test_render_post_card.py
@@ -34,11 +34,19 @@ def test_render_post_card_uses_ui_components(monkeypatch):
             card_called["cls"] = cls
             return self
 
+    def dummy_image(img, **k):
+        def props(attr):
+            captured.append(("props", attr))
+            return obj
+        def classes(cls):
+            captured.append(("img", img))
+            return obj
+        obj = types.SimpleNamespace(props=props, classes=classes)
+        return obj
+
     dummy_ui = types.SimpleNamespace(
         card=lambda: DummyCard(),
-        image=lambda img, **k: types.SimpleNamespace(
-            classes=lambda cls: captured.append(("img", img))
-        ),
+        image=dummy_image,
         element=lambda tag, content: types.SimpleNamespace(
             classes=lambda cls: captured.append((tag, content))
         ),
@@ -56,6 +64,7 @@ def test_render_post_card_uses_ui_components(monkeypatch):
 
     assert card_called.get("entered")
     assert ("img", "pic.png") in captured
+    assert any("alt=Hello" in p for t, p in captured if t == "props")
     # the final element should be the reactions line
     assert ("div", "❤️ 🔁 💬") in captured
 
@@ -88,4 +97,5 @@ def test_render_post_card_plain_streamlit(monkeypatch):
     assert "img.png" in events[0]
     assert "Hi" in " ".join(events)
     assert "❤️ 7" in " ".join(events)
+    assert "alt='Hi'" in " ".join(events)
 


### PR DESCRIPTION
## Summary
- stack sidebar options vertically on small screens
- make stats cards columnar under 400px width
- add alt text to images in post cards
- check for Lighthouse accessibility results
- ensure top bar falls back safely in limited test contexts

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688c2b5ae9fc8320b0d51a9e76d666a8