### PR TITLE
Update theme imports

### DIFF
--- a/modern_ui_components.py
+++ b/modern_ui_components.py
@@ -21,12 +21,7 @@ except Exception:  # pragma: no cover – fallback for isolated execution
 
 from uuid import uuid4
 from streamlit_helpers import safe_container
-
-try:
-    from modern_ui import inject_modern_styles
-except Exception:  # pragma: no cover - gracefully handle missing/invalid module
-    def inject_modern_styles(*_a, **_k):
-        return None
+from frontend.theme import inject_modern_styles
 
 try:
     from transcendental_resonance_frontend.src.utils.page_registry import get_pages_dir

--- a/transcendental_resonance_frontend/pages/agents.py
+++ b/transcendental_resonance_frontend/pages/agents.py
@@ -4,7 +4,7 @@
 
 import streamlit as st
 from frontend.light_theme import inject_light_theme
-from modern_ui import inject_modern_styles
+from frontend.theme import inject_modern_styles
 from agent_ui import render_agent_insights_tab
 from streamlit_helpers import theme_toggle
 

--- a/transcendental_resonance_frontend/pages/social.py
+++ b/transcendental_resonance_frontend/pages/social.py
@@ -5,7 +5,7 @@
 
 import streamlit as st
 from frontend.light_theme import inject_light_theme
-from modern_ui import inject_modern_styles
+from frontend.theme import inject_modern_styles
 from social_tabs import render_social_tab
 from streamlit_helpers import safe_container, render_mock_feed, theme_toggle
 from feed_renderer import render_feed

--- a/transcendental_resonance_frontend/pages/validation.py
+++ b/transcendental_resonance_frontend/pages/validation.py
@@ -6,7 +6,7 @@
 import importlib
 import streamlit as st
 from frontend.light_theme import inject_light_theme
-from modern_ui import inject_modern_styles
+from frontend.theme import inject_modern_styles
 from streamlit_helpers import safe_container, theme_toggle
 
 # --------------------------------------------------------------------

--- a/transcendental_resonance_frontend/pages/video_chat.py
+++ b/transcendental_resonance_frontend/pages/video_chat.py
@@ -7,7 +7,7 @@ import json
 
 import streamlit as st
 from frontend.light_theme import inject_light_theme
-from modern_ui import inject_modern_styles
+from frontend.theme import inject_modern_styles
 
 from ai_video_chat import create_session
 from video_chat_router import ConnectionManager

--- a/transcendental_resonance_frontend/pages/voting.py
+++ b/transcendental_resonance_frontend/pages/voting.py
@@ -5,7 +5,7 @@
 
 import streamlit as st
 from frontend.light_theme import inject_light_theme
-from modern_ui import inject_modern_styles
+from frontend.theme import inject_modern_styles
 from voting_ui import render_voting_tab
 from streamlit_helpers import safe_container, theme_toggle
 

--- a/ui.py
+++ b/ui.py
@@ -322,19 +322,8 @@ from streamlit_helpers import (
     render_post_card,
     render_instagram_grid,
 )
-from frontend.theme import apply_theme
-
-try:
-    from modern_ui import (
-        inject_modern_styles,
-        inject_light_theme,
-    )
-except Exception:  # pragma: no cover - gracefully handle missing/invalid module
-    def inject_modern_styles(*_a, **_k):
-        return None
-
-    def inject_light_theme(*_a, **_k):
-        return None
+from frontend.theme import apply_theme, inject_modern_styles
+from frontend.light_theme import inject_light_theme
 
 
 try:

--- a/ui_utils.py
+++ b/ui_utils.py
@@ -6,12 +6,7 @@
 from pathlib import Path
 import streamlit as st
 from streamlit_helpers import inject_global_styles
-try:
-    from modern_ui import render_modern_header
-except Exception:  # pragma: no cover - gracefully handle missing/invalid module
-    def render_modern_header(*_a, **_k):
-        return None
-from modern_ui_components import render_modern_sidebar
+from modern_ui_components import render_modern_header, render_modern_sidebar
 
 
 def summarize_text(text: str, max_len: int = 150) -> str:


### PR DESCRIPTION
## Summary
- update various frontend pages to use theme functions
- switch ui and utils to pull modern styles from frontend.theme
- clean up modern_ui references

## Testing
- `pytest -q` *(fails: OperationalError: no such table: harmonizers)*

------
https://chatgpt.com/codex/tasks/task_e_688c4087b8e88320a57eb46c41a53a76