### PR TITLE
Simplify Streamlit page wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,11 @@ Additional pages for **Voting**, **Agents**, and **Social** features are
 accessible from the navigation bar. These sections provide early scaffolding
 for governance, AI insights, and community interaction.
 
+Page implementations live in `transcendental_resonance_frontend/pages/`.
+Files inside `pages/` are minimal wrappers that simply import and run the
+corresponding module. Keep all logic in the frontend directory when
+modifying or adding pages.
+
 ### Starting the Backend
 
 The API must be reachable at [http://localhost:8000](http://localhost:8000). Start it with:

--- a/pages/agents.py
+++ b/pages/agents.py
@@ -1,43 +1,10 @@
 # STRICTLY A SOCIAL MEDIA PLATFORM
 # Intellectual Property & Artistic Inspiration
 # Legal & Ethical Safeguards
-"""Proxy loader for the Agents page."""
+"""Thin wrapper for the Agents page."""
 
-from __future__ import annotations
-
-import importlib
-import streamlit as st
+from transcendental_resonance_frontend.pages.agents import main, render
 
 
-def _load_real_page() -> bool:
-    """Import and invoke the real page if it exists. Return True on success."""
-    try:
-        mod = importlib.import_module(
-            "transcendental_resonance_frontend.pages.agents"
-        )
-    except ModuleNotFoundError:
-        return False
-
-    for fn in ("main", "render"):
-        if hasattr(mod, fn):
-            getattr(mod, fn)()
-            return True
-    return False
-
-
-def _placeholder() -> None:
-    st.header("Agents 👥")
-    st.info("The full Agents module isn’t installed yet.")
-
-
-def main() -> None:  # Streamlit runs this when the file is opened
-    if not _load_real_page():
-        _placeholder()
-
-
-def render() -> None:  # keep legacy compatibility
-    main()
-
-
-if __name__ == "__main__":  # manual execution
+if __name__ == "__main__":
     main()

--- a/pages/chat.py
+++ b/pages/chat.py
@@ -1,40 +1,9 @@
 # STRICTLY A SOCIAL MEDIA PLATFORM
 # Intellectual Property & Artistic Inspiration
 # Legal & Ethical Safeguards
-"""Proxy loader for the Chat page."""
+"""Thin wrapper for the Chat page."""
 
-from __future__ import annotations
-
-import importlib
-import streamlit as st
-
-
-def _load_real_page() -> bool:
-    try:
-        mod = importlib.import_module(
-            "transcendental_resonance_frontend.pages.chat"
-        )
-    except ModuleNotFoundError:
-        return False
-    for fn in ("main", "render"):
-        if hasattr(mod, fn):
-            getattr(mod, fn)()
-            return True
-    return False
-
-
-def _placeholder() -> None:
-    st.header("Chat 💬")
-    st.info("Chat UI not available.")
-
-
-def main() -> None:
-    if not _load_real_page():
-        _placeholder()
-
-
-def render() -> None:
-    main()
+from transcendental_resonance_frontend.pages.chat import main, render
 
 
 if __name__ == "__main__":

--- a/pages/feed.py
+++ b/pages/feed.py
@@ -1,40 +1,9 @@
 # STRICTLY A SOCIAL MEDIA PLATFORM
 # Intellectual Property & Artistic Inspiration
 # Legal & Ethical Safeguards
-"""Proxy loader for the Feed page."""
+"""Thin wrapper for the Feed page."""
 
-from __future__ import annotations
-
-import importlib
-import streamlit as st
-
-
-def _load_real_page() -> bool:
-    try:
-        mod = importlib.import_module(
-            "transcendental_resonance_frontend.pages.feed"
-        )
-    except ModuleNotFoundError:
-        return False
-    for fn in ("main", "render"):
-        if hasattr(mod, fn):
-            getattr(mod, fn)()
-            return True
-    return False
-
-
-def _placeholder() -> None:
-    st.header("Feed 📰")
-    st.info("Feed module not installed.")
-
-
-def main() -> None:
-    if not _load_real_page():
-        _placeholder()
-
-
-def render() -> None:
-    main()
+from transcendental_resonance_frontend.pages.feed import main, render
 
 
 if __name__ == "__main__":

--- a/pages/messages.py
+++ b/pages/messages.py
@@ -1,40 +1,9 @@
 # STRICTLY A SOCIAL MEDIA PLATFORM
 # Intellectual Property & Artistic Inspiration
 # Legal & Ethical Safeguards
-"""Proxy loader for the 1-to-1 Messages page."""
+"""Thin wrapper for the 1-to-1 Messages page."""
 
-from __future__ import annotations
-
-import importlib
-import streamlit as st
-
-
-def _load_real_page() -> bool:
-    try:
-        mod = importlib.import_module(
-            "transcendental_resonance_frontend.pages.messages"
-        )
-    except ModuleNotFoundError:
-        return False
-    for fn in ("main", "render"):
-        if hasattr(mod, fn):
-            getattr(mod, fn)()
-            return True
-    return False
-
-
-def _placeholder() -> None:
-    st.header("Direct Messages 💌")
-    st.info("Messages page coming soon.")
-
-
-def main() -> None:
-    if not _load_real_page():
-        _placeholder()
-
-
-def render() -> None:
-    main()
+from transcendental_resonance_frontend.pages.messages import main, render
 
 
 if __name__ == "__main__":

--- a/pages/messages_center.py
+++ b/pages/messages_center.py
@@ -1,40 +1,9 @@
 # STRICTLY A SOCIAL MEDIA PLATFORM
 # Intellectual Property & Artistic Inspiration
 # Legal & Ethical Safeguards
-"""Proxy loader for the Messages Center page."""
+"""Thin wrapper for the Messages Center page."""
 
-from __future__ import annotations
-
-import importlib
-import streamlit as st
-
-
-def _load_real_page() -> bool:
-    try:
-        mod = importlib.import_module(
-            "transcendental_resonance_frontend.pages.messages_center"
-        )
-    except ModuleNotFoundError:
-        return False
-    for fn in ("main", "render"):
-        if hasattr(mod, fn):
-            getattr(mod, fn)()
-            return True
-    return False
-
-
-def _placeholder() -> None:
-    st.header("Messages Center 📥")
-    st.info("Conversation hub unavailable.")
-
-
-def main() -> None:
-    if not _load_real_page():
-        _placeholder()
-
-
-def render() -> None:
-    main()
+from transcendental_resonance_frontend.pages.messages_center import main, render
 
 
 if __name__ == "__main__":

--- a/pages/profile.py
+++ b/pages/profile.py
@@ -1,40 +1,9 @@
 # STRICTLY A SOCIAL MEDIA PLATFORM
 # Intellectual Property & Artistic Inspiration
 # Legal & Ethical Safeguards
-"""Proxy loader for the Profile page."""
+"""Thin wrapper for the Profile page."""
 
-from __future__ import annotations
-
-import importlib
-import streamlit as st
-
-
-def _load_real_page() -> bool:
-    try:
-        mod = importlib.import_module(
-            "transcendental_resonance_frontend.pages.profile"
-        )
-    except ModuleNotFoundError:
-        return False
-    for fn in ("main", "render"):
-        if hasattr(mod, fn):
-            getattr(mod, fn)()
-            return True
-    return False
-
-
-def _placeholder() -> None:
-    st.header("Profile 👤")
-    st.info("Profile module not installed.")
-
-
-def main() -> None:
-    if not _load_real_page():
-        _placeholder()
-
-
-def render() -> None:
-    main()
+from transcendental_resonance_frontend.pages.profile import main, render
 
 
 if __name__ == "__main__":

--- a/pages/resonance_music.py
+++ b/pages/resonance_music.py
@@ -1,40 +1,9 @@
 # STRICTLY A SOCIAL MEDIA PLATFORM
 # Intellectual Property & Artistic Inspiration
 # Legal & Ethical Safeguards
-"""Proxy loader for the Resonance Music page."""
+"""Thin wrapper for the Resonance Music page."""
 
-from __future__ import annotations
-
-import importlib
-import streamlit as st
-
-
-def _load_real_page() -> bool:
-    try:
-        mod = importlib.import_module(
-            "transcendental_resonance_frontend.pages.resonance_music"
-        )
-    except ModuleNotFoundError:
-        return False
-    for fn in ("main", "render"):
-        if hasattr(mod, fn):
-            getattr(mod, fn)()
-            return True
-    return False
-
-
-def _placeholder() -> None:
-    st.header("Resonance Music 🎵")
-    st.info("Music page unavailable.")
-
-
-def main() -> None:
-    if not _load_real_page():
-        _placeholder()
-
-
-def render() -> None:
-    main()
+from transcendental_resonance_frontend.pages.resonance_music import main, render
 
 
 if __name__ == "__main__":

--- a/pages/social.py
+++ b/pages/social.py
@@ -1,40 +1,9 @@
 # STRICTLY A SOCIAL MEDIA PLATFORM
 # Intellectual Property & Artistic Inspiration
 # Legal & Ethical Safeguards
-"""Proxy loader for the Social page."""
+"""Thin wrapper for the Social page."""
 
-from __future__ import annotations
-
-import importlib
-import streamlit as st
-
-
-def _load_real_page() -> bool:
-    try:
-        mod = importlib.import_module(
-            "transcendental_resonance_frontend.pages.social"
-        )
-    except ModuleNotFoundError:
-        return False
-    for fn in ("main", "render"):
-        if hasattr(mod, fn):
-            getattr(mod, fn)()
-            return True
-    return False
-
-
-def _placeholder() -> None:
-    st.header("Social 🌐")
-    st.info("Social timeline is not ready.")
-
-
-def main() -> None:
-    if not _load_real_page():
-        _placeholder()
-
-
-def render() -> None:
-    main()
+from transcendental_resonance_frontend.pages.social import main, render
 
 
 if __name__ == "__main__":

--- a/pages/validation.py
+++ b/pages/validation.py
@@ -1,40 +1,9 @@
 # STRICTLY A SOCIAL MEDIA PLATFORM
 # Intellectual Property & Artistic Inspiration
 # Legal & Ethical Safeguards
-"""Proxy loader for the Validation page."""
+"""Thin wrapper for the Validation page."""
 
-from __future__ import annotations
-
-import importlib
-import streamlit as st
-
-
-def _load_real_page() -> bool:
-    try:
-        mod = importlib.import_module(
-            "transcendental_resonance_frontend.pages.validation"
-        )
-    except ModuleNotFoundError:
-        return False
-    for fn in ("main", "render"):
-        if hasattr(mod, fn):
-            getattr(mod, fn)()
-            return True
-    return False
-
-
-def _placeholder() -> None:
-    st.header("Validation ✅")
-    st.info("Validation page not available.")
-
-
-def main() -> None:
-    if not _load_real_page():
-        _placeholder()
-
-
-def render() -> None:
-    main()
+from transcendental_resonance_frontend.pages.validation import main, render
 
 
 if __name__ == "__main__":

--- a/pages/video_chat.py
+++ b/pages/video_chat.py
@@ -1,40 +1,9 @@
 # STRICTLY A SOCIAL MEDIA PLATFORM
 # Intellectual Property & Artistic Inspiration
 # Legal & Ethical Safeguards
-"""Proxy loader for the Video Chat page."""
+"""Thin wrapper for the Video Chat page."""
 
-from __future__ import annotations
-
-import importlib
-import streamlit as st
-
-
-def _load_real_page() -> bool:
-    try:
-        mod = importlib.import_module(
-            "transcendental_resonance_frontend.pages.video_chat"
-        )
-    except ModuleNotFoundError:
-        return False
-    for fn in ("main", "render"):
-        if hasattr(mod, fn):
-            getattr(mod, fn)()
-            return True
-    return False
-
-
-def _placeholder() -> None:
-    st.header("Video Chat 🎥")
-    st.info("Video chat module missing.")
-
-
-def main() -> None:
-    if not _load_real_page():
-        _placeholder()
-
-
-def render() -> None:
-    main()
+from transcendental_resonance_frontend.pages.video_chat import main, render
 
 
 if __name__ == "__main__":

--- a/pages/voting.py
+++ b/pages/voting.py
@@ -1,40 +1,9 @@
 # STRICTLY A SOCIAL MEDIA PLATFORM
 # Intellectual Property & Artistic Inspiration
 # Legal & Ethical Safeguards
-"""Proxy loader for the Voting page."""
+"""Thin wrapper for the Voting page."""
 
-from __future__ import annotations
-
-import importlib
-import streamlit as st
-
-
-def _load_real_page() -> bool:
-    try:
-        mod = importlib.import_module(
-            "transcendental_resonance_frontend.pages.voting"
-        )
-    except ModuleNotFoundError:
-        return False
-    for fn in ("main", "render"):
-        if hasattr(mod, fn):
-            getattr(mod, fn)()
-            return True
-    return False
-
-
-def _placeholder() -> None:
-    st.header("Voting 🗳️")
-    st.info("Voting page coming soon.")
-
-
-def main() -> None:
-    if not _load_real_page():
-        _placeholder()
-
-
-def render() -> None:
-    main()
+from transcendental_resonance_frontend.pages.voting import main, render
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- use one-line wrappers in `pages/` that call the true modules under `transcendental_resonance_frontend/pages`
- explain the `pages/` wrapper structure in the README

## Testing
- `pytest -q` *(fails: OperationalError: no such table: harmonizers)*

------
https://chatgpt.com/codex/tasks/task_e_688c417a58a883209a02c58a076717fc