### PR TITLE
Add alt text for feed images

### DIFF
--- a/transcendental_resonance_frontend/pages/feed.py
+++ b/transcendental_resonance_frontend/pages/feed.py
@@ -182,10 +182,15 @@ def _render_post(post: Post) -> None:
             "</div>",
             unsafe_allow_html=True,
         )
-        # Media
-        st.image(post.media, use_container_width=True, output_format="JPEG")
-        # Caption
+        # Media with alt text
         caption = sanitize_text(post.caption)
+        st.image(
+            post.media,
+            use_container_width=True,
+            output_format="JPEG",
+            alt=caption,
+        )
+        # Caption
         st.markdown(f"<div class='post-caption'>{caption}</div>", unsafe_allow_html=True)
 
         # Reactions & comments


### PR DESCRIPTION
## Summary
- show sanitized caption as alt text when rendering post images

## Testing
- `pytest -q` *(fails: no such table: harmonizers)*
- `pytest tests/test_feed_renderer.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688c4157c0848320a4a688dd68f8920e