### PR TITLE
Fix stray quotes in feed page

### DIFF
--- a/transcendental_resonance_frontend/pages/feed.py
+++ b/transcendental_resonance_frontend/pages/feed.py
@@ -142,7 +142,6 @@ if(sentinel){
 </script>
 """
 
-"""
 
 
 def _render_stories(users: List[User]) -> None:


### PR DESCRIPTION
## Summary
- remove leftover triple quote after `_SCROLL_JS`

## Testing
- `python -m py_compile transcendental_resonance_frontend/pages/feed.py`


------
https://chatgpt.com/codex/tasks/task_e_688c4149c5788320be103b0e7d9730e1