### PR TITLE
Replace deprecated experimental rerun

### DIFF
--- a/chat_ui.py
+++ b/chat_ui.py
@@ -106,7 +106,7 @@ def _start_ws_listener(url: str = "ws://localhost:8765") -> None:
                         "sender": "Peer",
                         "text": message,
                     })
-                    st.experimental_rerun()
+                    st.rerun()
         except Exception:
             st.session_state["_ws"] = None
 
@@ -147,7 +147,7 @@ def render_chat_interface() -> None:
                     "avatar": payload.get("avatar", "https://via.placeholder.com/32"),
                 }
             )
-            st.experimental_rerun()
+            st.rerun()
 
         manager.add_listener(handle_msg)
         manager.start()
@@ -204,7 +204,7 @@ def render_chat_interface() -> None:
             )
             if st.button("+", key=f"{page_prefix}add_emoji"):
                 st.session_state[f"{page_prefix}chat_input"] = (msg or "") + emoji
-                st.experimental_rerun()
+                st.rerun()
         with col3:
             if st.button("Send", key=f"{page_prefix}send_chat") and msg:
                 payload = {"sender": "You", "text": msg}

--- a/transcendental_resonance_frontend/pages/feed.py
+++ b/transcendental_resonance_frontend/pages/feed.py
@@ -196,7 +196,7 @@ def _render_post(post: Post) -> None:
             if cols[idx].button(str(count), key=btn_key):
                 reactions[emoji] += 1
                 st.session_state["reactions"][post.id] = reactions
-                st.experimental_rerun()
+                st.rerun()
             cols[idx].markdown(
                 f"""
                 <script>
@@ -222,7 +222,7 @@ def _render_post(post: Post) -> None:
                     comments.append({"user": "you", "text": sanitize_text(new)})
                     st.session_state["comments"][post.id] = comments
 
-                    st.experimental_rerun()
+                    st.rerun()
 
         st.markdown("</div>", unsafe_allow_html=True)
 
@@ -314,7 +314,7 @@ def _page_body() -> None:
         if offset >= len(posts):
             posts.extend(_generate_posts(3, start=len(posts)))
         st.session_state["post_offset"] += 3
-        st.experimental_rerun()
+        st.rerun()
 
 
 

--- a/transcendental_resonance_frontend/ui/chat_ui.py
+++ b/transcendental_resonance_frontend/ui/chat_ui.py
@@ -60,7 +60,7 @@ def render_chat_panel(user: str) -> None:
     if st.button("Send", key=f"{key_prefix}send_btn") and txt:
         msgs.append({"sender": "You", "text": txt})
         st.session_state.msg_input = ""
-        st.experimental_rerun()
+        st.rerun()
     if st.button("Start Video Call", key=f"{key_prefix}video_call"):
         st.toast("Video call integration pending")
 


### PR DESCRIPTION
## Summary
- replace `st.experimental_rerun()` with `st.rerun()` in chat and feed modules

## Testing
- `pytest -q` *(fails: OperationalError: no such table: harmonizers)*

------
https://chatgpt.com/codex/tasks/task_e_688c413417188320b26305c4a9b7fe09