### PR TITLE
Remove stray quote from feed page

### DIFF
--- a/transcendental_resonance_frontend/pages/feed.py
+++ b/transcendental_resonance_frontend/pages/feed.py
@@ -142,7 +142,6 @@ if(sentinel){
 </script>
 """
 
-"""
 
 
 def _render_stories(users: List[User]) -> None:


### PR DESCRIPTION
## Summary
- fix stray triple quotes in `feed.py`

## Testing
- `python -m py_compile transcendental_resonance_frontend/pages/feed.py`
- `pytest -q` *(fails: sqlalchemy.exc.OperationalError)*

------
https://chatgpt.com/codex/tasks/task_e_688c40a050bc8320a112a0e0bd0bbbc2