### PR TITLE
Refactor theme API to set_theme

### DIFF
--- a/frontend/__init__.py
+++ b/frontend/__init__.py
@@ -1,5 +1,5 @@
 """Convenience exports for frontend utilities."""
 
-from .theme import apply_theme, inject_modern_styles, get_accent_color
+from .theme import set_theme, inject_modern_styles, get_accent_color
 
-__all__ = ["apply_theme", "inject_modern_styles", "get_accent_color"]
+__all__ = ["set_theme", "inject_modern_styles", "get_accent_color"]

--- a/frontend/theme.py
+++ b/frontend/theme.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 from dataclasses import dataclass
-from typing import Literal
+
 import streamlit as st
 
 
@@ -90,10 +90,15 @@ button, .stButton>button {{
 </style>"""
 
 
-def set_theme(mode: Literal["light", "dark"]) -> None:
-    """Apply the global CSS for *mode* if not already active."""
+def set_theme(name: str) -> None:
+    """Apply the global CSS for *name* and remember the choice."""
+    mode = name.lower()
+    if mode not in THEMES:
+        mode = "light"
+
     if st.session_state.get("_theme") == mode:
         return
+
     st.markdown(get_global_css(mode), unsafe_allow_html=True)
     st.session_state["_theme"] = mode
 

--- a/modern_ui.py
+++ b/modern_ui.py
@@ -84,26 +84,6 @@ def inject_modern_styles() -> None:
     st.session_state["modern_styles_injected"] = True
 
 
-def inject_light_theme() -> None:
-    """Inject a minimalist light theme for broad compatibility."""
-
-    if st.session_state.get("_light_theme_injected"):
-        logger.debug("Light theme already injected; skipping")
-        return
-
-    css = """
-    <style>
-    body, .stApp {
-        background: #ffffff;
-        font-family: Helvetica, Arial, sans-serif;
-    }
-    button, .stButton > button {
-        border-radius: 0.5rem;
-    }
-    </style>
-    """
-    st.markdown(css, unsafe_allow_html=True)
-    st.session_state["_light_theme_injected"] = True
 
 def inject_premium_styles() -> None:
     """Backward compatible alias for :func:`inject_modern_styles`."""
@@ -285,7 +265,6 @@ def close_card_container() -> None:
 __all__ = [
     "render_lottie_animation",
     "inject_modern_styles",
-    "inject_light_theme",
     "inject_premium_styles",
     "render_modern_header",
     "render_validation_card",

--- a/social_tabs.py
+++ b/social_tabs.py
@@ -3,7 +3,7 @@
 # Legal & Ethical Safeguards
 import asyncio
 import streamlit as st
-from frontend.theme import apply_theme
+from frontend.theme import set_theme
 from streamlit_helpers import (
     alert,
     safe_container,
@@ -70,7 +70,7 @@ def _load_profile(username: str) -> tuple[dict, dict, dict]:
     return user, followers, following
 
 
-apply_theme("light")
+set_theme("light")
 
 
 

--- a/transcendental_resonance_frontend/pages/agents.py
+++ b/transcendental_resonance_frontend/pages/agents.py
@@ -3,7 +3,7 @@
 # Legal & Ethical Safeguards
 
 import streamlit as st
-from frontend.theme import apply_theme
+from frontend.theme import set_theme
 from modern_ui import inject_modern_styles
 
 from agent_ui import render_agent_insights_tab
@@ -11,7 +11,7 @@ from streamlit_helpers import theme_toggle
 
 __all__ = ["main", "render"]
 
-apply_theme("light")
+set_theme("light")
 inject_modern_styles()
 
 

--- a/transcendental_resonance_frontend/pages/chat.py
+++ b/transcendental_resonance_frontend/pages/chat.py
@@ -4,13 +4,13 @@
 """Chat page with text, video, and voice features."""
 
 import streamlit as st
-from frontend.theme import apply_theme
+from frontend.theme import set_theme
 from modern_ui import inject_modern_styles
 from streamlit_helpers import safe_container, header, theme_toggle
 from status_indicator import render_status_icon
 from chat_ui import render_chat_interface
 
-apply_theme("light")
+set_theme("light")
 inject_modern_styles()
 
 

--- a/transcendental_resonance_frontend/pages/feed.py
+++ b/transcendental_resonance_frontend/pages/feed.py
@@ -11,7 +11,7 @@ from typing import List, Dict, Any
 import random
 import streamlit as st
 
-from frontend.theme import apply_theme
+from frontend.theme import set_theme
 from modern_ui import inject_modern_styles
 from streamlit_helpers import theme_selector, safe_container, sanitize_text
 from modern_ui_components import st_javascript
@@ -270,7 +270,7 @@ def _load_more_posts() -> None:
 # Page entrypoints
 # ──────────────────────────────────────────────────────────────────────────────
 
-apply_theme("light")
+set_theme("light")
 inject_modern_styles()
 
 

--- a/transcendental_resonance_frontend/pages/messages.py
+++ b/transcendental_resonance_frontend/pages/messages.py
@@ -6,12 +6,12 @@
 from __future__ import annotations
 
 import streamlit as st
-from frontend.theme import apply_theme
+from frontend.theme import set_theme
 from modern_ui import inject_modern_styles
 from streamlit_helpers import theme_toggle
 from transcendental_resonance_frontend.ui.chat_ui import render_chat_ui
 
-apply_theme("light")
+set_theme("light")
 inject_modern_styles()
 
 

--- a/transcendental_resonance_frontend/pages/messages_center.py
+++ b/transcendental_resonance_frontend/pages/messages_center.py
@@ -9,14 +9,14 @@ from __future__ import annotations
 
 import asyncio
 import streamlit as st
-from frontend.theme import apply_theme
+from frontend.theme import set_theme
 from modern_ui import inject_modern_styles
 from streamlit_helpers import safe_container, theme_toggle
 from status_indicator import render_status_icon
 from transcendental_resonance_frontend.src.utils import api
 
 # ─── Apply global styles ────────────────────────────────────────────────────────
-apply_theme("light")
+set_theme("light")
 inject_modern_styles()
 
 # ─── Dummy data ────────────────────────────────────────────────────────────────

--- a/transcendental_resonance_frontend/pages/profile.py
+++ b/transcendental_resonance_frontend/pages/profile.py
@@ -4,7 +4,7 @@
 """User identity hub with profile and activity overview."""
 
 import streamlit as st
-from frontend.theme import apply_theme
+from frontend.theme import set_theme
 from modern_ui import inject_modern_styles
 from streamlit_helpers import (
     safe_container,
@@ -80,7 +80,7 @@ def _fetch_social(username: str) -> tuple[dict, dict]:
         )
     return followers or {}, following or {}
 
-apply_theme("light")
+set_theme("light")
 inject_modern_styles()
 ensure_active_user()
 

--- a/transcendental_resonance_frontend/pages/resonance_music.py
+++ b/transcendental_resonance_frontend/pages/resonance_music.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 import requests
 import streamlit as st
-from frontend.theme import apply_theme
+from frontend.theme import set_theme
 from modern_ui import inject_modern_styles
 from streamlit_helpers import (
     alert,
@@ -26,7 +26,7 @@ from streamlit_autorefresh import st_autorefresh
 from status_indicator import render_status_icon, check_backend # Ensure check_backend is imported
 from utils.api import get_resonance_summary, dispatch_route # Import get_resonance_summary and dispatch_route from utils.api
 
-apply_theme("light")
+set_theme("light")
 inject_modern_styles()
 
 # BACKEND_URL is defined in utils.api, but we keep it here for direct requests calls if needed

--- a/transcendental_resonance_frontend/pages/social.py
+++ b/transcendental_resonance_frontend/pages/social.py
@@ -4,14 +4,14 @@
 """Friends & Followers page."""
 
 import streamlit as st
-from frontend.theme import apply_theme
+from frontend.theme import set_theme
 from modern_ui import inject_modern_styles
 
 from social_tabs import render_social_tab
 from streamlit_helpers import safe_container, render_mock_feed, theme_toggle
 from feed_renderer import render_feed
 
-apply_theme("light")
+set_theme("light")
 inject_modern_styles()
 
 

--- a/transcendental_resonance_frontend/pages/validation.py
+++ b/transcendental_resonance_frontend/pages/validation.py
@@ -5,7 +5,7 @@
 
 import importlib
 import streamlit as st
-from frontend.theme import apply_theme
+from frontend.theme import set_theme
 from modern_ui import inject_modern_styles
 
 from streamlit_helpers import safe_container, theme_toggle
@@ -27,7 +27,7 @@ def _load_render_ui():
 render_validation_ui = _load_render_ui()
 
 # Inject modern global styles (safe when running in classic Streamlit)
-apply_theme("light")
+set_theme("light")
 inject_modern_styles()
 
 # --------------------------------------------------------------------

--- a/transcendental_resonance_frontend/pages/video_chat.py
+++ b/transcendental_resonance_frontend/pages/video_chat.py
@@ -6,7 +6,7 @@ import asyncio
 import json
 
 import streamlit as st
-from frontend.theme import apply_theme
+from frontend.theme import set_theme
 from modern_ui import inject_modern_styles
 
 
@@ -14,7 +14,7 @@ from ai_video_chat import create_session
 from video_chat_router import ConnectionManager
 from streamlit_helpers import safe_container, header, theme_toggle
 
-apply_theme("light")
+set_theme("light")
 inject_modern_styles()
 
 

--- a/transcendental_resonance_frontend/pages/voting.py
+++ b/transcendental_resonance_frontend/pages/voting.py
@@ -4,13 +4,13 @@
 """Governance and voting page."""
 
 import streamlit as st
-from frontend.theme import apply_theme
+from frontend.theme import set_theme
 from modern_ui import inject_modern_styles
 
 from voting_ui import render_voting_tab
 from streamlit_helpers import safe_container, theme_toggle
 
-apply_theme("light")
+set_theme("light")
 inject_modern_styles()
 
 

--- a/ui.py
+++ b/ui.py
@@ -325,15 +325,9 @@ from streamlit_helpers import (
 from frontend.theme import set_theme
 
 try:
-    from modern_ui import (
-        inject_modern_styles,
-        inject_light_theme,
-    )
+    from modern_ui import inject_modern_styles
 except Exception:  # pragma: no cover - gracefully handle missing/invalid module
     def inject_modern_styles(*_a, **_k):
-        return None
-
-    def inject_light_theme(*_a, **_k):
         return None
 
 
@@ -1493,7 +1487,7 @@ def main() -> None:
 
     # Simple light theme fallback
     try:
-        apply_theme("light")
+        set_theme("light")
     except Exception:  # pragma: no cover
         pass
 
@@ -1544,7 +1538,7 @@ def main() -> None:
         return
 
     try:
-        apply_theme("light")
+        set_theme("light")
 
 
         # Inject keyboard shortcuts for quick navigation


### PR DESCRIPTION
## Summary
- extend `frontend/theme.py` with `set_theme(name)`
- update all pages and helpers to use `set_theme`
- drop unused `inject_light_theme` helper
- clean up frontend exports and UI imports

## Testing
- `pytest -q` *(fails: OperationalError: no such table: harmonizers)*

------
https://chatgpt.com/codex/tasks/task_e_688c5f62bca88320974f9e4ddb70afac