### PR TITLE
Move theme setup into page entrypoints

### DIFF
--- a/transcendental_resonance_frontend/pages/agents.py
+++ b/transcendental_resonance_frontend/pages/agents.py
@@ -11,9 +11,6 @@ from streamlit_helpers import theme_toggle
 
 __all__ = ["main", "render"]
 
-apply_theme("light")
-inject_modern_styles()
-
 
 def main(main_container=None) -> None:
     """
@@ -21,6 +18,9 @@ def main(main_container=None) -> None:
 
     If no main_container is provided, uses Streamlit root context.
     """
+    apply_theme("light")
+    inject_modern_styles()
+
     container = main_container if main_container is not None else st
     theme_toggle("Dark Mode", key_suffix="agents")
 

--- a/transcendental_resonance_frontend/pages/chat.py
+++ b/transcendental_resonance_frontend/pages/chat.py
@@ -10,12 +10,13 @@ from streamlit_helpers import safe_container, header, theme_toggle
 from status_indicator import render_status_icon
 from chat_ui import render_chat_interface
 
-apply_theme("light")
-inject_modern_styles()
 
 
 def main(main_container=None) -> None:
     """Render the chat page."""
+    apply_theme("light")
+    inject_modern_styles()
+
     if main_container is None:
         main_container = st
     page = "chat"

--- a/transcendental_resonance_frontend/pages/feed.py
+++ b/transcendental_resonance_frontend/pages/feed.py
@@ -270,8 +270,6 @@ def _load_more_posts() -> None:
 # Page entrypoints
 # ──────────────────────────────────────────────────────────────────────────────
 
-apply_theme("light")
-inject_modern_styles()
 
 
 def _page_body() -> None:
@@ -324,6 +322,9 @@ def _page_body() -> None:
 
 def main(main_container=None) -> None:
     """Render the feed inside ``main_container`` (or root Streamlit)."""
+    apply_theme("light")
+    inject_modern_styles()
+
     container = main_container or st
     with safe_container(container):
         _page_body()

--- a/transcendental_resonance_frontend/pages/messages.py
+++ b/transcendental_resonance_frontend/pages/messages.py
@@ -11,12 +11,13 @@ from modern_ui import inject_modern_styles
 from streamlit_helpers import theme_toggle
 from transcendental_resonance_frontend.ui.chat_ui import render_chat_ui
 
-apply_theme("light")
-inject_modern_styles()
 
 
 def main(main_container=None) -> None:
     """Render the chat interface inside the given container (or the page itself)."""
+    apply_theme("light")
+    inject_modern_styles()
+
     theme_toggle("Dark Mode", key_suffix="messages")
     render_chat_ui(main_container)
 

--- a/transcendental_resonance_frontend/pages/messages_center.py
+++ b/transcendental_resonance_frontend/pages/messages_center.py
@@ -15,10 +15,6 @@ from streamlit_helpers import safe_container, theme_toggle
 from status_indicator import render_status_icon
 from transcendental_resonance_frontend.src.utils import api
 
-# ─── Apply global styles ────────────────────────────────────────────────────────
-apply_theme("light")
-inject_modern_styles()
-
 # ─── Dummy data ────────────────────────────────────────────────────────────────
 DUMMY_CONVERSATIONS: dict[str, list[dict[str, str]]] = {
     "alice": [
@@ -57,6 +53,9 @@ def send_message(target: str, text: str) -> None:
 
 # ─── Page Entrypoint ───────────────────────────────────────────────────────────
 def main(container: st.DeltaGenerator | None = None) -> None:
+    apply_theme("light")
+    inject_modern_styles()
+
     if container is None:
         container = st
 

--- a/transcendental_resonance_frontend/pages/profile.py
+++ b/transcendental_resonance_frontend/pages/profile.py
@@ -80,9 +80,6 @@ def _fetch_social(username: str) -> tuple[dict, dict]:
         )
     return followers or {}, following or {}
 
-apply_theme("light")
-inject_modern_styles()
-ensure_active_user()
 
 
 def _render_profile(username: str) -> None:
@@ -114,6 +111,10 @@ def _render_profile(username: str) -> None:
 
 
 def main(main_container=None) -> None:
+    apply_theme("light")
+    inject_modern_styles()
+    ensure_active_user()
+
     if main_container is None:
         main_container = st
     init_db()

--- a/transcendental_resonance_frontend/pages/resonance_music.py
+++ b/transcendental_resonance_frontend/pages/resonance_music.py
@@ -26,8 +26,6 @@ from streamlit_autorefresh import st_autorefresh
 from status_indicator import render_status_icon, check_backend # Ensure check_backend is imported
 from utils.api import get_resonance_summary, dispatch_route # Import get_resonance_summary and dispatch_route from utils.api
 
-apply_theme("light")
-inject_modern_styles()
 
 # BACKEND_URL is defined in utils.api, but we keep it here for direct requests calls if needed
 BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:8000")
@@ -72,6 +70,8 @@ def _run_async(coro):
 
 def main(main_container=None, status_container=None) -> None:
     """Render music generation and summary widgets."""
+    apply_theme("light")
+    inject_modern_styles()
 
     if main_container is None:
         main_container = st

--- a/transcendental_resonance_frontend/pages/social.py
+++ b/transcendental_resonance_frontend/pages/social.py
@@ -11,12 +11,13 @@ from social_tabs import render_social_tab
 from streamlit_helpers import safe_container, render_mock_feed, theme_toggle
 from feed_renderer import render_feed
 
-apply_theme("light")
-inject_modern_styles()
 
 
 def main(main_container=None) -> None:
     """Render the social page content within ``main_container``."""
+    apply_theme("light")
+    inject_modern_styles()
+
     if main_container is None:
         main_container = st
     theme_toggle("Dark Mode", key_suffix="social")

--- a/transcendental_resonance_frontend/pages/validation.py
+++ b/transcendental_resonance_frontend/pages/validation.py
@@ -26,10 +26,6 @@ def _load_render_ui():
 
 render_validation_ui = _load_render_ui()
 
-# Inject modern global styles (safe when running in classic Streamlit)
-apply_theme("light")
-inject_modern_styles()
-
 # --------------------------------------------------------------------
 # Page decorator (works even if Streamlit’s multipage API absent)
 # --------------------------------------------------------------------
@@ -44,6 +40,9 @@ def _page_decorator(func):
 @_page_decorator
 def main(main_container=None) -> None:
     """Render the validation UI inside a safe container."""
+    apply_theme("light")
+    inject_modern_styles()
+
     if main_container is None:
         main_container = st
     theme_toggle("Dark Mode", key_suffix="validation")

--- a/transcendental_resonance_frontend/pages/video_chat.py
+++ b/transcendental_resonance_frontend/pages/video_chat.py
@@ -14,8 +14,6 @@ from ai_video_chat import create_session
 from video_chat_router import ConnectionManager
 from streamlit_helpers import safe_container, header, theme_toggle
 
-apply_theme("light")
-inject_modern_styles()
 
 
 def _run_async(coro):
@@ -35,6 +33,9 @@ manager = ConnectionManager()
 
 def main(main_container=None) -> None:
     """Render the simple video chat demo."""
+    apply_theme("light")
+    inject_modern_styles()
+
     container = main_container if main_container is not None else st
     theme_toggle("Dark Mode", key_suffix="video_chat")
 

--- a/transcendental_resonance_frontend/pages/voting.py
+++ b/transcendental_resonance_frontend/pages/voting.py
@@ -10,12 +10,13 @@ from modern_ui import inject_modern_styles
 from voting_ui import render_voting_tab
 from streamlit_helpers import safe_container, theme_toggle
 
-apply_theme("light")
-inject_modern_styles()
 
 
 def main(main_container=None) -> None:
     """Render the Governance and Voting page inside ``main_container``."""
+    apply_theme("light")
+    inject_modern_styles()
+
     if main_container is None:
         main_container = st
     theme_toggle("Dark Mode", key_suffix="voting")


### PR DESCRIPTION
## Summary
- avoid Streamlit state changes on import
- move theme helpers into `main()` for each page

## Testing
- `pytest -q` *(fails: OperationalError: no such table: harmonizers)*

------
https://chatgpt.com/codex/tasks/task_e_688c5f11493483209ab260d2f7e65a69