### PR TITLE
Add image alt text

### DIFF
--- a/frontend/profile_card.py
+++ b/frontend/profile_card.py
@@ -70,7 +70,10 @@ def render_profile_card(
 
     # Banner + avatar
     st.markdown('<div class="pc-banner"></div>', unsafe_allow_html=True)
-    st.markdown(f'<img class="pc-avatar" src="{avatar_url}">', unsafe_allow_html=True)
+    st.markdown(
+        f'<img class="pc-avatar" src="{avatar_url}" alt="avatar">',
+        unsafe_allow_html=True,
+    )
 
     # Name & tagline
     st.markdown(f'<div class="pc-name">{username}</div>', unsafe_allow_html=True)

--- a/streamlit_helpers.py
+++ b/streamlit_helpers.py
@@ -278,7 +278,9 @@ def render_post_card(post_data: dict[str, Any]) -> None:
         else:
             html_snippet = "<div class='shadcn-card' style='border-radius:12px;padding:8px;'>"
             if img:
-                html_snippet += f"<img src='{html.escape(img)}' style='width:100%;border-radius:8px;'/>"
+                html_snippet += (
+                    f"<img src='{html.escape(img)}' alt='' style='width:100%;border-radius:8px;'/>"
+                )
             if username:
                 html_snippet += f"<div><strong>{html.escape(username)}</strong></div>"
             html_snippet += f"<p>{html.escape(text)}</p>"
@@ -318,7 +320,7 @@ def render_post_card(post_data: dict[str, Any]) -> None:
                 st.image(img, use_container_width=True)
             else:
                 getattr(st, "markdown", lambda *a, **k: None)(
-                    f"<img src='{html.escape(img)}' style='width:100%'>",
+                    f"<img src='{html.escape(img)}' alt='' style='width:100%'>",
                     unsafe_allow_html=True,
                 )
         write_fn = getattr(st, "write", getattr(st, "markdown", lambda x: None))


### PR DESCRIPTION
## Summary
- add missing alt text for profile avatar
- include alt on HTML image snippets in Streamlit helpers
- audit widgets for missing labels

## Testing
- `pytest -q` *(fails: OperationalError no such table)*

------
https://chatgpt.com/codex/tasks/task_e_688c5ef5b77483208fcd0078f12cf5be