### PR TITLE
Centralize theme injection

### DIFF
--- a/modern_ui.py
+++ b/modern_ui.py
@@ -33,11 +33,11 @@ def inject_modern_styles() -> None:
     """Inject global CSS using theme variables and local assets."""
     from modern_ui_components import SIDEBAR_STYLES
 
-    if st.session_state.get("modern_styles_injected"):
-        logger.debug("Modern styles already injected; skipping")
-        return
-
     theme.inject_modern_styles()
+
+    if st.session_state.get("_modern_ui_css_injected"):
+        logger.debug("Modern UI CSS already injected; skipping extra assets")
+        return
 
     css = """
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -81,29 +81,7 @@ def inject_modern_styles() -> None:
     """
     st.markdown(css, unsafe_allow_html=True)
     st.markdown(SIDEBAR_STYLES, unsafe_allow_html=True)
-    st.session_state["modern_styles_injected"] = True
-
-
-def inject_light_theme() -> None:
-    """Inject a minimalist light theme for broad compatibility."""
-
-    if st.session_state.get("_light_theme_injected"):
-        logger.debug("Light theme already injected; skipping")
-        return
-
-    css = """
-    <style>
-    body, .stApp {
-        background: #ffffff;
-        font-family: Helvetica, Arial, sans-serif;
-    }
-    button, .stButton > button {
-        border-radius: 0.5rem;
-    }
-    </style>
-    """
-    st.markdown(css, unsafe_allow_html=True)
-    st.session_state["_light_theme_injected"] = True
+    st.session_state["_modern_ui_css_injected"] = True
 
 def inject_premium_styles() -> None:
     """Backward compatible alias for :func:`inject_modern_styles`."""
@@ -285,7 +263,6 @@ def close_card_container() -> None:
 __all__ = [
     "render_lottie_animation",
     "inject_modern_styles",
-    "inject_light_theme",
     "inject_premium_styles",
     "render_modern_header",
     "render_validation_card",

--- a/ui.py
+++ b/ui.py
@@ -322,18 +322,12 @@ from streamlit_helpers import (
     render_post_card,
     render_instagram_grid,
 )
-from frontend.theme import set_theme
+from frontend.theme import set_theme, apply_theme
 
 try:
-    from modern_ui import (
-        inject_modern_styles,
-        inject_light_theme,
-    )
+    from modern_ui import inject_modern_styles
 except Exception:  # pragma: no cover - gracefully handle missing/invalid module
     def inject_modern_styles(*_a, **_k):
-        return None
-
-    def inject_light_theme(*_a, **_k):
         return None
 
 
@@ -1568,11 +1562,10 @@ def main() -> None:
             """,
             unsafe_allow_html=True,
         )
-        if not st.session_state.get("modern_styles_injected"):
-            try:
-                inject_modern_styles()
-            except Exception as exc:
-                logger.warning("CSS load failed: %s", exc)
+        try:
+            inject_modern_styles()
+        except Exception as exc:
+            logger.warning("CSS load failed: %s", exc)
 
         # Initialize session state
         defaults = {


### PR DESCRIPTION
## Summary
- remove the light-theme helper from `modern_ui`
- route all style setup through `frontend.theme`
- simplify CSS injection checks in `ui`

## Testing
- `make lint` *(fails: `streamlit-test` is not a valid Python package name)*
- `make test` *(fails: OperationalError: no such table: harmonizers)*

------
https://chatgpt.com/codex/tasks/task_e_688c5eece8508320a946becb84902d45