### PR TITLE
Consolidate profile container

### DIFF
--- a/transcendental_resonance_frontend/pages/profile.py
+++ b/transcendental_resonance_frontend/pages/profile.py
@@ -119,15 +119,8 @@ def main(main_container=None) -> None:
     init_db()
     seed_default_users()
     theme_toggle("Dark Mode", key_suffix="profile")
-    # …inside render_social_tab (or whichever function/file this is)
-    get_active_user()                     # make sure the key exists
-    container_ctx = safe_container(main_container)
-    with container_ctx:
-        get_active_user()                 # retrieve current value when needed
-        # …rest of the code …
 
-    container_ctx = safe_container(main_container)
-    with container_ctx:
+    with safe_container(main_container):
         # Header with status icon
         header_col, status_col = st.columns([8, 1])
         with header_col:


### PR DESCRIPTION
## Summary
- remove duplicate safe_container block in profile page
- consolidate profile content into a single `with safe_container` block
- drop placeholder comments

## Testing
- `pytest -k profile -q`
- `python -m py_compile transcendental_resonance_frontend/pages/profile.py`

------
https://chatgpt.com/codex/tasks/task_e_688cdf17b7148320bdc9afe15d6193b1