### PR TITLE
Fix modern style imports

### DIFF
--- a/transcendental_resonance_frontend/pages/agents.py
+++ b/transcendental_resonance_frontend/pages/agents.py
@@ -4,7 +4,7 @@
 
 import streamlit as st
 from frontend.theme import apply_theme
-from modern_ui import inject_modern_styles
+from frontend.theme import inject_modern_styles
 
 from agent_ui import render_agent_insights_tab
 from streamlit_helpers import theme_toggle

--- a/transcendental_resonance_frontend/pages/chat.py
+++ b/transcendental_resonance_frontend/pages/chat.py
@@ -5,7 +5,7 @@
 
 import streamlit as st
 from frontend.theme import apply_theme
-from modern_ui import inject_modern_styles
+from frontend.theme import inject_modern_styles
 from streamlit_helpers import safe_container, header, theme_toggle
 from status_indicator import render_status_icon
 from chat_ui import render_chat_interface

--- a/transcendental_resonance_frontend/pages/feed.py
+++ b/transcendental_resonance_frontend/pages/feed.py
@@ -12,7 +12,7 @@ import random
 import streamlit as st
 
 from frontend.theme import apply_theme
-from modern_ui import inject_modern_styles
+from frontend.theme import inject_modern_styles
 from streamlit_helpers import theme_selector, safe_container, sanitize_text
 from modern_ui_components import st_javascript
 

--- a/transcendental_resonance_frontend/pages/messages.py
+++ b/transcendental_resonance_frontend/pages/messages.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import streamlit as st
 from frontend.theme import apply_theme
-from modern_ui import inject_modern_styles
+from frontend.theme import inject_modern_styles
 from streamlit_helpers import theme_toggle
 from transcendental_resonance_frontend.ui.chat_ui import render_chat_ui
 

--- a/transcendental_resonance_frontend/pages/messages_center.py
+++ b/transcendental_resonance_frontend/pages/messages_center.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import asyncio
 import streamlit as st
 from frontend.theme import apply_theme
-from modern_ui import inject_modern_styles
+from frontend.theme import inject_modern_styles
 from streamlit_helpers import safe_container, theme_toggle
 from status_indicator import render_status_icon
 from transcendental_resonance_frontend.src.utils import api

--- a/transcendental_resonance_frontend/pages/profile.py
+++ b/transcendental_resonance_frontend/pages/profile.py
@@ -5,7 +5,7 @@
 
 import streamlit as st
 from frontend.theme import apply_theme
-from modern_ui import inject_modern_styles
+from frontend.theme import inject_modern_styles
 from streamlit_helpers import (
     safe_container,
     header,

--- a/transcendental_resonance_frontend/pages/resonance_music.py
+++ b/transcendental_resonance_frontend/pages/resonance_music.py
@@ -14,7 +14,7 @@ from pathlib import Path
 import requests
 import streamlit as st
 from frontend.theme import apply_theme
-from modern_ui import inject_modern_styles
+from frontend.theme import inject_modern_styles
 from streamlit_helpers import (
     alert,
     centered_container,

--- a/transcendental_resonance_frontend/pages/social.py
+++ b/transcendental_resonance_frontend/pages/social.py
@@ -5,7 +5,7 @@
 
 import streamlit as st
 from frontend.theme import apply_theme
-from modern_ui import inject_modern_styles
+from frontend.theme import inject_modern_styles
 
 from social_tabs import render_social_tab
 from streamlit_helpers import safe_container, render_mock_feed, theme_toggle

--- a/transcendental_resonance_frontend/pages/validation.py
+++ b/transcendental_resonance_frontend/pages/validation.py
@@ -6,7 +6,7 @@
 import importlib
 import streamlit as st
 from frontend.theme import apply_theme
-from modern_ui import inject_modern_styles
+from frontend.theme import inject_modern_styles
 
 from streamlit_helpers import safe_container, theme_toggle
 

--- a/transcendental_resonance_frontend/pages/video_chat.py
+++ b/transcendental_resonance_frontend/pages/video_chat.py
@@ -7,7 +7,7 @@ import json
 
 import streamlit as st
 from frontend.theme import apply_theme
-from modern_ui import inject_modern_styles
+from frontend.theme import inject_modern_styles
 
 
 from ai_video_chat import create_session

--- a/transcendental_resonance_frontend/pages/voting.py
+++ b/transcendental_resonance_frontend/pages/voting.py
@@ -5,7 +5,7 @@
 
 import streamlit as st
 from frontend.theme import apply_theme
-from modern_ui import inject_modern_styles
+from frontend.theme import inject_modern_styles
 
 from voting_ui import render_voting_tab
 from streamlit_helpers import safe_container, theme_toggle


### PR DESCRIPTION
## Summary
- use `inject_modern_styles` from `frontend.theme`
- keep theme helper imports modern

## Testing
- `python -m py_compile transcendental_resonance_frontend/pages/*.py`

------
https://chatgpt.com/codex/tasks/task_e_688c5ec66498832099c3b4f7b30084bb