### PR TITLE
Initialize DB in login tests

### DIFF
--- a/superNova_2177.py
+++ b/superNova_2177.py
@@ -379,6 +379,13 @@ redis_client = None
 _creative_leap_model = None
 
 
+def create_database() -> None:
+    """Initialize database tables using current settings."""
+    settings = get_settings()
+    db_models.init_db(settings.engine_url)
+
+
+
 def get_password_hash(password: str) -> str:
     if hasattr(pwd_context, "hash"):
         return pwd_context.hash(password)

--- a/tests/test_login_flow.py
+++ b/tests/test_login_flow.py
@@ -1,5 +1,12 @@
 import os
+import sys
 import importlib
+from pathlib import Path
+
+root = Path(__file__).resolve().parents[1]
+if str(root) not in sys.path:
+    sys.path.insert(0, str(root))
+
 from fastapi.testclient import TestClient
 import superNova_2177 as sn
 import db_models
@@ -17,7 +24,9 @@ def client(tmp_path, monkeypatch):
     importlib.reload(db_models)
     importlib.reload(login_router)
     sn_mod = importlib.reload(sn)
+    sn_mod.create_database()
     sn_mod.create_app()
+    sn_mod.Base.metadata.drop_all(bind=sn_mod.engine)
     sn_mod.Base.metadata.create_all(bind=sn_mod.engine)
     client = TestClient(sn_mod.app)
     with sn_mod.SessionLocal() as db:


### PR DESCRIPTION
## Summary
- add `create_database` helper for DB setup
- ensure `test_login_flow` imports root package
- rebuild tables in `client` fixture before inserting test data

## Testing
- `pytest tests/test_login_flow.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688cdf184ed08320b133dfa05500c44a