### PR TITLE
Clarify consolidated pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,7 +401,10 @@ for governance, AI insights, and community interaction.
 
 Full implementations for these pages live in
 `transcendental_resonance_frontend/pages/`. The lightweight files under the
-top-level `pages/` directory simply import and call those modules.
+top-level `pages/` directory simply import and call those modules. Earlier
+revisions included a `src/pages/` directory for NiceGUI prototypes, but the
+contents were consolidated under `pages/`. This folder is now the single source
+of truth for both the Streamlit wrappers and the NiceGUI frontend.
 
 
 ### Starting the Backend

--- a/transcendental_resonance_frontend/README.md
+++ b/transcendental_resonance_frontend/README.md
@@ -29,6 +29,11 @@ Replace the backend URL with the `BACKEND_URL` environment variable if your API 
 - `src/main.py` – entry point registering pages and launching the app
 - `tests/` – pytest-based unit tests (package marked by `__init__.py`)
 
+Earlier versions placed NiceGUI page modules under `src/pages/`. That directory
+was removed after consolidating all pages into the `pages/` package. The root
+`pages/` folder at the repository top level simply forwards to these modules so
+Streamlit can locate them when running `ui.py`.
+
 ## Notes
 
 This UI is mobile-first with a futuristic aesthetic. A theme selector cycles between


### PR DESCRIPTION
## Summary
- note removal of old src/pages directory in README
- explain page consolidation in `transcendental_resonance_frontend` README

## Testing
- `pytest -k 'frontend' -q`

------
https://chatgpt.com/codex/tasks/task_e_688ce3e1725c83208a4f7d23f908356a