### PR TITLE
Add theme utility tests

### DIFF
--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -1,0 +1,36 @@
+import types
+import sys
+from pathlib import Path
+import pytest
+
+pytest.importorskip("streamlit")
+pytestmark = pytest.mark.requires_streamlit
+
+root = Path(__file__).resolve().parents[1]
+if str(root) not in sys.path:
+    sys.path.insert(0, str(root))
+
+import frontend.theme as theme
+
+def test_theme_application_and_idempotent_styles(monkeypatch):
+    calls = []
+
+    def dummy_markdown(text, **kwargs):
+        calls.append(text)
+
+    dummy_st = types.SimpleNamespace(markdown=dummy_markdown, session_state={})
+    monkeypatch.setattr(theme, "st", dummy_st)
+
+    theme.apply_theme("light")
+    assert dummy_st.session_state["_theme"] == "light"
+    assert theme.get_accent_color() == theme.LIGHT_THEME.accent
+
+    theme.apply_theme("dark")
+    assert dummy_st.session_state["_theme"] == "dark"
+    assert theme.get_accent_color() == theme.DARK_THEME.accent
+
+    theme.inject_modern_styles()
+    theme.inject_modern_styles()
+
+    extra_css_calls = [c for c in calls if "Glassmorphic" in c]
+    assert len(extra_css_calls) == 1


### PR DESCRIPTION
## Summary
- test theme CSS helpers with mocked Streamlit

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ce3c057dc83209360e69291d0eca8