### PR TITLE
Add pre-commit config and lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,25 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          pip install black ruff
+      - name: Run black
+        run: black --check .
+      - name: Run ruff
+        run: ruff .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.7.0
+    hooks:
+      - id: black
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.0.280
+    hooks:
+      - id: ruff
+        args: ["--fix"]
+  - repo: local
+    hooks:
+      - id: patch-monitor
+        name: patch-monitor
+        entry: python scripts/patch_monitor_hook.py
+        language: system
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -148,8 +148,12 @@ This project depends on libraries such as `fastapi`, `pydantic-settings`, `struc
    # Windows
    .\venv\Scripts\activate
    ```
-4. You're ready to run the demo commands shown in [Quick Start](#-quick-start).
-5. On first launch the application seeds `harmonizers.db` with an `admin`,
+4. **Install the pre-commit hooks** so linting and the patch monitor run automatically:
+   ```bash
+   pre-commit install
+   ```
+5. You're ready to run the demo commands shown in [Quick Start](#-quick-start).
+6. On first launch the application seeds `harmonizers.db` with an `admin`,
    `guest`, and `demo_user` account so the UI has sample profiles ready.
 
 ### Extras


### PR DESCRIPTION
## Summary
- enforce formatting with black and ruff via pre-commit
- run patch monitor in pre-commit
- set up a GitHub Actions workflow that runs black and ruff
- document installing pre-commit hooks in README

## Testing
- `pre-commit run --files .pre-commit-config.yaml .github/workflows/lint.yml README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ce3bf29a88320976a24dc7216f378