### PR TITLE
UI cleanup and improved imports

### DIFF
--- a/chat_ui.py
+++ b/chat_ui.py
@@ -178,7 +178,7 @@ def render_chat_interface() -> None:
             cols = st.columns([1, 9]) if cls == "left" else st.columns([9, 1])
             avatar_col, msg_col = cols if cls == "left" else reversed(cols)
             with avatar_col:
-                st.image(avatar, width=32)
+                st.image(avatar, width=32, alt="avatar")
             with msg_col:
                 st.markdown(
                     f"<div class='chat-message'><div class='chat-bubble {cls}'><strong>{sender}:</strong> {translated}</div></div>",

--- a/frontend/ui_layout.py
+++ b/frontend/ui_layout.py
@@ -131,9 +131,10 @@ def sidebar_container() -> st.delta_generator.DeltaGenerator:
         const toggle=window.parent.document.getElementById('drawer_toggle');
         const sb=document.querySelector('[data-testid="stSidebar"]');
         function syncDrawer(){
-            if(!sb||!toggle) return;
-            if(window.innerWidth>=768){sb.classList.remove('collapsed');toggle.checked=true;return;}
-            sb.classList.toggle('collapsed', !toggle.checked);
+            if(!sb) return;
+            const open = toggle? toggle.checked : window.innerWidth>=768;
+            sb.classList.toggle('collapsed', !open);
+            if(toggle) localStorage.setItem('drawer_open', open);
         }
         syncDrawer();
         toggle?.addEventListener('change', syncDrawer);
@@ -229,7 +230,10 @@ def render_top_bar() -> None:
         <label for='drawer_toggle' id='drawer_btn'>☰</label>
         <script>
         const dt=document.getElementById('drawer_toggle');
-        dt?.addEventListener('change',()=>localStorage.setItem('drawer_open', dt.checked));
+        const saved = localStorage.getItem('drawer_open');
+        if(dt && saved !== null) dt.checked = saved === 'true';
+        function storeDrawer(){{ if(dt) localStorage.setItem('drawer_open', dt.checked); }}
+        dt?.addEventListener('change', storeDrawer);
         </script>
         """,
         unsafe_allow_html=True,
@@ -240,7 +244,12 @@ def render_top_bar() -> None:
     # search box with suggestions
     pid = st.session_state.get("active_page", "global")
     q_key = f"{pid}_search"
-    q = search_col.text_input("", placeholder="Search…", key=q_key, label_visibility="collapsed")
+    q = search_col.text_input(
+        "Search",
+        placeholder="Search…",
+        key=q_key,
+        label_visibility="hidden",
+    )
     if q:
         recent = st.session_state.setdefault("_recent_q", [])
         if q not in recent:

--- a/profile_card.py
+++ b/profile_card.py
@@ -15,7 +15,7 @@ def render_profile_card(username: str, avatar_url: str) -> None:
     st.markdown("<div class='glass-card'>", unsafe_allow_html=True)
     col1, col2 = st.columns([0.25, 0.75])
     with col1:
-        st.image(avatar_url, width=48, use_container_width=True)
+        st.image(avatar_url, width=48, use_container_width=True, alt="avatar")
     with col2:
         st.markdown(f"**{username}**")
         st.caption(badge)

--- a/social_tabs.py
+++ b/social_tabs.py
@@ -103,7 +103,6 @@ def render_social_tab(main_container=None) -> None:
                 key="target_username",
                 placeholder="Friend to follow",
             )
-        st.session_state["active_user"] = current_user
 
         if st.button("Follow/Unfollow", use_container_width=True) and target and current_user:
             with SessionLocal() as db:

--- a/streamlit_helpers.py
+++ b/streamlit_helpers.py
@@ -71,7 +71,7 @@ except Exception:  # noqa: BLE001
                 return _DummyElement(st.container())
 
             def image(self, img: str) -> _DummyElement:
-                st.image(img, use_container_width=True)
+                st.image(img, use_container_width=True, alt="image")
                 return _DummyElement()
 
             def badge(self, text: str) -> _DummyElement:
@@ -267,7 +267,7 @@ def render_post_card(post_data: dict[str, Any]) -> None:
     if ui is None:
         if hasattr(st, "image") and hasattr(st, "write"):
             if img:
-                st.image(img, use_container_width=True)
+                st.image(img, use_container_width=True, alt="post")
             caption_text = f"**{html.escape(username)}**: {text}" if username else text
             st.write(caption_text)
             getattr(st, "caption", st.write)(f"❤️ {likes}")
@@ -317,7 +317,7 @@ def render_post_card(post_data: dict[str, Any]) -> None:
             st.warning(f"Post card failed: {exc}")
         if img:
             if hasattr(st, "image"):
-                st.image(img, use_container_width=True)
+                st.image(img, use_container_width=True, alt="post")
             else:
                 getattr(st, "markdown", lambda *a, **k: None)(
                     f"<img src='{html.escape(img)}' alt='' style='width:100%'>",

--- a/transcendental_resonance_frontend/pages/feed.py
+++ b/transcendental_resonance_frontend/pages/feed.py
@@ -13,7 +13,7 @@ import streamlit as st
 
 from frontend.theme import set_theme
 from modern_ui import inject_modern_styles
-from streamlit_helpers import theme_selector, safe_container, sanitize_text
+from streamlit_helpers import theme_toggle, safe_container, sanitize_text
 from modern_ui_components import st_javascript
 from frontend.assets import story_css, story_js, reaction_css, scroll_js
 

--- a/transcendental_resonance_frontend/pages/messages_center.py
+++ b/transcendental_resonance_frontend/pages/messages_center.py
@@ -86,7 +86,7 @@ def main(container: st.DeltaGenerator | None = None) -> None:
                 avatar = msg.get("avatar", f"https://robohash.org/{msg['user']}.png?size=40x40")
                 with st.chat_message(msg["user"], avatar=avatar):
                     if img := msg.get("image"):
-                        st.image(img, use_container_width=True)
+                        st.image(img, use_container_width=True, alt="attachment")
                     st.write(msg["text"])
 
             # Input box

--- a/transcendental_resonance_frontend/pages/profile.py
+++ b/transcendental_resonance_frontend/pages/profile.py
@@ -131,7 +131,6 @@ def main(main_container=None) -> None:
         # Active user editable section
         current = get_active_user()
         current = st.text_input("Username", value=current, key="profile_user")
-        st.session_state["active_user"] = current
         _render_profile(current)
 
         # Divider + API Keys

--- a/transcendental_resonance_frontend/pages/resonance_music.py
+++ b/transcendental_resonance_frontend/pages/resonance_music.py
@@ -24,7 +24,10 @@ from streamlit_helpers import (
 )
 from streamlit_autorefresh import st_autorefresh
 from status_indicator import render_status_icon, check_backend # Ensure check_backend is imported
-from utils.api import get_resonance_summary, dispatch_route # Import get_resonance_summary and dispatch_route from utils.api
+from transcendental_resonance_frontend.src.utils.api import (
+    get_resonance_summary,
+    dispatch_route,
+)
 
 set_theme("light")
 inject_modern_styles()

--- a/ui.py
+++ b/ui.py
@@ -749,7 +749,12 @@ def render_modern_agents_page():
     cols = st.columns(len(agents))
     for col, name in zip(cols, agents):
         with col:
-            st.image("https://via.placeholder.com/80", width=80, use_container_width=True)
+            st.image(
+                "https://via.placeholder.com/80",
+                width=80,
+                use_container_width=True,
+                alt="placeholder",
+            )
             st.write(name)
             st.line_chart([1, 3, 2, 4])
 


### PR DESCRIPTION
## Summary
- fix search text field labeling and drawer script
- add alt text for placeholder images
- import `theme_toggle` on feed page
- adjust API path in resonance music module
- remove redundant session state assignments
- synchronize sidebar state with localStorage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ce46ecc08832083df8773e14b84c5