### PR TITLE
Remove redundant session state update

### DIFF
--- a/social_tabs.py
+++ b/social_tabs.py
@@ -103,7 +103,6 @@ def render_social_tab(main_container=None) -> None:
                 key="target_username",
                 placeholder="Friend to follow",
             )
-        st.session_state["active_user"] = current_user
 
         if st.button("Follow/Unfollow", use_container_width=True) and target and current_user:
             with SessionLocal() as db:

--- a/transcendental_resonance_frontend/pages/profile.py
+++ b/transcendental_resonance_frontend/pages/profile.py
@@ -131,7 +131,6 @@ def main(main_container=None) -> None:
         # Active user editable section
         current = get_active_user()
         current = st.text_input("Username", value=current, key="profile_user")
-        st.session_state["active_user"] = current
         _render_profile(current)
 
         # Divider + API Keys


### PR DESCRIPTION
## Summary
- ensure `active_user` is set via `ensure_active_user()`
- avoid resetting `active_user` after text inputs

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688d1962459c8320a4f55cd74c58a1e4