### PR TITLE
Fix theme_toggle import for feed page

### DIFF
--- a/transcendental_resonance_frontend/pages/feed.py
+++ b/transcendental_resonance_frontend/pages/feed.py
@@ -13,7 +13,7 @@ import streamlit as st
 
 from frontend.theme import set_theme
 from modern_ui import inject_modern_styles
-from streamlit_helpers import theme_selector, safe_container, sanitize_text
+from streamlit_helpers import theme_toggle, theme_selector, safe_container, sanitize_text
 from modern_ui_components import st_javascript
 from frontend.assets import story_css, story_js, reaction_css, scroll_js
 


### PR DESCRIPTION
## Summary
- ensure `theme_toggle` is imported in the feed page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d1960566483209fe8be56435a5ef1