### PR TITLE
Add alt text for images

### DIFF
--- a/chat_ui.py
+++ b/chat_ui.py
@@ -178,7 +178,7 @@ def render_chat_interface() -> None:
             cols = st.columns([1, 9]) if cls == "left" else st.columns([9, 1])
             avatar_col, msg_col = cols if cls == "left" else reversed(cols)
             with avatar_col:
-                st.image(avatar, width=32)
+                st.image(avatar, width=32, alt=f"{sender} avatar")
             with msg_col:
                 st.markdown(
                     f"<div class='chat-message'><div class='chat-bubble {cls}'><strong>{sender}:</strong> {translated}</div></div>",

--- a/profile_card.py
+++ b/profile_card.py
@@ -15,7 +15,7 @@ def render_profile_card(username: str, avatar_url: str) -> None:
     st.markdown("<div class='glass-card'>", unsafe_allow_html=True)
     col1, col2 = st.columns([0.25, 0.75])
     with col1:
-        st.image(avatar_url, width=48, use_container_width=True)
+        st.image(avatar_url, width=48, use_container_width=True, alt=f"{username} avatar")
     with col2:
         st.markdown(f"**{username}**")
         st.caption(badge)

--- a/streamlit_helpers.py
+++ b/streamlit_helpers.py
@@ -71,7 +71,7 @@ except Exception:  # noqa: BLE001
                 return _DummyElement(st.container())
 
             def image(self, img: str) -> _DummyElement:
-                st.image(img, use_container_width=True)
+                st.image(img, use_container_width=True, alt="content image")
                 return _DummyElement()
 
             def badge(self, text: str) -> _DummyElement:
@@ -267,7 +267,7 @@ def render_post_card(post_data: dict[str, Any]) -> None:
     if ui is None:
         if hasattr(st, "image") and hasattr(st, "write"):
             if img:
-                st.image(img, use_container_width=True)
+                st.image(img, use_container_width=True, alt="post image")
             caption_text = f"**{html.escape(username)}**: {text}" if username else text
             st.write(caption_text)
             getattr(st, "caption", st.write)(f"❤️ {likes}")
@@ -317,7 +317,7 @@ def render_post_card(post_data: dict[str, Any]) -> None:
             st.warning(f"Post card failed: {exc}")
         if img:
             if hasattr(st, "image"):
-                st.image(img, use_container_width=True)
+                st.image(img, use_container_width=True, alt="post image")
             else:
                 getattr(st, "markdown", lambda *a, **k: None)(
                     f"<img src='{html.escape(img)}' alt='' style='width:100%'>",

--- a/transcendental_resonance_frontend/pages/messages_center.py
+++ b/transcendental_resonance_frontend/pages/messages_center.py
@@ -86,7 +86,7 @@ def main(container: st.DeltaGenerator | None = None) -> None:
                 avatar = msg.get("avatar", f"https://robohash.org/{msg['user']}.png?size=40x40")
                 with st.chat_message(msg["user"], avatar=avatar):
                     if img := msg.get("image"):
-                        st.image(img, use_container_width=True)
+                        st.image(img, use_container_width=True, alt="message image")
                     st.write(msg["text"])
 
             # Input box

--- a/ui.py
+++ b/ui.py
@@ -751,7 +751,12 @@ def render_modern_agents_page():
     cols = st.columns(len(agents))
     for col, name in zip(cols, agents):
         with col:
-            st.image("https://via.placeholder.com/80", width=80, use_container_width=True)
+            st.image(
+                "https://via.placeholder.com/80",
+                width=80,
+                use_container_width=True,
+                alt=f"{name} avatar",
+            )
             st.write(name)
             st.line_chart([1, 3, 2, 4])
 


### PR DESCRIPTION
## Summary
- add alt text for message images in messages center
- pass alt labels when showing avatars in the UI and chat
- support alt text in DummyUI image helper
- describe alt text in profile card

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d195bd9b88320a50f7e525c63af2b