### PR TITLE
Update API import reference

### DIFF
--- a/transcendental_resonance_frontend/pages/resonance_music.py
+++ b/transcendental_resonance_frontend/pages/resonance_music.py
@@ -24,6 +24,7 @@ from streamlit_helpers import (
 )
 from streamlit_autorefresh import st_autorefresh
 from status_indicator import render_status_icon, check_backend # Ensure check_backend is imported
+# Use the shared API utilities from the frontend package
 from transcendental_resonance_frontend.src.utils.api import (
     get_resonance_summary,
     dispatch_route,


### PR DESCRIPTION
## Summary
- clarify where API helpers come from in resonance music page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d19b158a88320a99f3a71c2b4d665