### PR TITLE
Update utils.api imports

### DIFF
--- a/transcendental_resonance_frontend/pages/ai_assist_page.py
+++ b/transcendental_resonance_frontend/pages/ai_assist_page.py
@@ -9,7 +9,7 @@ except Exception:  # pragma: no cover - fallback to Streamlit
     ui = None  # type: ignore
     import streamlit as st
 
-from utils.api import api_call, TOKEN
+from transcendental_resonance_frontend.src.utils.api import api_call, TOKEN
 from utils.styles import get_theme
 from utils.layout import page_container
 from .login_page import login_page

--- a/transcendental_resonance_frontend/pages/debug_panel_page.py
+++ b/transcendental_resonance_frontend/pages/debug_panel_page.py
@@ -12,10 +12,10 @@ except Exception:  # pragma: no cover - fallback to Streamlit
     ui = None  # type: ignore
     import streamlit as st
 
-from utils.api import TOKEN
+from transcendental_resonance_frontend.src.utils.api import TOKEN
 from utils.styles import get_theme
 from utils.layout import page_container
-from utils.api import TOKEN, OFFLINE_MODE
+from transcendental_resonance_frontend.src.utils.api import TOKEN, OFFLINE_MODE
 from frontend_bridge import ROUTES, dispatch_route
 
 # Minimal example payloads for some routes

--- a/transcendental_resonance_frontend/pages/events_page.py
+++ b/transcendental_resonance_frontend/pages/events_page.py
@@ -11,7 +11,7 @@ except Exception:  # pragma: no cover - fallback to Streamlit
     ui = None  # type: ignore
     import streamlit as st
 
-from utils.api import api_call, TOKEN, BACKEND_URL
+from transcendental_resonance_frontend.src.utils.api import api_call, TOKEN, BACKEND_URL
 import httpx
 from utils.styles import get_theme
 from utils.layout import page_container

--- a/transcendental_resonance_frontend/pages/explore_page.py
+++ b/transcendental_resonance_frontend/pages/explore_page.py
@@ -7,7 +7,7 @@ try:
 except Exception:  # pragma: no cover - fallback to Streamlit
     ui = None  # type: ignore
     import streamlit as st
-from utils.api import TOKEN, api_call
+from transcendental_resonance_frontend.src.utils.api import TOKEN, api_call
 from utils.layout import page_container
 from utils.features import skeleton_loader
 from components.media_renderer import render_media_block

--- a/transcendental_resonance_frontend/pages/feed_page.py
+++ b/transcendental_resonance_frontend/pages/feed_page.py
@@ -11,7 +11,7 @@ except Exception:  # pragma: no cover - fallback to Streamlit
     ui = None  # type: ignore
     import streamlit as st
 
-from utils.api import TOKEN, api_call
+from transcendental_resonance_frontend.src.utils.api import TOKEN, api_call
 from utils.layout import page_container
 from utils.styles import get_theme
 from utils.features import quick_post_button, skeleton_loader, swipeable_glow_card

--- a/transcendental_resonance_frontend/pages/forks_page.py
+++ b/transcendental_resonance_frontend/pages/forks_page.py
@@ -9,7 +9,7 @@ except Exception:  # pragma: no cover - fallback to Streamlit
     ui = None  # type: ignore
     import streamlit as st
 
-from utils.api import api_call, TOKEN
+from transcendental_resonance_frontend.src.utils.api import api_call, TOKEN
 from utils.styles import get_theme
 from utils.layout import page_container
 from .login_page import login_page

--- a/transcendental_resonance_frontend/pages/groups_page.py
+++ b/transcendental_resonance_frontend/pages/groups_page.py
@@ -9,7 +9,7 @@ except Exception:  # pragma: no cover - fallback to Streamlit
     ui = None  # type: ignore
     import streamlit as st
 
-from utils.api import api_call, TOKEN, get_group_recommendations
+from transcendental_resonance_frontend.src.utils.api import api_call, TOKEN, get_group_recommendations
 from utils.styles import get_theme
 from utils.layout import page_container
 from utils.features import skeleton_loader

--- a/transcendental_resonance_frontend/pages/login_page.py
+++ b/transcendental_resonance_frontend/pages/login_page.py
@@ -9,7 +9,7 @@ except Exception:  # pragma: no cover - fallback to Streamlit
     ui = None  # type: ignore
     import streamlit as st
 
-from utils.api import api_call, set_token
+from transcendental_resonance_frontend.src.utils.api import api_call, set_token
 from utils.styles import get_theme
 
 

--- a/transcendental_resonance_frontend/pages/messages_page.py
+++ b/transcendental_resonance_frontend/pages/messages_page.py
@@ -10,7 +10,7 @@ except Exception:  # pragma: no cover - fallback to Streamlit
     ui = None  # type: ignore
     import streamlit as st
 
-from utils.api import TOKEN, api_call, listen_ws
+from transcendental_resonance_frontend.src.utils.api import TOKEN, api_call, listen_ws
 from utils.layout import page_container
 from utils.safe_markdown import safe_markdown
 from utils.styles import get_theme

--- a/transcendental_resonance_frontend/pages/moderation_dashboard_page.py
+++ b/transcendental_resonance_frontend/pages/moderation_dashboard_page.py
@@ -11,7 +11,7 @@ except Exception:  # pragma: no cover - fallback to Streamlit
     ui = None  # type: ignore
     import streamlit as st
 
-from utils.api import TOKEN, api_call, listen_ws
+from transcendental_resonance_frontend.src.utils.api import TOKEN, api_call, listen_ws
 from utils.layout import page_container
 from utils.styles import get_theme
 

--- a/transcendental_resonance_frontend/pages/moderation_page.py
+++ b/transcendental_resonance_frontend/pages/moderation_page.py
@@ -6,7 +6,7 @@ except Exception:  # pragma: no cover - fallback to Streamlit
     ui = None  # type: ignore
     import streamlit as st
 
-from utils.api import TOKEN, api_call, listen_ws
+from transcendental_resonance_frontend.src.utils.api import TOKEN, api_call, listen_ws
 from utils.layout import page_container
 from utils.styles import get_theme
 

--- a/transcendental_resonance_frontend/pages/music_page.py
+++ b/transcendental_resonance_frontend/pages/music_page.py
@@ -9,7 +9,7 @@ except Exception:  # pragma: no cover - fallback to Streamlit
     ui = None  # type: ignore
     import streamlit as st
 
-from utils.api import api_call, TOKEN
+from transcendental_resonance_frontend.src.utils.api import api_call, TOKEN
 from utils.styles import get_theme
 from utils.layout import page_container
 from .login_page import login_page

--- a/transcendental_resonance_frontend/pages/network_analysis_page.py
+++ b/transcendental_resonance_frontend/pages/network_analysis_page.py
@@ -10,7 +10,7 @@ try:
 except Exception:  # pragma: no cover - fallback to Streamlit
     ui = None  # type: ignore
     import streamlit as st
-from utils.api import TOKEN, api_call
+from transcendental_resonance_frontend.src.utils.api import TOKEN, api_call
 from utils.layout import page_container
 from utils.styles import get_theme
 

--- a/transcendental_resonance_frontend/pages/notifications_page.py
+++ b/transcendental_resonance_frontend/pages/notifications_page.py
@@ -8,7 +8,7 @@ try:
 except Exception:  # pragma: no cover - fallback to Streamlit
     ui = None  # type: ignore
     import streamlit as st
-from utils.api import TOKEN, api_call, listen_ws
+from transcendental_resonance_frontend.src.utils.api import TOKEN, api_call, listen_ws
 from utils.layout import page_container
 from utils.styles import get_theme
 

--- a/transcendental_resonance_frontend/pages/profile_page.py
+++ b/transcendental_resonance_frontend/pages/profile_page.py
@@ -9,7 +9,7 @@ try:
 except Exception:  # pragma: no cover - fallback to Streamlit
     ui = None  # type: ignore
     import streamlit as st
-from utils.api import (
+from transcendental_resonance_frontend.src.utils.api import (
     TOKEN,
     api_call,
     clear_token,

--- a/transcendental_resonance_frontend/pages/proposals_page.py
+++ b/transcendental_resonance_frontend/pages/proposals_page.py
@@ -9,7 +9,7 @@ except Exception:  # pragma: no cover - fallback to Streamlit
     ui = None  # type: ignore
     import streamlit as st
 
-from utils.api import api_call, TOKEN
+from transcendental_resonance_frontend.src.utils.api import api_call, TOKEN
 from utils.styles import get_theme
 from utils.layout import page_container
 from utils.features import skeleton_loader

--- a/transcendental_resonance_frontend/pages/recommendations_page.py
+++ b/transcendental_resonance_frontend/pages/recommendations_page.py
@@ -9,7 +9,7 @@ except Exception:  # pragma: no cover - fallback to Streamlit
     ui = None  # type: ignore
     import streamlit as st
 
-from utils.api import api_call, TOKEN
+from transcendental_resonance_frontend.src.utils.api import api_call, TOKEN
 from utils.styles import get_theme
 from utils.layout import page_container
 from utils.features import skeleton_loader

--- a/transcendental_resonance_frontend/pages/resonance_music.py
+++ b/transcendental_resonance_frontend/pages/resonance_music.py
@@ -24,7 +24,7 @@ from streamlit_helpers import (
 )
 from streamlit_autorefresh import st_autorefresh
 from status_indicator import render_status_icon, check_backend # Ensure check_backend is imported
-from utils.api import get_resonance_summary, dispatch_route # Import get_resonance_summary and dispatch_route from utils.api
+from transcendental_resonance_frontend.src.utils.api import get_resonance_summary, dispatch_route # Import get_resonance_summary and dispatch_route from utils.api
 
 set_theme("light")
 inject_modern_styles()

--- a/transcendental_resonance_frontend/pages/status_page.py
+++ b/transcendental_resonance_frontend/pages/status_page.py
@@ -8,7 +8,7 @@ try:
 except Exception:  # pragma: no cover - fallback to Streamlit
     ui = None  # type: ignore
     import streamlit as st
-from utils.api import TOKEN, api_call
+from transcendental_resonance_frontend.src.utils.api import TOKEN, api_call
 from utils.layout import page_container
 from utils.styles import get_theme
 

--- a/transcendental_resonance_frontend/pages/system_insights_page.py
+++ b/transcendental_resonance_frontend/pages/system_insights_page.py
@@ -8,7 +8,7 @@ try:
 except Exception:  # pragma: no cover - fallback to Streamlit
     ui = None  # type: ignore
     import streamlit as st
-from utils.api import TOKEN, api_call
+from transcendental_resonance_frontend.src.utils.api import TOKEN, api_call
 from utils.layout import page_container
 from utils.styles import get_theme
 

--- a/transcendental_resonance_frontend/pages/upload_page.py
+++ b/transcendental_resonance_frontend/pages/upload_page.py
@@ -11,7 +11,7 @@ except Exception:  # pragma: no cover - fallback to Streamlit
 import asyncio
 import contextlib
 
-from utils.api import api_call, TOKEN
+from transcendental_resonance_frontend.src.utils.api import api_call, TOKEN
 from utils.styles import get_theme
 from utils.layout import page_container
 from .login_page import login_page

--- a/transcendental_resonance_frontend/pages/validator_graph_page.py
+++ b/transcendental_resonance_frontend/pages/validator_graph_page.py
@@ -10,7 +10,7 @@ try:
 except Exception:  # pragma: no cover - fallback to Streamlit
     ui = None  # type: ignore
     import streamlit as st
-from utils.api import TOKEN, api_call
+from transcendental_resonance_frontend.src.utils.api import TOKEN, api_call
 from utils.layout import page_container
 from utils.styles import get_theme
 

--- a/transcendental_resonance_frontend/pages/vibenodes_page.py
+++ b/transcendental_resonance_frontend/pages/vibenodes_page.py
@@ -20,7 +20,7 @@ import contextlib
 from components.emoji_toolbar import emoji_toolbar
 from components.media_renderer import render_media_block
 
-from utils.api import TOKEN, api_call, listen_ws
+from transcendental_resonance_frontend.src.utils.api import TOKEN, api_call, listen_ws
 from utils.features import skeleton_loader
 from utils.layout import page_container
 from utils.safe_markdown import safe_markdown

--- a/transcendental_resonance_frontend/pages/video_chat_page.py
+++ b/transcendental_resonance_frontend/pages/video_chat_page.py
@@ -13,7 +13,7 @@ except Exception:  # pragma: no cover - fallback to Streamlit
     ui = None  # type: ignore
     import streamlit as st
 
-from utils.api import TOKEN, WS_CONNECTION, connect_ws
+from transcendental_resonance_frontend.src.utils.api import TOKEN, WS_CONNECTION, connect_ws
 from utils.layout import page_container
 from utils.styles import get_theme
 

--- a/transcendental_resonance_frontend/tests/test_offline_mode.py
+++ b/transcendental_resonance_frontend/tests/test_offline_mode.py
@@ -8,7 +8,7 @@ pytestmark = pytest.mark.requires_nicegui
 
 import inspect
 
-from utils.api import api_call, connect_ws, listen_ws
+from transcendental_resonance_frontend.src.utils.api import api_call, connect_ws, listen_ws
 from quantum_futures import generate_speculative_payload
 from nicegui import ui
 from utils import api


### PR DESCRIPTION
## Summary
- update all imports from `utils.api` to `transcendental_resonance_frontend.src.utils.api`
- adjust page and test modules accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d1961055083208cf404eeb3187cea