### PR TITLE
Add user search tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,3 +36,27 @@ def pytest_runtest_setup(item: pytest.Item) -> None:
     if item.get_closest_marker("requires_nicegui") and not HAS_NICEGUI:
         pytest.skip("nicegui not installed")
 
+
+@pytest.fixture(autouse=True)
+def _streamlit_poll(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force fast file watching and disable external network calls."""
+    monkeypatch.setenv("STREAMLIT_WATCHER_TYPE", "poll")
+
+
+@pytest.fixture(autouse=True)
+def _disable_network(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Prevent outgoing network connections except to localhost."""
+    import socket
+
+    real_create_connection = socket.create_connection
+
+    def guard(address, *args, **kwargs):
+        host = address[0]
+        if host not in {"127.0.0.1", "localhost"}:
+            raise RuntimeError("External network connections disabled during tests")
+        return real_create_connection(address, *args, **kwargs)
+
+    monkeypatch.setattr(socket, "create_connection", guard)
+    yield
+    monkeypatch.setattr(socket, "create_connection", real_create_connection)
+

--- a/tests/test_user_search.py
+++ b/tests/test_user_search.py
@@ -1,0 +1,73 @@
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+pytest.importorskip("streamlit")
+pytestmark = pytest.mark.requires_streamlit
+
+root = Path(__file__).resolve().parents[1]
+if str(root) not in sys.path:
+    sys.path.insert(0, str(root))
+
+import superNova_2177 as sn
+import db_models
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    monkeypatch.setenv("DB_MODE", "central")
+    db_path = tmp_path / "test.db"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+    monkeypatch.setenv("SECRET_KEY", "testsecret")
+    db_models.init_db(f"sqlite:///{db_path}")
+
+    importlib.reload(db_models)
+    sn_mod = importlib.reload(sn)
+    sn_mod.create_database()
+    sn_mod.create_app()
+    sn_mod.Base.metadata.drop_all(bind=sn_mod.engine)
+    sn_mod.Base.metadata.create_all(bind=sn_mod.engine)
+    with sn_mod.SessionLocal() as db:
+        users = [
+            sn_mod.Harmonizer(
+                username="alice",
+                email="alice@example.com",
+                hashed_password=sn_mod.get_password_hash("pw"),
+            ),
+            sn_mod.Harmonizer(
+                username="bob",
+                email="bob@example.com",
+                hashed_password=sn_mod.get_password_hash("pw"),
+            ),
+        ]
+        db.add_all(users)
+        db.commit()
+    return TestClient(sn_mod.app)
+
+
+def test_search_users_basic(client):
+    import superNova_2177 as sn_mod
+    with sn_mod.SessionLocal() as db:
+        data = sn_mod.search_users("al", db)
+    usernames = [u["username"] for u in data]
+    assert "alice" in usernames
+
+
+def test_search_users_result_limit(client):
+    import superNova_2177 as sn_mod
+    with sn_mod.SessionLocal() as db:
+        for i in range(10):
+            db.add(
+                sn_mod.Harmonizer(
+                    username=f"user{i}",
+                    email=f"user{i}@example.com",
+                    hashed_password=sn_mod.get_password_hash("pw"),
+                )
+            )
+        db.commit()
+    with sn_mod.SessionLocal() as db:
+        resp = sn_mod.search_users("user", db)
+    assert len(resp) <= 5


### PR DESCRIPTION
## Summary
- add user search tests
- enforce fast Streamlit watcher and disable network during tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d1df6595c8320bd8ca99dcfbf068c