### PR TITLE
Centralize modern style injection

### DIFF
--- a/frontend/theme.py
+++ b/frontend/theme.py
@@ -12,6 +12,7 @@ import streamlit as st
 @dataclass(frozen=True)
 class ColorTheme:
     """Container for theme colors and common tokens."""
+
     bg: str
     card: str
     accent: str
@@ -21,27 +22,29 @@ class ColorTheme:
 
     def css_vars(self) -> str:
         """Return CSS variable declarations for this theme."""
-        return "\n    ".join([
-            f"--bg: {self.bg};",
-            f"--card: {self.card};",
-            f"--accent: {self.accent};",
-            f"--text-muted: {self.text_muted};",
-            f"--radius: {self.radius};",
-            f"--transition: {self.transition};",
-        ])
+        return "\n    ".join(
+            [
+                f"--bg: {self.bg};",
+                f"--card: {self.card};",
+                f"--accent: {self.accent};",
+                f"--text-muted: {self.text_muted};",
+                f"--radius: {self.radius};",
+                f"--transition: {self.transition};",
+            ]
+        )
 
 
 # Modern “light” and “dark” palettes
 LIGHT_THEME = ColorTheme(
     bg="#F0F2F6",
     card="#FFFFFF",
-    accent="#0077B5",        # LinkedIn-blue accent
+    accent="#0077B5",  # LinkedIn-blue accent
     text_muted="#666666",
 )
 DARK_THEME = ColorTheme(
     bg="#0A0F14",
     card="rgba(255,255,255,0.05)",
-    accent="#00E5FF",        # Neon cyan
+    accent="#00E5FF",  # Neon cyan
     text_muted="#AAAAAA",
 )
 
@@ -126,41 +129,44 @@ def inject_modern_styles(theme: bool | str = True) -> None:
 
     apply_theme(mode)
 
-    extra = """
-    <style>
-    /* Glassmorphic cards */
-    .glass-card {
-        background: var(--card);
-        backdrop-filter: blur(10px);
-        border: 1px solid rgba(255,255,255,0.2);
-        border-radius: var(--radius);
-        padding: 1rem;
-        animation: fade-in var(--transition) forwards;
-        box-shadow: 0 8px 20px rgba(0,0,0,0.1);
-    }
-
-    /* Accent gradient buttons */
-    .insta-btn, .linkedin-btn {
-        padding: 0.6rem 1.2rem;
-        border: none;
-        border-radius: var(--radius);
-        color: white !important;
-        font-weight: 600;
-        cursor: pointer;
-        transition: transform 0.2s ease;
-    }
-    .insta-btn {
-        background: linear-gradient(45deg, #F58529, #DD2A7B, #8134AF);
-    }
-    .linkedin-btn {
-        background: var(--accent);
-    }
-    .insta-btn:active, .linkedin-btn:active {
-        transform: scale(0.97);
-    }
-
-    </style>
-    """
+    extra = (
+        "<link rel='preconnect' href='https://fonts.googleapis.com'>\n"
+        "<link href='https://fonts.googleapis.com/css2?family=Inter:wght@400;600&"
+        "display=swap' rel='stylesheet'>\n"
+        "<style>\n"
+        "/* Glassmorphic cards */\n"
+        ".glass-card {\n"
+        "    background: var(--card);\n"
+        "    backdrop-filter: blur(10px);\n"
+        "    border: 1px solid rgba(255,255,255,0.2);\n"
+        "    border-radius: var(--radius);\n"
+        "    padding: 1rem;\n"
+        "    animation: fade-in var(--transition) forwards;\n"
+        "    box-shadow: 0 8px 20px rgba(0,0,0,0.1);\n"
+        "}\n"
+        "\n"
+        "/* Accent gradient buttons */\n"
+        ".insta-btn, .linkedin-btn {\n"
+        "    padding: 0.6rem 1.2rem;\n"
+        "    border: none;\n"
+        "    border-radius: var(--radius);\n"
+        "    color: white !important;\n"
+        "    font-weight: 600;\n"
+        "    cursor: pointer;\n"
+        "    transition: transform 0.2s ease;\n"
+        "}\n"
+        ".insta-btn {\n"
+        "    background: linear-gradient(45deg, #F58529, #DD2A7B, #8134AF);\n"
+        "}\n"
+        ".linkedin-btn {\n"
+        "    background: var(--accent);\n"
+        "}\n"
+        ".insta-btn:active, .linkedin-btn:active {\n"
+        "    transform: scale(0.97);\n"
+        "}\n"
+        "\n"
+        "</style>\n"
+    )
     st.markdown(extra, unsafe_allow_html=True)
     st.session_state["_styles_injected"] = True
 
@@ -168,7 +174,9 @@ def inject_modern_styles(theme: bool | str = True) -> None:
 def set_theme(name: str) -> None:
     """Store ``name`` in session state and apply CSS once."""
     mode = _resolve_mode(name)
-    if st.session_state.get("_theme") == mode and st.session_state.get("_styles_injected"):
+    if st.session_state.get("_theme") == mode and st.session_state.get(
+        "_styles_injected"
+    ):
         return
 
     st.session_state["_theme"] = mode

--- a/frontend/ui_layout.py
+++ b/frontend/ui_layout.py
@@ -7,8 +7,10 @@ Key helpers
 -----------
 main_container()            – main page container
 sidebar_container()         – Streamlit sidebar wrapper
-render_top_bar()            – sticky translucent navbar (logo · search · bell · beta · avatar)
-render_sidebar_nav(...)     – vertical nav (option-menu or radio fallback)
+render_top_bar()            – sticky translucent navbar
+                             (logo · search · bell · beta · avatar)
+render_sidebar_nav(...)     – vertical nav
+                             (option-menu or radio fallback)
 render_title_bar(icon,txt)  – page H1 with emoji / icon
 show_preview_badge(text)    – floating “Preview” badge
 render_profile_card(user)   – proxy around profile_card.render_profile_card
@@ -26,58 +28,71 @@ import streamlit as st
 from modern_ui_components import SIDEBAR_STYLES
 from profile_card import render_profile_card as _render_profile_card
 from frontend import theme
+
 try:
     from streamlit_javascript import st_javascript
 except Exception:  # pragma: no cover - optional dependency
+
     def st_javascript(*_a, **_kw):
         return None
+
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # CONSTANTS & GLOBAL CSS
 # ═══════════════════════════════════════════════════════════════════════════════
 _EMOJI_FALLBACK = "🔖"
-LAYOUT_CSS = """
-<style>
-.glass-card{
-  background:rgba(255,255,255,.06);
-  border:1px solid rgba(255,255,255,.10);
-  backdrop-filter:blur(14px);
-  border-radius:1rem;
-  padding:1rem;
-}
-.insta-card{
-  display:flex;flex-direction:column;
-  background:var(--card);
-  border-radius:1rem;
-  overflow:hidden;
-  box-shadow:0 2px 6px rgba(0,0,0,.1);
-  transition:transform .25s ease,box-shadow .25s ease;
-}
-.insta-card:hover{
-  transform:translateY(-4px);
-  box-shadow:0 8px 22px rgba(0,0,0,.18);
-}
-</style>
-"""
 
 # Slide-in drawer & mobile bottom tabs
 DRAWER_CSS = """
 <style>
-[data-testid='stSidebar']{background:var(--card);border-right:1px solid rgba(255,255,255,0.1);transition:transform 0.3s ease;z-index:1002;}
-[data-testid='stSidebar'].collapsed{transform:translateX(-100%);}
-@media(min-width:768px){[data-testid='stSidebar']{transform:none!important;}}
-#drawer_btn{display:none;background:none;border:none;color:#fff;font-size:1.3rem;cursor:pointer;}
+[data-testid='stSidebar']{
+  background: var(--card);
+  border-right: 1px solid rgba(255,255,255,0.1);
+  transition: transform 0.3s ease;
+  z-index: 1002;
+}
+[data-testid='stSidebar'].collapsed {
+  transform: translateX(-100%);
+}
+@media(min-width:768px){
+  [data-testid='stSidebar']{transform:none!important;}
+}
+#drawer_btn{
+  display: none;
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 1.3rem;
+  cursor: pointer;
+}
 @media(max-width:768px){#drawer_btn{display:block;}}
 </style>
 """
 
 BOTTOM_TAB_TEMPLATE = """
 <style>
-.sn-bottom-tabs{position:fixed;bottom:0;left:0;right:0;display:none;background:var(--card);border-top:1px solid rgba(255,255,255,0.1);z-index:1001;}
-.sn-bottom-tabs a{flex:1;text-align:center;padding:.4rem 0;color:var(--text-muted);text-decoration:none;}
+.sn-bottom-tabs{
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: none;
+  background: var(--card);
+  border-top: 1px solid rgba(255,255,255,0.1);
+  z-index: 1001;
+}
+.sn-bottom-tabs a{
+  flex: 1;
+  text-align: center;
+  padding: .4rem 0;
+  color: var(--text-muted);
+  text-decoration: none;
+}
 .sn-bottom-tabs a i{font-size:1.2rem;}
 .sn-bottom-tabs a.active{color:{accent};}
-@media(max-width:768px){.sn-bottom-tabs{display:flex;align-items:center;justify-content:space-around;}}
+@media(max-width:768px){
+  .sn-bottom-tabs{display:flex;align-items:center;justify-content:space-around;}
+}
 @media(min-width:768px){.sn-bottom-tabs{display:none!important;}}
 </style>
 <div class='sn-bottom-tabs'>
@@ -89,7 +104,9 @@ BOTTOM_TAB_TEMPLATE = """
 </div>
 <script>
   var active='{active}';
-  document.querySelectorAll('.sn-bottom-tabs a').forEach(a=>{if(a.dataset.tag===active){a.classList.add('active');}});
+  document.querySelectorAll('.sn-bottom-tabs a').forEach(a=>{
+    if(a.dataset.tag===active){a.classList.add('active');}
+  });
 </script>
 """
 
@@ -105,18 +122,18 @@ except Exception:  # pragma: no cover
 # optional pretty-sidebar package
 try:
     from streamlit_option_menu import option_menu
+
     USE_OPTION_MENU = True
 except ImportError:  # pragma: no cover
     USE_OPTION_MENU = False
+
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # BASIC CONTAINERS
 # ═══════════════════════════════════════════════════════════════════════════════
 def main_container() -> st.delta_generator.DeltaGenerator:
     """Main content container (injects base CSS once)."""
-    if "_layout_css_injected" not in st.session_state:
-        st.markdown(LAYOUT_CSS, unsafe_allow_html=True)
-        st.session_state["_layout_css_injected"] = True
+    theme.inject_modern_styles()
     return st.container()
 
 
@@ -224,47 +241,55 @@ def render_top_bar() -> None:
         return
     menu_col, logo_col, search_col, bell_col, beta_col, avatar_col = cols
 
-    menu_col.markdown(
-        f"""
-        <input type='checkbox' id='drawer_toggle' {'checked' if st.session_state.get('_drawer_open', True) else ''} hidden>
+    checked = "checked" if st.session_state.get("_drawer_open", True) else ""
+    drawer_html = f"""
+        <input type='checkbox' id='drawer_toggle' {checked} hidden>
         <label for='drawer_toggle' id='drawer_btn'>☰</label>
         <script>
-        const dt=document.getElementById('drawer_toggle');
-        const saved = localStorage.getItem('drawer_open');
-        if(dt && saved !== null) dt.checked = saved === 'true';
-        function storeDrawer(){{ if(dt) localStorage.setItem('drawer_open', dt.checked); }}
-        dt?.addEventListener('change', storeDrawer);
+          const dt=document.getElementById('drawer_toggle');
+          const saved = localStorage.getItem('drawer_open');
+          if(dt && saved !== null) dt.checked = saved === 'true';
+          function storeDrawer(){{
+            if(dt) localStorage.setItem('drawer_open', dt.checked);
+          }}
+          dt?.addEventListener('change', storeDrawer);
         </script>
-        """,
-        unsafe_allow_html=True,
-    )
+    """
+    menu_col.markdown(drawer_html, unsafe_allow_html=True)
 
-    logo_col.markdown('<i class="fa-solid fa-rocket fa-lg"></i>', unsafe_allow_html=True)
+    logo_col.markdown(
+        '<i class="fa-solid fa-rocket fa-lg"></i>', unsafe_allow_html=True
+    )
 
     # search box with suggestions
     pid = st.session_state.get("active_page", "global")
     q_key = f"{pid}_search"
-    q = search_col.text_input("Search", placeholder="Search…", key=q_key, label_visibility="hidden")
+    q = search_col.text_input(
+        "Search", placeholder="Search…", key=q_key, label_visibility="hidden"
+    )
     if q:
         recent = st.session_state.setdefault("_recent_q", [])
         if q not in recent:
             recent.append(q)
             st.session_state["_recent_q"] = recent[-6:]
 
-    if (sugs := st.session_state.get("_recent_q")):
+    if sugs := st.session_state.get("_recent_q"):
         options = "".join(f"<option value='{s}'></option>" for s in sugs)
-        search_col.markdown(
-            f"<datalist id='recent-sugs'>{options}</datalist>"
-            "<script>window.parent.document.querySelector('.sn-topbar input[type=text]')?.setAttribute('list','recent-sugs');</script>",
-            unsafe_allow_html=True,
+        data_list = f"<datalist id='recent-sugs'>{options}</datalist>"
+        script = (
+            "<script>window.parent.document.querySelector("
+            "'.sn-topbar input[type=text]')?.setAttribute('list','recent-sugs');"
+            "</script>"
         )
+        search_col.markdown(data_list + script, unsafe_allow_html=True)
 
     # notifications bell
     n_notes = len(st.session_state.get("notifications", []))
-    bell_col.markdown(
-        f'<button class="sn-bell" data-count="{n_notes or ""}" aria-label="Notifications"></button>',
-        unsafe_allow_html=True,
+    bell_html = (
+        f'<button class="sn-bell" data-count="{n_notes or ""}" '
+        'aria-label="Notifications"></button>'
     )
+    bell_col.markdown(bell_html, unsafe_allow_html=True)
     with bell_col.popover("Notifications"):
         if n_notes:
             for note in st.session_state["notifications"]:
@@ -281,7 +306,9 @@ def render_top_bar() -> None:
         pass
 
     # avatar placeholder
-    avatar_col.markdown('<i class="fa-regular fa-circle-user fa-lg"></i>', unsafe_allow_html=True)
+    avatar_col.markdown(
+        '<i class="fa-regular fa-circle-user fa-lg"></i>', unsafe_allow_html=True
+    )
 
     # close .sn-topbar
     st.markdown("</div>", unsafe_allow_html=True)
@@ -302,7 +329,8 @@ def _render_sidebar_nav(
 ) -> str:
     """Vertical sidebar nav; returns the *label* of the chosen page."""
     raw_pairs = (
-        list(page_links.items()) if isinstance(page_links, dict)
+        list(page_links.items())
+        if isinstance(page_links, dict)
         else [(None, p) for p in page_links]
     )
     icons = list(icons or [None] * len(raw_pairs))
@@ -333,9 +361,9 @@ def _render_sidebar_nav(
 
     default_lbl = default or choices[0][0]
     active_lbl = st.session_state.get(session_key, default_lbl)
-    if active_lbl not in [l for l, _ in choices]:
+    if active_lbl not in [label for label, _ in choices]:
         active_lbl = default_lbl
-    default_idx = [l for l, _ in choices].index(active_lbl)
+    default_idx = [label for label, _ in choices].index(active_lbl)
 
     with st.sidebar:
         st.markdown(SIDEBAR_STYLES, unsafe_allow_html=True)
@@ -352,8 +380,8 @@ def _render_sidebar_nav(
         elif USE_OPTION_MENU:
             chosen = option_menu(
                 menu_title="",
-                options=[l for l, _ in choices],
-                icons=[icon_map.get(l) or "dot" for l, _ in choices],
+                options=[label for label, _ in choices],
+                icons=[icon_map.get(label) or "dot" for label, _ in choices],
                 orientation="vertical",
                 key=key,
                 default_index=default_idx,
@@ -365,8 +393,11 @@ def _render_sidebar_nav(
                 f"{icon_map.get(lbl) or ''} {lbl}".strip() for lbl, _ in choices
             ]
             picked = st.radio(
-                "Navigation", radio_labels,
-                index=default_idx, key=key, label_visibility="collapsed"
+                "Navigation",
+                radio_labels,
+                index=default_idx,
+                key=key,
+                label_visibility="collapsed",
             )
             chosen = choices[radio_labels.index(picked)][0]
 
@@ -385,6 +416,7 @@ def render_sidebar_nav(*a, **kw):
 
 
 render_modern_sidebar = render_sidebar_nav  # legacy alias
+
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # TITLE & BADGE
@@ -417,6 +449,7 @@ def render_bottom_tab_bar() -> None:
         BOTTOM_TAB_TEMPLATE.format(accent=accent, active=active),
         unsafe_allow_html=True,
     )
+
 
 # ═══════════════════════════════════════════════════════════════════════════════
 __all__ = [

--- a/modern_ui_components.py
+++ b/modern_ui_components.py
@@ -10,6 +10,7 @@ import streamlit as st
 from typing import Optional, Dict
 from contextlib import contextmanager
 from pathlib import Path
+
 try:
     # Prefer the shared path constants if available
     _paths = importlib.import_module("utils.paths")
@@ -17,29 +18,33 @@ try:
     PAGES_DIR = _paths.PAGES_DIR
     get_pages_dir = _paths.get_pages_dir
 except Exception:  # pragma: no cover – fallback for isolated execution
-    ROOT_DIR = Path(__file__).resolve().parents[1]          # repo root
+    ROOT_DIR = Path(__file__).resolve().parents[1]  # repo root
     PAGES_DIR = ROOT_DIR / "transcendental_resonance_frontend" / "pages"
 
     def get_pages_dir() -> Path:
         return PAGES_DIR
 
-from uuid import uuid4
+
 from streamlit_helpers import safe_container
 from frontend.theme import inject_modern_styles
 
 from frontend import theme
+
 try:
     from streamlit_javascript import st_javascript
 except Exception:  # pragma: no cover - optional dependency or missing runtime
+
     def st_javascript(*_args, **_kwargs) -> None:
         """Fallback no-op when ``streamlit_javascript`` is unavailable."""
         return None
+
 
 HAS_LUCIDE = importlib.util.find_spec("lucide-react") is not None
 LUCIDE_LOADED_KEY = "_lucide_js_loaded"
 
 try:
     from streamlit_option_menu import option_menu
+
     USE_OPTION_MENU = True
 except Exception:  # pragma: no cover - optional dependency
     option_menu = None  # type: ignore
@@ -127,7 +132,9 @@ def shadcn_card(title: Optional[str] = None):
     st.markdown(SHADCN_CARD_CSS, unsafe_allow_html=True)
     st.markdown("<div class='shadcn-card'>", unsafe_allow_html=True)
     if title:
-        st.markdown(f"<div class='shadcn-card-title'>{title}</div>", unsafe_allow_html=True)
+        st.markdown(
+            f"<div class='shadcn-card-title'>{title}</div>", unsafe_allow_html=True
+        )
     with st.container() as container:
         yield container
     st.markdown("</div>", unsafe_allow_html=True)
@@ -150,32 +157,9 @@ def _icon_html(name: str) -> str:
     return name
 
 
-
 def render_modern_layout() -> None:
     """Apply global styles and base glassmorphism containers."""
     inject_modern_styles()
-    st.markdown(
-        """
-        <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
-        <style>
-        .glass-card {
-            background: rgba(255,255,255,0.3);
-            border-radius: 16px;
-            border: 1px solid rgba(255,255,255,0.4);
-            backdrop-filter: blur(14px);
-            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-            padding: 1rem;
-            margin-bottom: 1rem;
-            transition: box-shadow 0.2s ease, transform 0.2s ease;
-        }
-        .glass-card:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 4px 12px rgba(0,0,0,0.15);
-        }
-        </style>
-        """,
-        unsafe_allow_html=True,
-    )
 
 
 def render_modern_header(title: str) -> None:
@@ -220,7 +204,6 @@ def render_modern_sidebar(
     missing_pages: list[str] = []
 
     for label, page_ref in pages.items():
-
         slug = str(page_ref).strip("/").split("?")[0].rsplit(".", 1)[-1]
 
         exists = any((d / f"{slug}.py").exists() for d in existing_dirs)
@@ -232,24 +215,20 @@ def render_modern_sidebar(
         valid_pages[label] = page_ref
 
     if missing_pages:
-
         msg = "Unknown pages: " + ", ".join(missing_pages)
 
         if hasattr(st, "warning"):
-
             st.warning(msg, icon="⚠️")
 
         else:  # pragma: no cover - used in tests with SimpleNamespace
-
             print(msg)
 
     if not valid_pages:
-
         st.error("No valid pages available", icon="⚠️")
 
         return ""
 
-    pages = valid_pages    
+    pages = valid_pages
 
     opts = list(pages.keys())
     if not opts:
@@ -283,16 +262,17 @@ def render_modern_sidebar(
             st.session_state[collapsed_key] = not st.session_state[collapsed_key]
     else:
         # fallback in case st.button is unavailable (optional)
-        collapsed = st.session_state.get(collapsed_key, False)
-
+        st.session_state.get(collapsed_key, False)
 
     container_ctx = safe_container(container)
     with container_ctx:
         st.markdown(SIDEBAR_STYLES, unsafe_allow_html=True)
-        st.markdown(
-            f"<script>var sb=document.querySelector('[data-testid=\"stSidebar\"]'); if(sb) sb.classList.toggle('collapsed', {str(st.session_state.get(collapsed_key, False)).lower()});</script>",
-            unsafe_allow_html=True,
+        script = (
+            "<script>var sb=document.querySelector('[data-testid=\"stSidebar\"]'); "
+            f"if(sb) sb.classList.toggle('collapsed', {str(st.session_state.get(collapsed_key, False)).lower()});"  # noqa: E501
+            "</script>"
         )
+        st.markdown(script, unsafe_allow_html=True)
         st.markdown(
             f"<div class='glass-card sidebar-nav {orientation_cls}'>",
             unsafe_allow_html=True,
@@ -306,7 +286,9 @@ def render_modern_sidebar(
                     icons=[icon_map.get(o, "dot") for o in opts],
                     orientation="horizontal" if horizontal else "vertical",
                     key=widget_key,
-                    default_index=opts.index(st.session_state.get(session_key, opts[0])),
+                    default_index=opts.index(
+                        st.session_state.get(session_key, opts[0])
+                    ),
                 )
             elif horizontal:
                 # Render as horizontal buttons
@@ -325,7 +307,9 @@ def render_modern_sidebar(
                     index=opts.index(st.session_state.get(session_key, opts[0])),
                 )
                 choice = opts[
-                    [f"{_icon_html(icon_map.get(o, ''))} {o}".strip() for o in opts].index(choice_disp)
+                    [
+                        f"{_icon_html(icon_map.get(o, ''))} {o}".strip() for o in opts
+                    ].index(choice_disp)
                 ]
 
         except Exception:
@@ -343,7 +327,9 @@ def render_modern_sidebar(
                     unsafe_allow_html=True,
                 )
                 st.session_state[LUCIDE_LOADED_KEY] = True
-            st.markdown("<script>lucide.createIcons();</script>", unsafe_allow_html=True)
+            st.markdown(
+                "<script>lucide.createIcons();</script>", unsafe_allow_html=True
+            )
         return choice
 
 
@@ -374,7 +360,7 @@ def render_post_card(entry: dict) -> None:
             f"<br>Score: {score}" if score is not None else ""
         )
     st.markdown(
-        f"<div class='sn-card' style='background:white;padding:1rem;margin-bottom:1rem;'>{content}</div>",
+        f"<div class='sn-card' style='background:white;padding:1rem;margin-bottom:1rem;'>{content}</div>",  # noqa: E501
         unsafe_allow_html=True,
     )
 


### PR DESCRIPTION
## Summary
- consolidate style links and CSS in `frontend.theme.inject_modern_styles`
- call theme helpers from `frontend.ui_layout.main_container`
- simplify `modern_ui_components.render_modern_layout`

## Testing
- `pre-commit run --files frontend/theme.py modern_ui_components.py frontend/ui_layout.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d1df543848320862da17a3f2f148b