### PR TITLE
Create common utils.api and update page imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,17 @@ This project depends on libraries such as `fastapi`, `pydantic-settings`, `struc
 6. On first launch the application seeds `harmonizers.db` with an `admin`,
    `guest`, and `demo_user` account so the UI has sample profiles ready.
 
+### Module Search Path
+
+Add the repository root to your `PYTHONPATH` or install the project in editable
+mode so imports like `from utils.api import api_call` resolve correctly:
+
+```bash
+pip install -e .
+# or
+export PYTHONPATH="${PWD}"
+```
+
 ### Extras
 
 The NiceGUI-based frontend under `transcendental_resonance_frontend/` is

--- a/transcendental_resonance_frontend/pages/ai_assist_page.py
+++ b/transcendental_resonance_frontend/pages/ai_assist_page.py
@@ -9,7 +9,7 @@ except Exception:  # pragma: no cover - fallback to Streamlit
     ui = None  # type: ignore
     import streamlit as st
 
-from transcendental_resonance_frontend.src.utils.api import api_call, TOKEN
+from utils.api import api_call, TOKEN
 from utils.styles import get_theme
 from utils.layout import page_container
 from .login_page import login_page

--- a/transcendental_resonance_frontend/pages/debug_panel_page.py
+++ b/transcendental_resonance_frontend/pages/debug_panel_page.py
@@ -12,10 +12,10 @@ except Exception:  # pragma: no cover - fallback to Streamlit
     ui = None  # type: ignore
     import streamlit as st
 
-from transcendental_resonance_frontend.src.utils.api import TOKEN
+from utils.api import TOKEN
 from utils.styles import get_theme
 from utils.layout import page_container
-from transcendental_resonance_frontend.src.utils.api import TOKEN, OFFLINE_MODE
+from utils.api import TOKEN, OFFLINE_MODE
 from frontend_bridge import ROUTES, dispatch_route
 
 # Minimal example payloads for some routes

--- a/transcendental_resonance_frontend/pages/events_page.py
+++ b/transcendental_resonance_frontend/pages/events_page.py
@@ -11,7 +11,7 @@ except Exception:  # pragma: no cover - fallback to Streamlit
     ui = None  # type: ignore
     import streamlit as st
 
-from transcendental_resonance_frontend.src.utils.api import api_call, TOKEN, BACKEND_URL
+from utils.api import api_call, TOKEN, BACKEND_URL
 import httpx
 from utils.styles import get_theme
 from utils.layout import page_container

--- a/transcendental_resonance_frontend/pages/explore_page.py
+++ b/transcendental_resonance_frontend/pages/explore_page.py
@@ -7,7 +7,7 @@ try:
 except Exception:  # pragma: no cover - fallback to Streamlit
     ui = None  # type: ignore
     import streamlit as st
-from transcendental_resonance_frontend.src.utils.api import TOKEN, api_call
+from utils.api import TOKEN, api_call
 from utils.layout import page_container
 from utils.features import skeleton_loader
 from components.media_renderer import render_media_block

--- a/transcendental_resonance_frontend/pages/feed_page.py
+++ b/transcendental_resonance_frontend/pages/feed_page.py
@@ -11,7 +11,7 @@ except Exception:  # pragma: no cover - fallback to Streamlit
     ui = None  # type: ignore
     import streamlit as st
 
-from transcendental_resonance_frontend.src.utils.api import TOKEN, api_call
+from utils.api import TOKEN, api_call
 from utils.layout import page_container
 from utils.styles import get_theme
 from utils.features import quick_post_button, skeleton_loader, swipeable_glow_card

--- a/transcendental_resonance_frontend/pages/forks_page.py
+++ b/transcendental_resonance_frontend/pages/forks_page.py
@@ -9,7 +9,7 @@ except Exception:  # pragma: no cover - fallback to Streamlit
     ui = None  # type: ignore
     import streamlit as st
 
-from transcendental_resonance_frontend.src.utils.api import api_call, TOKEN
+from utils.api import api_call, TOKEN
 from utils.styles import get_theme
 from utils.layout import page_container
 from .login_page import login_page

--- a/transcendental_resonance_frontend/pages/groups_page.py
+++ b/transcendental_resonance_frontend/pages/groups_page.py
@@ -9,7 +9,7 @@ except Exception:  # pragma: no cover - fallback to Streamlit
     ui = None  # type: ignore
     import streamlit as st
 
-from transcendental_resonance_frontend.src.utils.api import api_call, TOKEN, get_group_recommendations
+from utils.api import api_call, TOKEN, get_group_recommendations
 from utils.styles import get_theme
 from utils.layout import page_container
 from utils.features import skeleton_loader

--- a/transcendental_resonance_frontend/pages/login_page.py
+++ b/transcendental_resonance_frontend/pages/login_page.py
@@ -9,7 +9,7 @@ except Exception:  # pragma: no cover - fallback to Streamlit
     ui = None  # type: ignore
     import streamlit as st
 
-from transcendental_resonance_frontend.src.utils.api import api_call, set_token
+from utils.api import api_call, set_token
 from utils.styles import get_theme
 
 

--- a/transcendental_resonance_frontend/pages/messages_page.py
+++ b/transcendental_resonance_frontend/pages/messages_page.py
@@ -10,7 +10,7 @@ except Exception:  # pragma: no cover - fallback to Streamlit
     ui = None  # type: ignore
     import streamlit as st
 
-from transcendental_resonance_frontend.src.utils.api import TOKEN, api_call, listen_ws
+from utils.api import TOKEN, api_call, listen_ws
 from utils.layout import page_container
 from utils.safe_markdown import safe_markdown
 from utils.styles import get_theme

--- a/transcendental_resonance_frontend/pages/moderation_dashboard_page.py
+++ b/transcendental_resonance_frontend/pages/moderation_dashboard_page.py
@@ -11,7 +11,7 @@ except Exception:  # pragma: no cover - fallback to Streamlit
     ui = None  # type: ignore
     import streamlit as st
 
-from transcendental_resonance_frontend.src.utils.api import TOKEN, api_call, listen_ws
+from utils.api import TOKEN, api_call, listen_ws
 from utils.layout import page_container
 from utils.styles import get_theme
 

--- a/transcendental_resonance_frontend/pages/moderation_page.py
+++ b/transcendental_resonance_frontend/pages/moderation_page.py
@@ -6,7 +6,7 @@ except Exception:  # pragma: no cover - fallback to Streamlit
     ui = None  # type: ignore
     import streamlit as st
 
-from transcendental_resonance_frontend.src.utils.api import TOKEN, api_call, listen_ws
+from utils.api import TOKEN, api_call, listen_ws
 from utils.layout import page_container
 from utils.styles import get_theme
 

--- a/transcendental_resonance_frontend/pages/music_page.py
+++ b/transcendental_resonance_frontend/pages/music_page.py
@@ -9,7 +9,7 @@ except Exception:  # pragma: no cover - fallback to Streamlit
     ui = None  # type: ignore
     import streamlit as st
 
-from transcendental_resonance_frontend.src.utils.api import api_call, TOKEN
+from utils.api import api_call, TOKEN
 from utils.styles import get_theme
 from utils.layout import page_container
 from .login_page import login_page

--- a/transcendental_resonance_frontend/pages/network_analysis_page.py
+++ b/transcendental_resonance_frontend/pages/network_analysis_page.py
@@ -10,7 +10,7 @@ try:
 except Exception:  # pragma: no cover - fallback to Streamlit
     ui = None  # type: ignore
     import streamlit as st
-from transcendental_resonance_frontend.src.utils.api import TOKEN, api_call
+from utils.api import TOKEN, api_call
 from utils.layout import page_container
 from utils.styles import get_theme
 

--- a/transcendental_resonance_frontend/pages/notifications_page.py
+++ b/transcendental_resonance_frontend/pages/notifications_page.py
@@ -8,7 +8,7 @@ try:
 except Exception:  # pragma: no cover - fallback to Streamlit
     ui = None  # type: ignore
     import streamlit as st
-from transcendental_resonance_frontend.src.utils.api import TOKEN, api_call, listen_ws
+from utils.api import TOKEN, api_call, listen_ws
 from utils.layout import page_container
 from utils.styles import get_theme
 

--- a/transcendental_resonance_frontend/pages/profile_page.py
+++ b/transcendental_resonance_frontend/pages/profile_page.py
@@ -9,7 +9,7 @@ try:
 except Exception:  # pragma: no cover - fallback to Streamlit
     ui = None  # type: ignore
     import streamlit as st
-from transcendental_resonance_frontend.src.utils.api import (
+from utils.api import (
     TOKEN,
     api_call,
     clear_token,

--- a/transcendental_resonance_frontend/pages/proposals_page.py
+++ b/transcendental_resonance_frontend/pages/proposals_page.py
@@ -9,7 +9,7 @@ except Exception:  # pragma: no cover - fallback to Streamlit
     ui = None  # type: ignore
     import streamlit as st
 
-from transcendental_resonance_frontend.src.utils.api import api_call, TOKEN
+from utils.api import api_call, TOKEN
 from utils.styles import get_theme
 from utils.layout import page_container
 from utils.features import skeleton_loader

--- a/transcendental_resonance_frontend/pages/recommendations_page.py
+++ b/transcendental_resonance_frontend/pages/recommendations_page.py
@@ -9,7 +9,7 @@ except Exception:  # pragma: no cover - fallback to Streamlit
     ui = None  # type: ignore
     import streamlit as st
 
-from transcendental_resonance_frontend.src.utils.api import api_call, TOKEN
+from utils.api import api_call, TOKEN
 from utils.styles import get_theme
 from utils.layout import page_container
 from utils.features import skeleton_loader

--- a/transcendental_resonance_frontend/pages/resonance_music.py
+++ b/transcendental_resonance_frontend/pages/resonance_music.py
@@ -24,7 +24,7 @@ from streamlit_helpers import (
 )
 from streamlit_autorefresh import st_autorefresh
 from status_indicator import render_status_icon, check_backend # Ensure check_backend is imported
-from transcendental_resonance_frontend.src.utils.api import get_resonance_summary, dispatch_route # Import get_resonance_summary and dispatch_route from utils.api
+from utils.api import get_resonance_summary, dispatch_route # Import get_resonance_summary and dispatch_route from utils.api
 
 
 set_theme("light")

--- a/transcendental_resonance_frontend/pages/status_page.py
+++ b/transcendental_resonance_frontend/pages/status_page.py
@@ -8,7 +8,7 @@ try:
 except Exception:  # pragma: no cover - fallback to Streamlit
     ui = None  # type: ignore
     import streamlit as st
-from transcendental_resonance_frontend.src.utils.api import TOKEN, api_call
+from utils.api import TOKEN, api_call
 from utils.layout import page_container
 from utils.styles import get_theme
 

--- a/transcendental_resonance_frontend/pages/system_insights_page.py
+++ b/transcendental_resonance_frontend/pages/system_insights_page.py
@@ -8,7 +8,7 @@ try:
 except Exception:  # pragma: no cover - fallback to Streamlit
     ui = None  # type: ignore
     import streamlit as st
-from transcendental_resonance_frontend.src.utils.api import TOKEN, api_call
+from utils.api import TOKEN, api_call
 from utils.layout import page_container
 from utils.styles import get_theme
 

--- a/transcendental_resonance_frontend/pages/upload_page.py
+++ b/transcendental_resonance_frontend/pages/upload_page.py
@@ -11,7 +11,7 @@ except Exception:  # pragma: no cover - fallback to Streamlit
 import asyncio
 import contextlib
 
-from transcendental_resonance_frontend.src.utils.api import api_call, TOKEN
+from utils.api import api_call, TOKEN
 from utils.styles import get_theme
 from utils.layout import page_container
 from .login_page import login_page

--- a/transcendental_resonance_frontend/pages/validator_graph_page.py
+++ b/transcendental_resonance_frontend/pages/validator_graph_page.py
@@ -10,7 +10,7 @@ try:
 except Exception:  # pragma: no cover - fallback to Streamlit
     ui = None  # type: ignore
     import streamlit as st
-from transcendental_resonance_frontend.src.utils.api import TOKEN, api_call
+from utils.api import TOKEN, api_call
 from utils.layout import page_container
 from utils.styles import get_theme
 

--- a/transcendental_resonance_frontend/pages/vibenodes_page.py
+++ b/transcendental_resonance_frontend/pages/vibenodes_page.py
@@ -20,7 +20,7 @@ import contextlib
 from components.emoji_toolbar import emoji_toolbar
 from components.media_renderer import render_media_block
 
-from transcendental_resonance_frontend.src.utils.api import TOKEN, api_call, listen_ws
+from utils.api import TOKEN, api_call, listen_ws
 from utils.features import skeleton_loader
 from utils.layout import page_container
 from utils.safe_markdown import safe_markdown

--- a/transcendental_resonance_frontend/pages/video_chat_page.py
+++ b/transcendental_resonance_frontend/pages/video_chat_page.py
@@ -13,7 +13,7 @@ except Exception:  # pragma: no cover - fallback to Streamlit
     ui = None  # type: ignore
     import streamlit as st
 
-from transcendental_resonance_frontend.src.utils.api import TOKEN, WS_CONNECTION, connect_ws
+from utils.api import TOKEN, WS_CONNECTION, connect_ws
 from utils.layout import page_container
 from utils.styles import get_theme
 

--- a/utils/api.py
+++ b/utils/api.py
@@ -1,0 +1,122 @@
+"""Re-export API helpers for convenience.
+
+This module simply exposes the functions and variables from
+``transcendental_resonance_frontend.src.utils.api`` under the ``utils.api``
+namespace so imports remain stable regardless of where the frontend lives.
+"""
+
+from transcendental_resonance_frontend.src.utils import api as _api
+
+
+def _sync_state() -> None:
+    """Propagate local variables to the underlying API module."""
+    _api.ui = ui
+    _api.TOKEN = TOKEN
+    _api.OFFLINE_MODE = OFFLINE_MODE
+    _api.BACKEND_URL = BACKEND_URL
+    _api.WS_CONNECTION = WS_CONNECTION
+
+ui = _api.ui
+TOKEN = _api.TOKEN
+OFFLINE_MODE = _api.OFFLINE_MODE
+BACKEND_URL = _api.BACKEND_URL
+WS_CONNECTION = _api.WS_CONNECTION
+
+
+async def api_call(*args, **kwargs):
+    _sync_state()
+    return await _api.api_call(*args, **kwargs)
+
+def set_token(token: str) -> None:
+    global TOKEN
+    TOKEN = token
+    _sync_state()
+
+def clear_token() -> None:
+    global TOKEN
+    TOKEN = None
+    _sync_state()
+
+async def get_user(username: str):
+    _sync_state()
+    return await _api.get_user(username)
+
+async def get_followers(username: str):
+    _sync_state()
+    return await _api.get_followers(username)
+
+async def get_following(username: str):
+    _sync_state()
+    return await _api.get_following(username)
+
+async def toggle_follow(username: str):
+    _sync_state()
+    return await _api.toggle_follow(username)
+
+async def get_user_recommendations():
+    _sync_state()
+    return await _api.get_user_recommendations()
+
+async def get_group_recommendations():
+    _sync_state()
+    return await _api.get_group_recommendations()
+
+async def connect_ws(*args, **kwargs):
+    _sync_state()
+    return await _api.connect_ws(*args, **kwargs)
+
+async def listen_ws(*args, **kwargs):
+    _sync_state()
+    return await _api.listen_ws(*args, **kwargs)
+
+async def combined_search(query: str):
+    _sync_state()
+    return await _api.combined_search(query)
+
+async def get_resonance_summary(name: str):
+    _sync_state()
+    return await _api.get_resonance_summary(name)
+
+dispatch_route = getattr(_api, "dispatch_route", None)
+
+async def get_flagged_items():
+    _sync_state()
+    return await (_api.get_flagged_items() if hasattr(_api, "get_flagged_items") else None)
+
+async def perform_moderation_action(flag_id: str, action: str):
+    _sync_state()
+    if hasattr(_api, "perform_moderation_action"):
+        return await _api.perform_moderation_action(flag_id, action)
+    return None
+on_request_start = _api.on_request_start
+on_request_end = _api.on_request_end
+on_ws_status_change = _api.on_ws_status_change
+
+
+
+__all__ = [
+    "ui",
+    "TOKEN",
+    "OFFLINE_MODE",
+    "BACKEND_URL",
+    "WS_CONNECTION",
+    "api_call",
+    "set_token",
+    "clear_token",
+    "get_user",
+    "get_followers",
+    "get_following",
+    "toggle_follow",
+    "get_user_recommendations",
+    "get_group_recommendations",
+    "connect_ws",
+    "listen_ws",
+    "combined_search",
+    "get_resonance_summary",
+    "dispatch_route",
+    "get_flagged_items",
+    "perform_moderation_action",
+    "on_request_start",
+    "on_request_end",
+    "on_ws_status_change",
+]


### PR DESCRIPTION
## Summary
- add `utils.api` which re-exports the NiceGUI API helpers
- point all page modules at the new shared helper module
- document the `PYTHONPATH` requirement in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d1df453f883208077355ae776373d