### PR TITLE
Initialize themes inside page functions

### DIFF
--- a/transcendental_resonance_frontend/pages/agents.py
+++ b/transcendental_resonance_frontend/pages/agents.py
@@ -3,16 +3,12 @@
 # Legal & Ethical Safeguards
 
 import streamlit as st
-from frontend.theme import set_theme
-from modern_ui import inject_modern_styles
+from frontend.theme import apply_theme, inject_modern_styles
 
 from agent_ui import render_agent_insights_tab
 from streamlit_helpers import theme_toggle
 
 __all__ = ["main", "render"]
-
-set_theme("light")
-inject_modern_styles()
 
 
 def main(main_container=None) -> None:
@@ -21,6 +17,9 @@ def main(main_container=None) -> None:
 
     If no main_container is provided, uses Streamlit root context.
     """
+    apply_theme("light")
+    inject_modern_styles()
+
     container = main_container if main_container is not None else st
     theme_toggle("Dark Mode", key_suffix="agents")
 

--- a/transcendental_resonance_frontend/pages/chat.py
+++ b/transcendental_resonance_frontend/pages/chat.py
@@ -4,18 +4,17 @@
 """Chat page with text, video, and voice features."""
 
 import streamlit as st
-from frontend.theme import set_theme
-from modern_ui import inject_modern_styles
+from frontend.theme import apply_theme, inject_modern_styles
 from streamlit_helpers import safe_container, header, theme_toggle
 from status_indicator import render_status_icon
 from chat_ui import render_chat_interface
 
-set_theme("light")
-inject_modern_styles()
-
 
 def main(main_container=None) -> None:
     """Render the chat page."""
+    apply_theme("light")
+    inject_modern_styles()
+
     if main_container is None:
         main_container = st
     page = "chat"

--- a/transcendental_resonance_frontend/pages/feed.py
+++ b/transcendental_resonance_frontend/pages/feed.py
@@ -11,8 +11,7 @@ from typing import List, Dict, Any
 import random
 import streamlit as st
 
-from frontend.theme import set_theme
-from modern_ui import inject_modern_styles
+from frontend.theme import apply_theme, inject_modern_styles
 from streamlit_helpers import theme_toggle, safe_container, sanitize_text
 
 from modern_ui_components import st_javascript
@@ -208,9 +207,6 @@ def _load_more_posts() -> None:
 # Page entrypoints
 # ──────────────────────────────────────────────────────────────────────────────
 
-set_theme("light")
-inject_modern_styles()
-
 
 def _page_body() -> None:
     """Render the main feed inside the current container."""
@@ -262,6 +258,9 @@ def _page_body() -> None:
 
 def main(main_container=None) -> None:
     """Render the feed inside ``main_container`` (or root Streamlit)."""
+    apply_theme("light")
+    inject_modern_styles()
+
     container = main_container or st
     with safe_container(container):
         _page_body()

--- a/transcendental_resonance_frontend/pages/messages.py
+++ b/transcendental_resonance_frontend/pages/messages.py
@@ -6,17 +6,18 @@
 from __future__ import annotations
 
 import streamlit as st
-from frontend.theme import set_theme
-from modern_ui import inject_modern_styles
+from frontend.theme import apply_theme, inject_modern_styles
 from streamlit_helpers import theme_toggle
 from transcendental_resonance_frontend.ui.chat_ui import render_chat_ui
 
-set_theme("light")
-inject_modern_styles()
+
 
 
 def main(main_container=None) -> None:
     """Render the chat interface inside the given container (or the page itself)."""
+    apply_theme("light")
+    inject_modern_styles()
+
     theme_toggle("Dark Mode", key_suffix="messages")
     render_chat_ui(main_container)
 

--- a/transcendental_resonance_frontend/pages/messages_center.py
+++ b/transcendental_resonance_frontend/pages/messages_center.py
@@ -9,15 +9,12 @@ from __future__ import annotations
 
 import asyncio
 import streamlit as st
-from frontend.theme import set_theme
-from modern_ui import inject_modern_styles
+from frontend.theme import apply_theme, inject_modern_styles
 from streamlit_helpers import safe_container, theme_toggle
 from status_indicator import render_status_icon
 from transcendental_resonance_frontend.src.utils import api
 
 # ─── Apply global styles ────────────────────────────────────────────────────────
-set_theme("light")
-inject_modern_styles()
 
 # ─── Dummy data ────────────────────────────────────────────────────────────────
 DUMMY_CONVERSATIONS: dict[str, list[dict[str, str]]] = {
@@ -57,6 +54,9 @@ def send_message(target: str, text: str) -> None:
 
 # ─── Page Entrypoint ───────────────────────────────────────────────────────────
 def main(container: st.DeltaGenerator | None = None) -> None:
+    apply_theme("light")
+    inject_modern_styles()
+
     if container is None:
         container = st
 

--- a/transcendental_resonance_frontend/pages/profile.py
+++ b/transcendental_resonance_frontend/pages/profile.py
@@ -4,8 +4,7 @@
 """User identity hub with profile and activity overview."""
 
 import streamlit as st
-from frontend.theme import set_theme
-from modern_ui import inject_modern_styles
+from frontend.theme import apply_theme, inject_modern_styles
 from streamlit_helpers import (
     safe_container,
     header,
@@ -80,8 +79,7 @@ def _fetch_social(username: str) -> tuple[dict, dict]:
         )
     return followers or {}, following or {}
 
-set_theme("light")
-inject_modern_styles()
+
 ensure_active_user()
 
 
@@ -114,6 +112,9 @@ def _render_profile(username: str) -> None:
 
 
 def main(main_container=None) -> None:
+    apply_theme("light")
+    inject_modern_styles()
+
     if main_container is None:
         main_container = st
     init_db()

--- a/transcendental_resonance_frontend/pages/resonance_music.py
+++ b/transcendental_resonance_frontend/pages/resonance_music.py
@@ -13,8 +13,7 @@ from pathlib import Path
 
 import requests
 import streamlit as st
-from frontend.theme import set_theme
-from modern_ui import inject_modern_styles
+from frontend.theme import apply_theme, inject_modern_styles
 from streamlit_helpers import (
     alert,
     centered_container,
@@ -25,10 +24,6 @@ from streamlit_helpers import (
 from streamlit_autorefresh import st_autorefresh
 from status_indicator import render_status_icon, check_backend # Ensure check_backend is imported
 from transcendental_resonance_frontend.src.utils.api import get_resonance_summary, dispatch_route # Import get_resonance_summary and dispatch_route from utils.api
-
-
-set_theme("light")
-inject_modern_styles()
 
 # BACKEND_URL is defined in utils.api, but we keep it here for direct requests calls if needed
 BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:8000")
@@ -73,6 +68,9 @@ def _run_async(coro):
 
 def main(main_container=None, status_container=None) -> None:
     """Render music generation and summary widgets."""
+
+    apply_theme("light")
+    inject_modern_styles()
 
     if main_container is None:
         main_container = st

--- a/transcendental_resonance_frontend/pages/social.py
+++ b/transcendental_resonance_frontend/pages/social.py
@@ -4,19 +4,20 @@
 """Friends & Followers page."""
 
 import streamlit as st
-from frontend.theme import set_theme
-from modern_ui import inject_modern_styles
+from frontend.theme import apply_theme, inject_modern_styles
 
 from social_tabs import render_social_tab
 from streamlit_helpers import safe_container, render_mock_feed, theme_toggle
 from feed_renderer import render_feed
 
-set_theme("light")
-inject_modern_styles()
+
 
 
 def main(main_container=None) -> None:
     """Render the social page content within ``main_container``."""
+    apply_theme("light")
+    inject_modern_styles()
+
     if main_container is None:
         main_container = st
     theme_toggle("Dark Mode", key_suffix="social")

--- a/transcendental_resonance_frontend/pages/validation.py
+++ b/transcendental_resonance_frontend/pages/validation.py
@@ -5,8 +5,7 @@
 
 import importlib
 import streamlit as st
-from frontend.theme import set_theme
-from modern_ui import inject_modern_styles
+from frontend.theme import apply_theme, inject_modern_styles
 
 from streamlit_helpers import safe_container, theme_toggle
 
@@ -27,8 +26,6 @@ def _load_render_ui():
 render_validation_ui = _load_render_ui()
 
 # Inject modern global styles (safe when running in classic Streamlit)
-set_theme("light")
-inject_modern_styles()
 
 # --------------------------------------------------------------------
 # Page decorator (works even if Streamlit’s multipage API absent)
@@ -44,6 +41,9 @@ def _page_decorator(func):
 @_page_decorator
 def main(main_container=None) -> None:
     """Render the validation UI inside a safe container."""
+    apply_theme("light")
+    inject_modern_styles()
+
     if main_container is None:
         main_container = st
     theme_toggle("Dark Mode", key_suffix="validation")

--- a/transcendental_resonance_frontend/pages/video_chat.py
+++ b/transcendental_resonance_frontend/pages/video_chat.py
@@ -6,16 +6,12 @@ import asyncio
 import json
 
 import streamlit as st
-from frontend.theme import set_theme
-from modern_ui import inject_modern_styles
+from frontend.theme import apply_theme, inject_modern_styles
 
 
 from ai_video_chat import create_session
 from video_chat_router import ConnectionManager
 from streamlit_helpers import safe_container, header, theme_toggle
-
-set_theme("light")
-inject_modern_styles()
 
 
 def _run_async(coro):
@@ -35,6 +31,9 @@ manager = ConnectionManager()
 
 def main(main_container=None) -> None:
     """Render the simple video chat demo."""
+    apply_theme("light")
+    inject_modern_styles()
+
     container = main_container if main_container is not None else st
     theme_toggle("Dark Mode", key_suffix="video_chat")
 

--- a/transcendental_resonance_frontend/pages/voting.py
+++ b/transcendental_resonance_frontend/pages/voting.py
@@ -4,18 +4,17 @@
 """Governance and voting page."""
 
 import streamlit as st
-from frontend.theme import set_theme
-from modern_ui import inject_modern_styles
+from frontend.theme import apply_theme, inject_modern_styles
 
 from voting_ui import render_voting_tab
 from streamlit_helpers import safe_container, theme_toggle
 
-set_theme("light")
-inject_modern_styles()
-
 
 def main(main_container=None) -> None:
     """Render the Governance and Voting page inside ``main_container``."""
+    apply_theme("light")
+    inject_modern_styles()
+
     if main_container is None:
         main_container = st
     theme_toggle("Dark Mode", key_suffix="voting")


### PR DESCRIPTION
## Summary
- call `apply_theme("light")` and `inject_modern_styles()` in each page's `main()`
- drop top level theme setup and update imports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d1df2b02c83208c35b1ee8182e6a5