### PR TITLE
Deduplicate theme helpers

### DIFF
--- a/chat_ui.py
+++ b/chat_ui.py
@@ -9,7 +9,7 @@ import threading
 from typing import Optional
 import streamlit as st
 from streamlit.runtime.scriptrunner import add_script_run_ctx
-from modern_ui import inject_modern_styles
+from modern_ui import apply_modern_styles
 from realtime_comm import ChatWebSocketManager
 
 try:
@@ -17,7 +17,7 @@ try:
 except Exception:  # pragma: no cover - optional dependency
     websockets = None
 
-inject_modern_styles()
+apply_modern_styles()
 
 
 def _run_async(coro):

--- a/docs/codex_theme.md
+++ b/docs/codex_theme.md
@@ -8,10 +8,10 @@ It is available through `streamlit_helpers.theme_selector()` and sets the
 
 ```python
 from streamlit_helpers import theme_selector
-from modern_ui import inject_modern_styles
+from modern_ui import apply_modern_styles
 
 # Apply premium styles and add a radio selector to switch themes
-inject_modern_styles()
+apply_modern_styles()
 theme_selector("Theme")
 ```
 
@@ -29,7 +29,7 @@ font = "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
 
 ### CSS Classes
 
-The `inject_modern_styles()` helper exposes a few utility classes:
+The `apply_modern_styles()` helper exposes a few utility classes:
 
 | Class | Purpose |
 |-------|---------|

--- a/docs/streamlit_ui_extension_example.md
+++ b/docs/streamlit_ui_extension_example.md
@@ -8,9 +8,9 @@ HTML injection.
 ```python
 import streamlit as st
 from streamlit_helpers import header, theme_selector, centered_container
-from modern_ui import inject_modern_styles
+from modern_ui import apply_modern_styles
 
-inject_modern_styles()
+apply_modern_styles()
 header("Custom Page", layout="wide")
 with centered_container():
     theme_selector("Theme")

--- a/frontend/theme.py
+++ b/frontend/theme.py
@@ -15,6 +15,7 @@ class ColorTheme:
     bg: str
     card: str
     accent: str
+    text: str
     text_muted: str
     radius: str = "1rem"
     transition: str = "0.4s ease"
@@ -25,6 +26,7 @@ class ColorTheme:
             f"--bg: {self.bg};",
             f"--card: {self.card};",
             f"--accent: {self.accent};",
+            f"--text: {self.text};",
             f"--text-muted: {self.text_muted};",
             f"--radius: {self.radius};",
             f"--transition: {self.transition};",
@@ -36,12 +38,14 @@ LIGHT_THEME = ColorTheme(
     bg="#F0F2F6",
     card="#FFFFFF",
     accent="#0077B5",        # LinkedIn-blue accent
+    text="#222222",
     text_muted="#666666",
 )
 DARK_THEME = ColorTheme(
     bg="#0A0F14",
     card="rgba(255,255,255,0.05)",
     accent="#00E5FF",        # Neon cyan
+    text="#FFFFFF",
     text_muted="#AAAAAA",
 )
 
@@ -75,6 +79,7 @@ def get_global_css(theme: bool | str = True) -> str:
 
 body {{
     background: var(--bg) !important;
+    color: var(--text);
     font-family: 'Inter', sans-serif;
     transition: background var(--transition);
 }}
@@ -127,6 +132,8 @@ def inject_modern_styles(theme: bool | str = True) -> None:
     apply_theme(mode)
 
     extra = """
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <style>
     /* Glassmorphic cards */
     .glass-card {

--- a/modern_ui.py
+++ b/modern_ui.py
@@ -29,7 +29,7 @@ def render_lottie_animation(url: str, *, height: int = 200, fallback: str = "ðŸš
 logger = logging.getLogger("modern_ui")
 
 
-def inject_modern_styles() -> None:
+def apply_modern_styles() -> None:
     """Inject global CSS using theme variables and local assets."""
     from modern_ui_components import SIDEBAR_STYLES
 
@@ -40,14 +40,12 @@ def inject_modern_styles() -> None:
         return
 
     css = """
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <script type="module" src="/static/lucide-react.min.js"></script>
     <style>
     body, .stApp {
         background: var(--bg);
-        color: var(--text-muted);
+        color: var(--text);
         font-family: 'Inter', sans-serif;
     }
     .card, .custom-container {
@@ -84,8 +82,8 @@ def inject_modern_styles() -> None:
     st.session_state["_modern_ui_css_injected"] = True
 
 def inject_premium_styles() -> None:
-    """Backward compatible alias for :func:`inject_modern_styles`."""
-    inject_modern_styles()
+    """Backward compatible alias for :func:`apply_modern_styles`."""
+    apply_modern_styles()
 
 
 def render_modern_header() -> None:
@@ -262,7 +260,7 @@ def close_card_container() -> None:
 
 __all__ = [
     "render_lottie_animation",
-    "inject_modern_styles",
+    "apply_modern_styles",
     "inject_premium_styles",
     "render_modern_header",
     "render_validation_card",

--- a/modern_ui_components.py
+++ b/modern_ui_components.py
@@ -25,7 +25,7 @@ except Exception:  # pragma: no cover – fallback for isolated execution
 
 from uuid import uuid4
 from streamlit_helpers import safe_container
-from frontend.theme import inject_modern_styles
+from modern_ui import apply_modern_styles
 
 from frontend import theme
 try:
@@ -153,10 +153,9 @@ def _icon_html(name: str) -> str:
 
 def render_modern_layout() -> None:
     """Apply global styles and base glassmorphism containers."""
-    inject_modern_styles()
+    apply_modern_styles()
     st.markdown(
         """
-        <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
         <style>
         .glass-card {
             background: rgba(255,255,255,0.3);

--- a/streamlit_helpers.py
+++ b/streamlit_helpers.py
@@ -113,13 +113,7 @@ def safe_element(tag: str, content: str) -> Any:
 # Optional modern-ui styles injector
 # ──────────────────────────────────────────────────────────────────────────────
 
-try:
-    from modern_ui import inject_modern_styles  # type: ignore
-except Exception:  # noqa: BLE001
-
-    def inject_modern_styles(*_a: Any, **_kw: Any) -> None:  # type: ignore
-        """No-op when *modern_ui* is absent."""
-        return None
+from frontend.theme import inject_modern_styles
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -279,7 +273,7 @@ def render_post_card(post_data: dict[str, Any]) -> None:
             st.write(caption_text)
             getattr(st, "caption", st.write)(f"❤️ {likes}")
             getattr(st, "markdown", lambda *a, **k: None)(
-                "<div style='color:var(--text-color);font-size:1.2em;'>❤️ 🔁 💬</div>",
+                "<div style='color:var(--text);font-size:1.2em;'>❤️ 🔁 💬</div>",
                 unsafe_allow_html=True,
             )
         else:
@@ -291,7 +285,7 @@ def render_post_card(post_data: dict[str, Any]) -> None:
             if username:
                 html_snippet += f"<div><strong>{html.escape(username)}</strong></div>"
             html_snippet += f"<p>{html.escape(text)}</p>"
-            html_snippet += f"<div style='color:var(--text-color);font-size:1.2em;'>❤️ {likes} 🔁 💬</div>"
+            html_snippet += f"<div style='color:var(--text);font-size:1.2em;'>❤️ {likes} 🔁 💬</div>"
             html_snippet += "</div>"
             getattr(st, "markdown", lambda *a, **k: None)(html_snippet, unsafe_allow_html=True)
         return
@@ -314,7 +308,7 @@ def render_post_card(post_data: dict[str, Any]) -> None:
                 ui.element("div", reaction).classes("text-center text-lg")
             else:
                 getattr(st, "markdown", lambda *a, **k: None)(
-                    f"<div style='color:var(--text-color);font-size:1.2em;'>{reaction}</div>",
+                    f"<div style='color:var(--text);font-size:1.2em;'>{reaction}</div>",
                     unsafe_allow_html=True,
                 )
     except Exception as exc:  # noqa: BLE001
@@ -339,7 +333,7 @@ def render_post_card(post_data: dict[str, Any]) -> None:
         write_fn(text)
         getattr(st, "caption", write_fn)(f"❤️ {likes}")
         getattr(st, "markdown", lambda *a, **k: None)(
-            "<div style='color:var(--text-color);font-size:1.2em;'>❤️ 🔁 💬</div>",
+            "<div style='color:var(--text);font-size:1.2em;'>❤️ 🔁 💬</div>",
             unsafe_allow_html=True,
         )
 

--- a/transcendental_resonance_frontend/pages/agents.py
+++ b/transcendental_resonance_frontend/pages/agents.py
@@ -4,7 +4,7 @@
 
 import streamlit as st
 from frontend.theme import set_theme
-from modern_ui import inject_modern_styles
+from modern_ui import apply_modern_styles
 
 from agent_ui import render_agent_insights_tab
 from streamlit_helpers import theme_toggle
@@ -12,7 +12,7 @@ from streamlit_helpers import theme_toggle
 __all__ = ["main", "render"]
 
 set_theme("light")
-inject_modern_styles()
+apply_modern_styles()
 
 
 def main(main_container=None) -> None:

--- a/transcendental_resonance_frontend/pages/chat.py
+++ b/transcendental_resonance_frontend/pages/chat.py
@@ -5,13 +5,13 @@
 
 import streamlit as st
 from frontend.theme import set_theme
-from modern_ui import inject_modern_styles
+from modern_ui import apply_modern_styles
 from streamlit_helpers import safe_container, header, theme_toggle
 from status_indicator import render_status_icon
 from chat_ui import render_chat_interface
 
 set_theme("light")
-inject_modern_styles()
+apply_modern_styles()
 
 
 def main(main_container=None) -> None:

--- a/transcendental_resonance_frontend/pages/feed.py
+++ b/transcendental_resonance_frontend/pages/feed.py
@@ -12,7 +12,7 @@ import random
 import streamlit as st
 
 from frontend.theme import set_theme
-from modern_ui import inject_modern_styles
+from modern_ui import apply_modern_styles
 from streamlit_helpers import theme_toggle, safe_container, sanitize_text
 
 from modern_ui_components import st_javascript
@@ -209,7 +209,7 @@ def _load_more_posts() -> None:
 # ──────────────────────────────────────────────────────────────────────────────
 
 set_theme("light")
-inject_modern_styles()
+apply_modern_styles()
 
 
 def _page_body() -> None:

--- a/transcendental_resonance_frontend/pages/messages.py
+++ b/transcendental_resonance_frontend/pages/messages.py
@@ -7,12 +7,12 @@ from __future__ import annotations
 
 import streamlit as st
 from frontend.theme import set_theme
-from modern_ui import inject_modern_styles
+from modern_ui import apply_modern_styles
 from streamlit_helpers import theme_toggle
 from transcendental_resonance_frontend.ui.chat_ui import render_chat_ui
 
 set_theme("light")
-inject_modern_styles()
+apply_modern_styles()
 
 
 def main(main_container=None) -> None:

--- a/transcendental_resonance_frontend/pages/messages_center.py
+++ b/transcendental_resonance_frontend/pages/messages_center.py
@@ -10,14 +10,14 @@ from __future__ import annotations
 import asyncio
 import streamlit as st
 from frontend.theme import set_theme
-from modern_ui import inject_modern_styles
+from modern_ui import apply_modern_styles
 from streamlit_helpers import safe_container, theme_toggle
 from status_indicator import render_status_icon
 from transcendental_resonance_frontend.src.utils import api
 
 # ─── Apply global styles ────────────────────────────────────────────────────────
 set_theme("light")
-inject_modern_styles()
+apply_modern_styles()
 
 # ─── Dummy data ────────────────────────────────────────────────────────────────
 DUMMY_CONVERSATIONS: dict[str, list[dict[str, str]]] = {

--- a/transcendental_resonance_frontend/pages/profile.py
+++ b/transcendental_resonance_frontend/pages/profile.py
@@ -5,7 +5,7 @@
 
 import streamlit as st
 from frontend.theme import set_theme
-from modern_ui import inject_modern_styles
+from modern_ui import apply_modern_styles
 from streamlit_helpers import (
     safe_container,
     header,
@@ -81,7 +81,7 @@ def _fetch_social(username: str) -> tuple[dict, dict]:
     return followers or {}, following or {}
 
 set_theme("light")
-inject_modern_styles()
+apply_modern_styles()
 ensure_active_user()
 
 

--- a/transcendental_resonance_frontend/pages/resonance_music.py
+++ b/transcendental_resonance_frontend/pages/resonance_music.py
@@ -14,7 +14,7 @@ from pathlib import Path
 import requests
 import streamlit as st
 from frontend.theme import set_theme
-from modern_ui import inject_modern_styles
+from modern_ui import apply_modern_styles
 from streamlit_helpers import (
     alert,
     centered_container,
@@ -28,7 +28,7 @@ from transcendental_resonance_frontend.src.utils.api import get_resonance_summar
 
 
 set_theme("light")
-inject_modern_styles()
+apply_modern_styles()
 
 # BACKEND_URL is defined in utils.api, but we keep it here for direct requests calls if needed
 BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:8000")

--- a/transcendental_resonance_frontend/pages/social.py
+++ b/transcendental_resonance_frontend/pages/social.py
@@ -5,14 +5,14 @@
 
 import streamlit as st
 from frontend.theme import set_theme
-from modern_ui import inject_modern_styles
+from modern_ui import apply_modern_styles
 
 from social_tabs import render_social_tab
 from streamlit_helpers import safe_container, render_mock_feed, theme_toggle
 from feed_renderer import render_feed
 
 set_theme("light")
-inject_modern_styles()
+apply_modern_styles()
 
 
 def main(main_container=None) -> None:

--- a/transcendental_resonance_frontend/pages/validation.py
+++ b/transcendental_resonance_frontend/pages/validation.py
@@ -6,7 +6,7 @@
 import importlib
 import streamlit as st
 from frontend.theme import set_theme
-from modern_ui import inject_modern_styles
+from modern_ui import apply_modern_styles
 
 from streamlit_helpers import safe_container, theme_toggle
 
@@ -28,7 +28,7 @@ render_validation_ui = _load_render_ui()
 
 # Inject modern global styles (safe when running in classic Streamlit)
 set_theme("light")
-inject_modern_styles()
+apply_modern_styles()
 
 # --------------------------------------------------------------------
 # Page decorator (works even if Streamlit’s multipage API absent)

--- a/transcendental_resonance_frontend/pages/video_chat.py
+++ b/transcendental_resonance_frontend/pages/video_chat.py
@@ -7,7 +7,7 @@ import json
 
 import streamlit as st
 from frontend.theme import set_theme
-from modern_ui import inject_modern_styles
+from modern_ui import apply_modern_styles
 
 
 from ai_video_chat import create_session
@@ -15,7 +15,7 @@ from video_chat_router import ConnectionManager
 from streamlit_helpers import safe_container, header, theme_toggle
 
 set_theme("light")
-inject_modern_styles()
+apply_modern_styles()
 
 
 def _run_async(coro):

--- a/transcendental_resonance_frontend/pages/voting.py
+++ b/transcendental_resonance_frontend/pages/voting.py
@@ -5,13 +5,13 @@
 
 import streamlit as st
 from frontend.theme import set_theme
-from modern_ui import inject_modern_styles
+from modern_ui import apply_modern_styles
 
 from voting_ui import render_voting_tab
 from streamlit_helpers import safe_container, theme_toggle
 
 set_theme("light")
-inject_modern_styles()
+apply_modern_styles()
 
 
 def main(main_container=None) -> None:

--- a/transcendental_resonance_frontend/ui/chat_ui.py
+++ b/transcendental_resonance_frontend/ui/chat_ui.py
@@ -2,10 +2,10 @@
 from __future__ import annotations
 
 import streamlit as st
-from modern_ui import inject_modern_styles
+from modern_ui import apply_modern_styles
 from streamlit_helpers import safe_container, header
 
-inject_modern_styles()
+apply_modern_styles()
 
 DUMMY_CONVOS = [
     {"user": "Alice", "preview": "Hey there!"},

--- a/ui.py
+++ b/ui.py
@@ -325,14 +325,7 @@ from streamlit_helpers import (
 )
 
 from frontend.theme import set_theme
-from frontend.theme import apply_theme
-
-
-try:
-    from modern_ui import inject_modern_styles
-except Exception:  # pragma: no cover - gracefully handle missing/invalid module
-    def inject_modern_styles(*_a, **_k):
-        return None
+from frontend.theme import apply_theme, inject_modern_styles
 
 
 
@@ -497,13 +490,6 @@ def render_landing_page():
             if st.button("Run Validation", key="landing_run_validation"):
                 run_analysis([], layout="force")
         st.markdown("</div></div>", unsafe_allow_html=True)
-
-
-def inject_modern_styles() -> None:
-    """Backward compatible alias for modern theme injection."""
-    from frontend.theme import inject_modern_styles as _impl
-
-    _impl()
 
 
 # Backward compatibility alias


### PR DESCRIPTION
## Summary
- centralize theme utilities in `frontend.theme`
- add new `--text` CSS variable and modern font injection
- rename premium helper to `apply_modern_styles`
- update docs and pages to use the new helper
- fix post card styling for new variable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d1df19fc08320a8072af0e7da6ccf