### PR TITLE
Refactor page theming

### DIFF
--- a/transcendental_resonance_frontend/pages/agents.py
+++ b/transcendental_resonance_frontend/pages/agents.py
@@ -3,16 +3,13 @@
 # Legal & Ethical Safeguards
 
 import streamlit as st
-from frontend.theme import set_theme
+from frontend.theme import apply_theme
 from modern_ui import inject_modern_styles
 
 from agent_ui import render_agent_insights_tab
 from streamlit_helpers import theme_toggle
 
 __all__ = ["main", "render"]
-
-set_theme("light")
-inject_modern_styles()
 
 
 def main(main_container=None) -> None:
@@ -22,6 +19,8 @@ def main(main_container=None) -> None:
     If no main_container is provided, uses Streamlit root context.
     """
     container = main_container if main_container is not None else st
+    apply_theme("light")
+    inject_modern_styles()
     theme_toggle("Dark Mode", key_suffix="agents")
 
     try:
@@ -32,14 +31,15 @@ def main(main_container=None) -> None:
 
         if container.button("Test Agent", key="test_agent"):
             container.success(f"✅ {selected_agent} agent test complete")
-            container.json({
-                "agent": selected_agent,
-                "status": "ok",
-                "test": True,
-            })
+            container.json(
+                {
+                    "agent": selected_agent,
+                    "status": "ok",
+                    "test": True,
+                }
+            )
     except Exception as e:
         container.error(f"❌ Failed to render Agents UI: {e}")
-
 
     try:
         render_agent_insights_tab(main_container=main_container)

--- a/transcendental_resonance_frontend/pages/chat.py
+++ b/transcendental_resonance_frontend/pages/chat.py
@@ -4,14 +4,11 @@
 """Chat page with text, video, and voice features."""
 
 import streamlit as st
-from frontend.theme import set_theme
+from frontend.theme import apply_theme
 from modern_ui import inject_modern_styles
 from streamlit_helpers import safe_container, header, theme_toggle
 from status_indicator import render_status_icon
 from chat_ui import render_chat_interface
-
-set_theme("light")
-inject_modern_styles()
 
 
 def main(main_container=None) -> None:
@@ -20,6 +17,8 @@ def main(main_container=None) -> None:
         main_container = st
     page = "chat"
     st.session_state["active_page"] = page
+    apply_theme("light")
+    inject_modern_styles()
     theme_toggle("Dark Mode", key_suffix=page)
 
     container_ctx = safe_container(main_container)

--- a/transcendental_resonance_frontend/pages/feed.py
+++ b/transcendental_resonance_frontend/pages/feed.py
@@ -6,17 +6,17 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
-from typing import List, Dict, Any
+from typing import List, Dict
 
 import random
 import streamlit as st
 
-from frontend.theme import set_theme
+from frontend.theme import apply_theme
 from modern_ui import inject_modern_styles
 from streamlit_helpers import theme_toggle, safe_container, sanitize_text
 
 from modern_ui_components import st_javascript
-from frontend.assets import story_css, story_js, reaction_css, scroll_js
+from frontend.assets import story_css, story_js, reaction_css
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Sample data models
@@ -40,7 +40,7 @@ class Post:
     timestamp: datetime
     reactions: Dict[str, int] = field(
         default_factory=lambda: {"❤️": 0, "🔥": 0, "👍": 0}
-    )
+    )  # noqa: E501
     comments: List[Dict[str, str]] = field(default_factory=list)
 
 
@@ -90,7 +90,8 @@ def _render_stories(users: List[User]) -> None:
         avatar = sanitize_text(u.avatar)
         username = sanitize_text(u.username)
         html += (
-            f"<div class='story-item'><img src='{avatar}' width='60' alt='avatar'/><br>{username}</div>"
+            f"<div class='story-item'><img src='{avatar}' width='60' alt='avatar'/>"
+            f"<br>{username}</div>"
         )
     html += "</div>"
     st.markdown(html, unsafe_allow_html=True)
@@ -112,11 +113,14 @@ def _render_post(post: Post) -> None:
         avatar = sanitize_text(post.user.avatar)
         username = sanitize_text(post.user.username)
         st.markdown(
-            f"<div class='post-header'><img src='{avatar}' alt='avatar'/>"
-            f"<strong>{username}</strong> "
-            f"<span>{' '.join(post.user.badges)}</span>"
-            f"<span style='margin-left:auto;font-size:0.75rem;'>{post.timestamp:%H:%M}</span>"
-            "</div>",
+            (
+                f"<div class='post-header'><img src='{avatar}' alt='avatar'/>"
+                f"<strong>{username}</strong> "
+                f"<span>{' '.join(post.user.badges)}</span>"
+                f"<span style='margin-left:auto;font-size:0.75rem;'>"
+                f"{post.timestamp:%H:%M}</span>"
+                "</div>"
+            ),
             unsafe_allow_html=True,
         )
         # Media with alt text
@@ -128,7 +132,9 @@ def _render_post(post: Post) -> None:
             alt=caption,
         )
         # Caption
-        st.markdown(f"<div class='post-caption'>{caption}</div>", unsafe_allow_html=True)
+        st.markdown(
+            f"<div class='post-caption'>{caption}</div>", unsafe_allow_html=True
+        )
 
         # Reactions & comments
         cols = st.columns(len(reactions) + 1)
@@ -142,10 +148,27 @@ def _render_post(post: Post) -> None:
             cols[idx].markdown(
                 f"""
                 <script>
-                const btns = document.querySelectorAll('button[data-testid="widget-button"]');
-                const btn = btns[btns.length-1];
-                if(btn){{btn.id='{btn_key}';btn.classList.add('reaction-btn','fa-solid','{icon_map.get(emoji, 'fa-heart')}');
-                if(!btn.querySelector('i'))btn.insertAdjacentHTML('afterbegin','<i class="fa-solid {icon_map.get(emoji, 'fa-heart')}"></i> ');}}
+                const btns = document.querySelectorAll(
+                    'button[data-testid="widget-button"]'
+                );
+                const btn = btns[btns.length - 1];
+                if (btn) {{
+                    btn.id = '{btn_key}';
+                    btn.classList.add(
+                        'reaction-btn',
+                        'fa-solid',
+                        '{icon_map.get(emoji, 'fa-heart')}'
+                    );
+                    if (!btn.querySelector('i')) {{
+                        btn.insertAdjacentHTML(
+                            'afterbegin',
+                            (
+                                '<i class="fa-solid '
+                                f"{icon_map.get(emoji, 'fa-heart')}"></i> "
+                            )
+                        );
+                    }}
+                }}
                 </script>
                 """,
                 unsafe_allow_html=True,
@@ -156,8 +179,8 @@ def _render_post(post: Post) -> None:
             with st.popover("💬"):
                 st.markdown("### comments")
                 for c in comments:
-                    user = sanitize_text(c['user'])
-                    text = sanitize_text(c['text'])
+                    user = sanitize_text(c["user"])
+                    text = sanitize_text(c["text"])
                     st.write(f"**{user}**: {text}")
                 new = st.text_input("Add a comment", key=f"c_{post.id}")
                 if st.button("post", key=f"cbtn_{post.id}") and new:
@@ -208,9 +231,6 @@ def _load_more_posts() -> None:
 # Page entrypoints
 # ──────────────────────────────────────────────────────────────────────────────
 
-set_theme("light")
-inject_modern_styles()
-
 
 def _page_body() -> None:
     """Render the main feed inside the current container."""
@@ -259,10 +279,11 @@ def _page_body() -> None:
         st.rerun()
 
 
-
 def main(main_container=None) -> None:
     """Render the feed inside ``main_container`` (or root Streamlit)."""
     container = main_container or st
+    apply_theme("light")
+    inject_modern_styles()
     with safe_container(container):
         _page_body()
 
@@ -274,4 +295,3 @@ def render() -> None:
 
 if __name__ == "__main__":
     render()
-

--- a/transcendental_resonance_frontend/pages/messages.py
+++ b/transcendental_resonance_frontend/pages/messages.py
@@ -5,18 +5,16 @@
 
 from __future__ import annotations
 
-import streamlit as st
-from frontend.theme import set_theme
+from frontend.theme import apply_theme
 from modern_ui import inject_modern_styles
 from streamlit_helpers import theme_toggle
 from transcendental_resonance_frontend.ui.chat_ui import render_chat_ui
 
-set_theme("light")
-inject_modern_styles()
-
 
 def main(main_container=None) -> None:
     """Render the chat interface inside the given container (or the page itself)."""
+    apply_theme("light")
+    inject_modern_styles()
     theme_toggle("Dark Mode", key_suffix="messages")
     render_chat_ui(main_container)
 

--- a/transcendental_resonance_frontend/pages/messages_center.py
+++ b/transcendental_resonance_frontend/pages/messages_center.py
@@ -9,15 +9,13 @@ from __future__ import annotations
 
 import asyncio
 import streamlit as st
-from frontend.theme import set_theme
+from frontend.theme import apply_theme
 from modern_ui import inject_modern_styles
 from streamlit_helpers import safe_container, theme_toggle
 from status_indicator import render_status_icon
 from transcendental_resonance_frontend.src.utils import api
 
 # ─── Apply global styles ────────────────────────────────────────────────────────
-set_theme("light")
-inject_modern_styles()
 
 # ─── Dummy data ────────────────────────────────────────────────────────────────
 DUMMY_CONVERSATIONS: dict[str, list[dict[str, str]]] = {
@@ -43,9 +41,7 @@ async def _post_message(target: str, text: str) -> None:
 def send_message(target: str, text: str) -> None:
     """Append locally or POST remotely, then flip a little toggle to refresh."""
     if api.OFFLINE_MODE:
-        st.session_state["conversations"][target].append(
-            {"user": "You", "text": text}
-        )
+        st.session_state["conversations"][target].append({"user": "You", "text": text})
     else:
         try:
             asyncio.run(_post_message(target, text))
@@ -59,6 +55,8 @@ def send_message(target: str, text: str) -> None:
 def main(container: st.DeltaGenerator | None = None) -> None:
     if container is None:
         container = st
+    apply_theme("light")
+    inject_modern_styles()
 
     st.session_state.setdefault("conversations", DUMMY_CONVERSATIONS.copy())
     theme_toggle("Dark Mode", key_suffix="msg_center")
@@ -82,8 +80,10 @@ def main(container: st.DeltaGenerator | None = None) -> None:
             st.subheader(f"Chat with {selected.capitalize()}")
             # Render past messages
             for msg in thread:
-                role = "assistant" if msg["user"] != "You" else "user"
-                avatar = msg.get("avatar", f"https://robohash.org/{msg['user']}.png?size=40x40")
+                "assistant" if msg["user"] != "You" else "user"
+                avatar = msg.get(
+                    "avatar", f"https://robohash.org/{msg['user']}.png?size=40x40"
+                )
                 with st.chat_message(msg["user"], avatar=avatar):
                     if img := msg.get("image"):
                         st.image(
@@ -101,7 +101,9 @@ def main(container: st.DeltaGenerator | None = None) -> None:
 
         # ── Refresh Button (in case offline) ───────────────────────────
         if st.button("🔄 Refresh"):
-            st.session_state["_refresh_chat"] = not st.session_state.get("_refresh_chat", False)
+            st.session_state["_refresh_chat"] = not st.session_state.get(
+                "_refresh_chat", False
+            )
 
 
 def render() -> None:

--- a/transcendental_resonance_frontend/pages/profile.py
+++ b/transcendental_resonance_frontend/pages/profile.py
@@ -4,7 +4,7 @@
 """User identity hub with profile and activity overview."""
 
 import streamlit as st
-from frontend.theme import set_theme
+from frontend.theme import apply_theme
 from modern_ui import inject_modern_styles
 from streamlit_helpers import (
     safe_container,
@@ -14,13 +14,11 @@ from streamlit_helpers import (
     ensure_active_user,
 )
 from api_key_input import render_api_key_ui
-from social_tabs import _load_profile
 from transcendental_resonance_frontend.ui.profile_card import (
     DEFAULT_USER,
     render_profile_card,
 )
 from status_indicator import render_status_icon
-from feed_renderer import render_mock_feed, DEMO_POSTS
 
 
 try:
@@ -52,6 +50,7 @@ except Exception:  # pragma: no cover - optional dependency
     def seed_default_users() -> None:  # type: ignore
         pass
 
+
 import asyncio
 
 
@@ -80,8 +79,7 @@ def _fetch_social(username: str) -> tuple[dict, dict]:
         )
     return followers or {}, following or {}
 
-set_theme("light")
-inject_modern_styles()
+
 ensure_active_user()
 
 
@@ -116,6 +114,8 @@ def _render_profile(username: str) -> None:
 def main(main_container=None) -> None:
     if main_container is None:
         main_container = st
+    apply_theme("light")
+    inject_modern_styles()
     init_db()
     seed_default_users()
     theme_toggle("Dark Mode", key_suffix="profile")
@@ -167,8 +167,6 @@ def main(main_container=None) -> None:
             {**DEFAULT_USER, "username": username},
         )
         render_profile_card(data)
-
-
 
 
 def render() -> None:

--- a/transcendental_resonance_frontend/pages/resonance_music.py
+++ b/transcendental_resonance_frontend/pages/resonance_music.py
@@ -8,12 +8,12 @@ from __future__ import annotations
 import asyncio
 import base64
 import os
-from typing import Any, Optional, Dict
+from typing import Optional
 from pathlib import Path
 
 import requests
 import streamlit as st
-from frontend.theme import set_theme
+from frontend.theme import apply_theme
 from modern_ui import inject_modern_styles
 from streamlit_helpers import (
     alert,
@@ -23,23 +23,24 @@ from streamlit_helpers import (
     theme_toggle,
 )
 from streamlit_autorefresh import st_autorefresh
-from status_indicator import render_status_icon, check_backend # Ensure check_backend is imported
-from transcendental_resonance_frontend.src.utils.api import get_resonance_summary, dispatch_route # Import get_resonance_summary and dispatch_route from utils.api
+from status_indicator import (
+    render_status_icon,
+    check_backend,
+)  # Ensure check_backend is imported
+from transcendental_resonance_frontend.src.utils.api import (
+    get_resonance_summary,
+    dispatch_route,
+)  # Import get_resonance_summary and dispatch_route from utils.api
 
 
-set_theme("light")
-inject_modern_styles()
-
-# BACKEND_URL is defined in utils.api, but we keep it here for direct requests calls if needed
+# BACKEND_URL is defined in utils.api, but kept here for direct requests
 BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:8000")
 AMBIENT_URL = os.getenv(
     "AMBIENT_MP3_URL",
-    "https://raw.githubusercontent.com/anars/blank-audio/master/10-minutes-of-silence.mp3",
+    "https://raw.githubusercontent.com/anars/blank-audio/master/10-minutes-of-silence.mp3",  # noqa: E501
 )
 
-DEFAULT_AMBIENT_URL = (
-    "https://raw.githubusercontent.com/anars/blank-audio/master/10-seconds-of-silence.mp3"
-)
+DEFAULT_AMBIENT_URL = "https://raw.githubusercontent.com/anars/blank-audio/master/10-seconds-of-silence.mp3"  # noqa: E501
 
 
 def _load_ambient_audio() -> Optional[bytes]:
@@ -78,6 +79,8 @@ def main(main_container=None, status_container=None) -> None:
         main_container = st
     if status_container is None:
         status_container = st
+    apply_theme("light")
+    inject_modern_styles()
     theme_toggle("Dark Mode", key_suffix="music")
 
     # Auto-refresh for backend health check (global, outside main_container)
@@ -89,16 +92,22 @@ def main(main_container=None, status_container=None) -> None:
         render_status_icon(endpoint="/healthz")
 
     # Display alert if backend is not reachable (check once per rerun)
-    backend_ok = check_backend(endpoint="/healthz") # Use the modular check_backend
+    backend_ok = check_backend(endpoint="/healthz")  # Use the modular check_backend
     if not backend_ok:
         alert(
-            f"Backend service unreachable. Please ensure it is running at {BACKEND_URL}.",
+            (
+                "Backend service unreachable. "
+                f"Please ensure it is running at {BACKEND_URL}."
+            ),
             "error",
         )
 
     render_resonance_music_page(main_container=main_container, backend_ok=backend_ok)
 
-def render_resonance_music_page(main_container=None, backend_ok: Optional[bool] = None) -> None:
+
+def render_resonance_music_page(
+    main_container=None, backend_ok: Optional[bool] = None
+) -> None:
     """
     Render the Resonance Music page with backend MIDI generation and metrics summary.
     Handles dynamic selection of profile/track and safely wraps container logic.
@@ -124,15 +133,22 @@ def render_resonance_music_page(main_container=None, backend_ok: Optional[bool] 
             if audio_bytes:
                 encoded = base64.b64encode(audio_bytes).decode()
                 st.markdown(
-                    f"<audio id='ambient-audio' autoplay loop style='display:none'>"
-                    f"<source src='data:audio/mp3;base64,{encoded}' type='audio/mp3'></audio>",
+                    (
+                        "<audio id='ambient-audio' autoplay loop style='display:none'>"
+                        f"<source src='data:audio/mp3;base64,{encoded}'"
+                        " type='audio/mp3'>"
+                        "</audio>"
+                    ),
                     unsafe_allow_html=True,
                 )
             else:
                 st.error("Failed to load ambient music. Please try again later.")
         else:
             st.markdown(
-                "<script>var a=document.getElementById('ambient-audio');if(a){a.pause();a.remove();}</script>",
+                (
+                    "<script>var a=document.getElementById('ambient-audio');"
+                    "if(a){a.pause();a.remove();}</script>"
+                ),
                 unsafe_allow_html=True,
             )
 
@@ -145,7 +161,7 @@ def render_resonance_music_page(main_container=None, backend_ok: Optional[bool] 
             combined_options,
             index=0,
             placeholder="tracks or resonance profiles",
-            key="resonance_profile_select"
+            key="resonance_profile_select",
         )
 
         midi_placeholder = st.empty()
@@ -153,7 +169,13 @@ def render_resonance_music_page(main_container=None, backend_ok: Optional[bool] 
         # --- Generate Music Section ---
         if st.button("Generate music", key="generate_music_btn"):
             if not backend_ok:
-                alert(f"Cannot generate music: Backend service unreachable at {BACKEND_URL}.", "error")
+                alert(
+                    (
+                        "Cannot generate music: Backend service unreachable at "
+                        f"{BACKEND_URL}."
+                    ),
+                    "error",
+                )
                 return
 
             with st.spinner("Generating..."):
@@ -161,7 +183,9 @@ def render_resonance_music_page(main_container=None, backend_ok: Optional[bool] 
                     result = _run_async(
                         dispatch_route("generate_midi", {"profile": choice})
                     )
-                    midi_b64 = result.get("midi_base64") if isinstance(result, dict) else None
+                    midi_b64 = (
+                        result.get("midi_base64") if isinstance(result, dict) else None
+                    )
 
                     if midi_b64:
                         midi_bytes = base64.b64decode(midi_b64)
@@ -170,13 +194,23 @@ def render_resonance_music_page(main_container=None, backend_ok: Optional[bool] 
                     else:
                         alert("No MIDI data returned from generation.", "warning")
                 except Exception as exc:
-                    alert(f"Music generation failed: {exc}. Ensure backend is running and 'generate_midi' route is available.", "error")
+                    alert(
+                        (
+                            f"Music generation failed: {exc}. "
+                            "Ensure backend is running and "
+                            "'generate_midi' route is available."
+                        ),
+                        "error",
+                    )
 
         # --- Fetch Resonance Summary Section ---
         if st.button("Fetch resonance summary", key="fetch_summary_btn"):
             if not backend_ok:
                 alert(
-                    f"Cannot fetch summary: Backend service unreachable at {BACKEND_URL}.",
+                    (
+                        "Cannot fetch summary: Backend service unreachable at "
+                        f"{BACKEND_URL}."
+                    ),
                     "error",
                 )
                 return
@@ -186,7 +220,11 @@ def render_resonance_music_page(main_container=None, backend_ok: Optional[bool] 
                     data = _run_async(get_resonance_summary(choice))
                 except Exception as exc:
                     alert(
-                        f"Failed to load summary: {exc}. Ensure backend is running and 'resonance-summary' route is available.",
+                        (
+                            f"Failed to load summary: {exc}. "
+                            "Ensure backend is running and "
+                            "'resonance-summary' route is available."
+                        ),
                         "error",
                     )
                 else:
@@ -197,7 +235,10 @@ def render_resonance_music_page(main_container=None, backend_ok: Optional[bool] 
                         header("Metrics")
                         if metrics:
                             st.table(
-                                {"metric": list(metrics.keys()), "value": list(metrics.values())}
+                                {
+                                    "metric": list(metrics.keys()),
+                                    "value": list(metrics.values()),
+                                }
                             )
                         else:
                             st.toast("No metrics available for this profile.")

--- a/transcendental_resonance_frontend/pages/social.py
+++ b/transcendental_resonance_frontend/pages/social.py
@@ -4,21 +4,20 @@
 """Friends & Followers page."""
 
 import streamlit as st
-from frontend.theme import set_theme
+from frontend.theme import apply_theme
 from modern_ui import inject_modern_styles
 
 from social_tabs import render_social_tab
 from streamlit_helpers import safe_container, render_mock_feed, theme_toggle
 from feed_renderer import render_feed
 
-set_theme("light")
-inject_modern_styles()
-
 
 def main(main_container=None) -> None:
     """Render the social page content within ``main_container``."""
     if main_container is None:
         main_container = st
+    apply_theme("light")
+    inject_modern_styles()
     theme_toggle("Dark Mode", key_suffix="social")
 
     container_ctx = safe_container(main_container)

--- a/transcendental_resonance_frontend/pages/validation.py
+++ b/transcendental_resonance_frontend/pages/validation.py
@@ -5,16 +5,18 @@
 
 import importlib
 import streamlit as st
-from frontend.theme import set_theme
+from frontend.theme import apply_theme
 from modern_ui import inject_modern_styles
 
 from streamlit_helpers import safe_container, theme_toggle
+
 
 # --------------------------------------------------------------------
 # Dynamic loader with graceful degradation
 # --------------------------------------------------------------------
 def _fallback_validation_ui(*_a, **_k):
     st.warning("Validation UI unavailable")
+
 
 def _load_render_ui():
     """Try to import ui.render_validation_ui, else return a stub."""
@@ -24,11 +26,11 @@ def _load_render_ui():
     except Exception:  # pragma: no cover
         return _fallback_validation_ui
 
+
 render_validation_ui = _load_render_ui()
 
 # Inject modern global styles (safe when running in classic Streamlit)
-set_theme("light")
-inject_modern_styles()
+
 
 # --------------------------------------------------------------------
 # Page decorator (works even if Streamlit’s multipage API absent)
@@ -38,6 +40,7 @@ def _page_decorator(func):
         return st.experimental_page("Validation")(func)
     return func
 
+
 # --------------------------------------------------------------------
 # Main entry point
 # --------------------------------------------------------------------
@@ -46,6 +49,8 @@ def main(main_container=None) -> None:
     """Render the validation UI inside a safe container."""
     if main_container is None:
         main_container = st
+    apply_theme("light")
+    inject_modern_styles()
     theme_toggle("Dark Mode", key_suffix="validation")
 
     global render_validation_ui
@@ -61,6 +66,7 @@ def main(main_container=None) -> None:
     except AttributeError:
         # If safe_container gave an unexpected object, fall back
         render_validation_ui(main_container=main_container)
+
 
 def render() -> None:
     """Alias used by other modules/pages."""

--- a/transcendental_resonance_frontend/pages/video_chat.py
+++ b/transcendental_resonance_frontend/pages/video_chat.py
@@ -3,19 +3,15 @@
 from __future__ import annotations
 
 import asyncio
-import json
 
 import streamlit as st
-from frontend.theme import set_theme
+from frontend.theme import apply_theme
 from modern_ui import inject_modern_styles
 
 
 from ai_video_chat import create_session
 from video_chat_router import ConnectionManager
 from streamlit_helpers import safe_container, header, theme_toggle
-
-set_theme("light")
-inject_modern_styles()
 
 
 def _run_async(coro):
@@ -36,6 +32,8 @@ manager = ConnectionManager()
 def main(main_container=None) -> None:
     """Render the simple video chat demo."""
     container = main_container if main_container is not None else st
+    apply_theme("light")
+    inject_modern_styles()
     theme_toggle("Dark Mode", key_suffix="video_chat")
 
     container_ctx = safe_container(container)
@@ -80,4 +78,3 @@ def render() -> None:
 
 if __name__ == "__main__":
     main()
-

--- a/transcendental_resonance_frontend/pages/voting.py
+++ b/transcendental_resonance_frontend/pages/voting.py
@@ -4,20 +4,19 @@
 """Governance and voting page."""
 
 import streamlit as st
-from frontend.theme import set_theme
+from frontend.theme import apply_theme
 from modern_ui import inject_modern_styles
 
 from voting_ui import render_voting_tab
 from streamlit_helpers import safe_container, theme_toggle
-
-set_theme("light")
-inject_modern_styles()
 
 
 def main(main_container=None) -> None:
     """Render the Governance and Voting page inside ``main_container``."""
     if main_container is None:
         main_container = st
+    apply_theme("light")
+    inject_modern_styles()
     theme_toggle("Dark Mode", key_suffix="voting")
 
     container_ctx = safe_container(main_container)


### PR DESCRIPTION
## Summary
- stop calling `set_theme()`/`inject_modern_styles()` on import
- use `apply_theme("light")` at the start of each page
- run `inject_modern_styles()` inside page `main()`/`render()`
- format code via pre-commit

## Testing
- `pre-commit run --files transcendental_resonance_frontend/pages/agents.py transcendental_resonance_frontend/pages/chat.py transcendental_resonance_frontend/pages/feed.py transcendental_resonance_frontend/pages/messages.py transcendental_resonance_frontend/pages/messages_center.py transcendental_resonance_frontend/pages/profile.py transcendental_resonance_frontend/pages/resonance_music.py transcendental_resonance_frontend/pages/social.py transcendental_resonance_frontend/pages/validation.py transcendental_resonance_frontend/pages/video_chat.py transcendental_resonance_frontend/pages/voting.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d1de548588320907a2ba36d29f30d