### PR TITLE
Remove duplicate CSS helpers

### DIFF
--- a/agent_ui.py
+++ b/agent_ui.py
@@ -8,7 +8,7 @@ from typing import Any, cast
 
 import streamlit as st
 from streamlit_helpers import (
-    inject_global_styles,
+    inject_modern_styles,
     theme_selector,
     safe_container,
     BOX_CSS,
@@ -43,7 +43,7 @@ def render_agent_insights_tab(main_container=None) -> None:
     if main_container is None:
         main_container = st
 
-    inject_global_styles()
+    inject_modern_styles()
     theme_selector("Theme", key_suffix="agent_insights")
     container_ctx = safe_container(main_container)
     with container_ctx:

--- a/chat_ui.py
+++ b/chat_ui.py
@@ -9,7 +9,6 @@ import threading
 from typing import Optional
 import streamlit as st
 from streamlit.runtime.scriptrunner import add_script_run_ctx
-from modern_ui import inject_modern_styles
 from realtime_comm import ChatWebSocketManager
 
 try:
@@ -17,7 +16,6 @@ try:
 except Exception:  # pragma: no cover - optional dependency
     websockets = None
 
-inject_modern_styles()
 
 
 def _run_async(coro):

--- a/modern_ui.py
+++ b/modern_ui.py
@@ -29,65 +29,6 @@ def render_lottie_animation(url: str, *, height: int = 200, fallback: str = "ðŸš
 logger = logging.getLogger("modern_ui")
 
 
-def inject_modern_styles() -> None:
-    """Inject global CSS using theme variables and local assets."""
-    from modern_ui_components import SIDEBAR_STYLES
-
-    theme.inject_modern_styles()
-
-    if st.session_state.get("_modern_ui_css_injected"):
-        logger.debug("Modern UI CSS already injected; skipping extra assets")
-        return
-
-    css = """
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <script type="module" src="/static/lucide-react.min.js"></script>
-    <style>
-    body, .stApp {
-        background: var(--bg);
-        color: var(--text-muted);
-        font-family: 'Inter', sans-serif;
-    }
-    .card, .custom-container {
-        background: var(--card);
-        border-radius: 1rem;
-        box-shadow: 0 2px 6px rgba(0,0,0,0.08);
-        transition: transform .2s ease, box-shadow .2s ease;
-    }
-    .card:hover, .custom-container:hover {
-        transform: translateY(-2px);
-        box-shadow: 0 4px 12px rgba(0,0,0,0.12);
-    }
-    .insta-card {
-        display: flex;
-        flex-direction: column;
-        background: var(--card);
-        border-radius: 1rem;
-        overflow: hidden;
-        box-shadow: 0 2px 6px rgba(0,0,0,0.1);
-        transition: transform .2s ease, box-shadow .2s ease;
-    }
-    .insta-card img {
-        width: 100%;
-        height: auto;
-    }
-    .insta-card:hover {
-        transform: translateY(-4px);
-        box-shadow: 0 8px 24px rgba(0,0,0,0.15);
-    }
-    </style>
-    """
-    st.markdown(css, unsafe_allow_html=True)
-    st.markdown(SIDEBAR_STYLES, unsafe_allow_html=True)
-    st.session_state["_modern_ui_css_injected"] = True
-
-def inject_premium_styles() -> None:
-    """Backward compatible alias for :func:`inject_modern_styles`."""
-    inject_modern_styles()
-
-
 def render_modern_header() -> None:
     """Render the premium glassy header."""
     st.markdown(
@@ -262,8 +203,6 @@ def close_card_container() -> None:
 
 __all__ = [
     "render_lottie_animation",
-    "inject_modern_styles",
-    "inject_premium_styles",
     "render_modern_header",
     "render_validation_card",
     "render_stats_section",

--- a/pages/agents.py
+++ b/pages/agents.py
@@ -3,14 +3,17 @@
 # Legal & Ethical Safeguards
 """Thin wrapper for the Agents page."""
 
+from frontend.theme import inject_modern_styles
 from transcendental_resonance_frontend.pages import agents as real_page
 
 
 def main() -> None:  # Streamlit runs this when the file is opened
+    inject_modern_styles()
     real_page.main()
 
 
 def render() -> None:  # keep legacy compatibility
+    inject_modern_styles()
     real_page.main()
 
 

--- a/pages/chat.py
+++ b/pages/chat.py
@@ -5,14 +5,17 @@
 
 from __future__ import annotations
 
+from frontend.theme import inject_modern_styles
 from transcendental_resonance_frontend.pages import chat as real_page
 
 
 def main() -> None:
+    inject_modern_styles()
     real_page.main()
 
 
 def render() -> None:
+    inject_modern_styles()
     real_page.main()
 
 

--- a/pages/feed.py
+++ b/pages/feed.py
@@ -5,14 +5,17 @@
 
 from __future__ import annotations
 
+from frontend.theme import inject_modern_styles
 from transcendental_resonance_frontend.pages import feed as real_page
 
 
 def main() -> None:
+    inject_modern_styles()
     real_page.main()
 
 
 def render() -> None:
+    inject_modern_styles()
     real_page.main()
 
 

--- a/pages/messages.py
+++ b/pages/messages.py
@@ -5,14 +5,17 @@
 
 from __future__ import annotations
 
+from frontend.theme import inject_modern_styles
 from transcendental_resonance_frontend.pages import messages as real_page
 
 
 def main() -> None:
+    inject_modern_styles()
     real_page.main()
 
 
 def render() -> None:
+    inject_modern_styles()
     real_page.main()
 
 

--- a/pages/messages_center.py
+++ b/pages/messages_center.py
@@ -5,14 +5,17 @@
 
 from __future__ import annotations
 
+from frontend.theme import inject_modern_styles
 from transcendental_resonance_frontend.pages import messages_center as real_page
 
 
 def main() -> None:
+    inject_modern_styles()
     real_page.main()
 
 
 def render() -> None:
+    inject_modern_styles()
     real_page.main()
 
 

--- a/pages/profile.py
+++ b/pages/profile.py
@@ -5,14 +5,17 @@
 
 from __future__ import annotations
 
+from frontend.theme import inject_modern_styles
 from transcendental_resonance_frontend.pages import profile as real_page
 
 
 def main() -> None:
+    inject_modern_styles()
     real_page.main()
 
 
 def render() -> None:
+    inject_modern_styles()
     real_page.main()
 
 

--- a/pages/resonance_music.py
+++ b/pages/resonance_music.py
@@ -5,14 +5,17 @@
 
 from __future__ import annotations
 
+from frontend.theme import inject_modern_styles
 from transcendental_resonance_frontend.pages import resonance_music as real_page
 
 
 def main() -> None:
+    inject_modern_styles()
     real_page.main()
 
 
 def render() -> None:
+    inject_modern_styles()
     real_page.main()
 
 

--- a/pages/social.py
+++ b/pages/social.py
@@ -5,14 +5,17 @@
 
 from __future__ import annotations
 
+from frontend.theme import inject_modern_styles
 from transcendental_resonance_frontend.pages import social as real_page
 
 
 def main() -> None:
+    inject_modern_styles()
     real_page.main()
 
 
 def render() -> None:
+    inject_modern_styles()
     real_page.main()
 
 

--- a/pages/validation.py
+++ b/pages/validation.py
@@ -5,14 +5,17 @@
 
 from __future__ import annotations
 
+from frontend.theme import inject_modern_styles
 from transcendental_resonance_frontend.pages import validation as real_page
 
 
 def main() -> None:
+    inject_modern_styles()
     real_page.main()
 
 
 def render() -> None:
+    inject_modern_styles()
     real_page.main()
 
 

--- a/pages/video_chat.py
+++ b/pages/video_chat.py
@@ -5,14 +5,17 @@
 
 from __future__ import annotations
 
+from frontend.theme import inject_modern_styles
 from transcendental_resonance_frontend.pages import video_chat as real_page
 
 
 def main() -> None:
+    inject_modern_styles()
     real_page.main()
 
 
 def render() -> None:
+    inject_modern_styles()
     real_page.main()
 
 

--- a/pages/voting.py
+++ b/pages/voting.py
@@ -5,14 +5,17 @@
 
 from __future__ import annotations
 
+from frontend.theme import inject_modern_styles
 from transcendental_resonance_frontend.pages import voting as real_page
 
 
 def main() -> None:
+    inject_modern_styles()
     real_page.main()
 
 
 def render() -> None:
+    inject_modern_styles()
     real_page.main()
 
 

--- a/streamlit_helpers.py
+++ b/streamlit_helpers.py
@@ -110,16 +110,9 @@ def safe_element(tag: str, content: str) -> Any:
 
 
 # ──────────────────────────────────────────────────────────────────────────────
-# Optional modern-ui styles injector
+# Modern UI styles injector
 # ──────────────────────────────────────────────────────────────────────────────
-
-try:
-    from modern_ui import inject_modern_styles  # type: ignore
-except Exception:  # noqa: BLE001
-
-    def inject_modern_styles(*_a: Any, **_kw: Any) -> None:  # type: ignore
-        """No-op when *modern_ui* is absent."""
-        return None
+from frontend.theme import inject_modern_styles
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -578,10 +571,6 @@ def inject_instagram_styles() -> None:
     )
 
 
-# Backwards-compat alias
-def inject_global_styles() -> None:
-    """Deprecated – prefer *modern_ui.inject_modern_styles*."""
-    inject_modern_styles()
 
 
 def ensure_active_user() -> str:
@@ -614,7 +603,6 @@ __all__ = [
     "centered_container",
     "safe_container",
     "tabs_nav",
-    "inject_global_styles",
     "inject_instagram_styles",
     "ensure_active_user",
     "BOX_CSS",

--- a/transcendental_resonance_frontend/pages/agents.py
+++ b/transcendental_resonance_frontend/pages/agents.py
@@ -4,7 +4,6 @@
 
 import streamlit as st
 from frontend.theme import set_theme
-from modern_ui import inject_modern_styles
 
 from agent_ui import render_agent_insights_tab
 from streamlit_helpers import theme_toggle
@@ -12,7 +11,6 @@ from streamlit_helpers import theme_toggle
 __all__ = ["main", "render"]
 
 set_theme("light")
-inject_modern_styles()
 
 
 def main(main_container=None) -> None:

--- a/transcendental_resonance_frontend/pages/chat.py
+++ b/transcendental_resonance_frontend/pages/chat.py
@@ -5,13 +5,11 @@
 
 import streamlit as st
 from frontend.theme import set_theme
-from modern_ui import inject_modern_styles
 from streamlit_helpers import safe_container, header, theme_toggle
 from status_indicator import render_status_icon
 from chat_ui import render_chat_interface
 
 set_theme("light")
-inject_modern_styles()
 
 
 def main(main_container=None) -> None:

--- a/transcendental_resonance_frontend/pages/feed.py
+++ b/transcendental_resonance_frontend/pages/feed.py
@@ -12,7 +12,6 @@ import random
 import streamlit as st
 
 from frontend.theme import set_theme
-from modern_ui import inject_modern_styles
 from streamlit_helpers import theme_toggle, safe_container, sanitize_text
 
 from modern_ui_components import st_javascript
@@ -209,7 +208,6 @@ def _load_more_posts() -> None:
 # ──────────────────────────────────────────────────────────────────────────────
 
 set_theme("light")
-inject_modern_styles()
 
 
 def _page_body() -> None:

--- a/transcendental_resonance_frontend/pages/messages.py
+++ b/transcendental_resonance_frontend/pages/messages.py
@@ -7,12 +7,10 @@ from __future__ import annotations
 
 import streamlit as st
 from frontend.theme import set_theme
-from modern_ui import inject_modern_styles
 from streamlit_helpers import theme_toggle
 from transcendental_resonance_frontend.ui.chat_ui import render_chat_ui
 
 set_theme("light")
-inject_modern_styles()
 
 
 def main(main_container=None) -> None:

--- a/transcendental_resonance_frontend/pages/messages_center.py
+++ b/transcendental_resonance_frontend/pages/messages_center.py
@@ -10,14 +10,12 @@ from __future__ import annotations
 import asyncio
 import streamlit as st
 from frontend.theme import set_theme
-from modern_ui import inject_modern_styles
 from streamlit_helpers import safe_container, theme_toggle
 from status_indicator import render_status_icon
 from transcendental_resonance_frontend.src.utils import api
 
 # ─── Apply global styles ────────────────────────────────────────────────────────
 set_theme("light")
-inject_modern_styles()
 
 # ─── Dummy data ────────────────────────────────────────────────────────────────
 DUMMY_CONVERSATIONS: dict[str, list[dict[str, str]]] = {

--- a/transcendental_resonance_frontend/pages/profile.py
+++ b/transcendental_resonance_frontend/pages/profile.py
@@ -5,7 +5,6 @@
 
 import streamlit as st
 from frontend.theme import set_theme
-from modern_ui import inject_modern_styles
 from streamlit_helpers import (
     safe_container,
     header,
@@ -81,7 +80,6 @@ def _fetch_social(username: str) -> tuple[dict, dict]:
     return followers or {}, following or {}
 
 set_theme("light")
-inject_modern_styles()
 ensure_active_user()
 
 

--- a/transcendental_resonance_frontend/pages/resonance_music.py
+++ b/transcendental_resonance_frontend/pages/resonance_music.py
@@ -14,7 +14,6 @@ from pathlib import Path
 import requests
 import streamlit as st
 from frontend.theme import set_theme
-from modern_ui import inject_modern_styles
 from streamlit_helpers import (
     alert,
     centered_container,
@@ -28,7 +27,6 @@ from transcendental_resonance_frontend.src.utils.api import get_resonance_summar
 
 
 set_theme("light")
-inject_modern_styles()
 
 # BACKEND_URL is defined in utils.api, but we keep it here for direct requests calls if needed
 BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:8000")

--- a/transcendental_resonance_frontend/pages/social.py
+++ b/transcendental_resonance_frontend/pages/social.py
@@ -5,14 +5,12 @@
 
 import streamlit as st
 from frontend.theme import set_theme
-from modern_ui import inject_modern_styles
 
 from social_tabs import render_social_tab
 from streamlit_helpers import safe_container, render_mock_feed, theme_toggle
 from feed_renderer import render_feed
 
 set_theme("light")
-inject_modern_styles()
 
 
 def main(main_container=None) -> None:

--- a/transcendental_resonance_frontend/pages/validation.py
+++ b/transcendental_resonance_frontend/pages/validation.py
@@ -6,7 +6,6 @@
 import importlib
 import streamlit as st
 from frontend.theme import set_theme
-from modern_ui import inject_modern_styles
 
 from streamlit_helpers import safe_container, theme_toggle
 
@@ -28,7 +27,6 @@ render_validation_ui = _load_render_ui()
 
 # Inject modern global styles (safe when running in classic Streamlit)
 set_theme("light")
-inject_modern_styles()
 
 # --------------------------------------------------------------------
 # Page decorator (works even if Streamlit’s multipage API absent)

--- a/transcendental_resonance_frontend/pages/video_chat.py
+++ b/transcendental_resonance_frontend/pages/video_chat.py
@@ -7,7 +7,6 @@ import json
 
 import streamlit as st
 from frontend.theme import set_theme
-from modern_ui import inject_modern_styles
 
 
 from ai_video_chat import create_session
@@ -15,7 +14,6 @@ from video_chat_router import ConnectionManager
 from streamlit_helpers import safe_container, header, theme_toggle
 
 set_theme("light")
-inject_modern_styles()
 
 
 def _run_async(coro):

--- a/transcendental_resonance_frontend/pages/voting.py
+++ b/transcendental_resonance_frontend/pages/voting.py
@@ -5,13 +5,11 @@
 
 import streamlit as st
 from frontend.theme import set_theme
-from modern_ui import inject_modern_styles
 
 from voting_ui import render_voting_tab
 from streamlit_helpers import safe_container, theme_toggle
 
 set_theme("light")
-inject_modern_styles()
 
 
 def main(main_container=None) -> None:

--- a/transcendental_resonance_frontend/ui/chat_ui.py
+++ b/transcendental_resonance_frontend/ui/chat_ui.py
@@ -2,10 +2,7 @@
 from __future__ import annotations
 
 import streamlit as st
-from modern_ui import inject_modern_styles
 from streamlit_helpers import safe_container, header
-
-inject_modern_styles()
 
 DUMMY_CONVOS = [
     {"user": "Alice", "preview": "Hey there!"},

--- a/ui.py
+++ b/ui.py
@@ -324,15 +324,7 @@ from streamlit_helpers import (
     render_instagram_grid,
 )
 
-from frontend.theme import set_theme
-from frontend.theme import apply_theme
-
-
-try:
-    from modern_ui import inject_modern_styles
-except Exception:  # pragma: no cover - gracefully handle missing/invalid module
-    def inject_modern_styles(*_a, **_k):
-        return None
+from frontend.theme import set_theme, apply_theme, inject_modern_styles
 
 
 
@@ -499,17 +491,7 @@ def render_landing_page():
         st.markdown("</div></div>", unsafe_allow_html=True)
 
 
-def inject_modern_styles() -> None:
-    """Backward compatible alias for modern theme injection."""
-    from frontend.theme import inject_modern_styles as _impl
 
-    _impl()
-
-
-# Backward compatibility alias
-def inject_dark_theme() -> None:
-    """Legacy alias for inject_modern_styles()."""
-    inject_modern_styles()
 
 
 def load_page_with_fallback(choice: str, module_paths: list[str] | None = None) -> None:

--- a/ui_utils.py
+++ b/ui_utils.py
@@ -5,7 +5,7 @@
 
 from pathlib import Path
 import streamlit as st
-from streamlit_helpers import inject_global_styles
+from streamlit_helpers import inject_modern_styles
 from modern_ui_components import render_modern_header, render_modern_sidebar
 
 
@@ -52,14 +52,14 @@ def load_rfc_entries(rfc_dir: Path):
 
 def render_main_ui() -> None:
     """Render a minimal placeholder for the Streamlit dashboard."""
-    inject_global_styles()
+    inject_modern_styles()
     st.title("superNova_2177")
     st.write("UI initialization complete.")
 
 
 def render_modern_layout() -> None:
     """Demo layout showcasing the modern styles."""
-    inject_global_styles()
+    inject_modern_styles()
 
     pages = {"Home": "home", "Feed": "feed", "Profile": "profile"}
     choice = render_modern_sidebar(

--- a/voting_ui.py
+++ b/voting_ui.py
@@ -11,7 +11,7 @@ try:
 except Exception:  # pragma: no cover - optional dependency
     AgGrid = None  # type: ignore
     GridOptionsBuilder = None  # type: ignore
-from streamlit_helpers import alert, inject_global_styles
+from streamlit_helpers import alert, inject_modern_styles
 
 try:
     from frontend_bridge import dispatch_route
@@ -422,7 +422,7 @@ def render_voting_tab(main_container=None) -> None:
 
     container_ctx = safe_container(main_container)
     with container_ctx:
-        inject_global_styles()
+        inject_modern_styles()
         st.markdown(VOTING_CSS, unsafe_allow_html=True)
         sub1, sub2, sub3, sub4 = st.tabs(
             [


### PR DESCRIPTION
## Summary
- drop deprecated CSS injection functions
- update pages and helpers to call `frontend.theme.inject_modern_styles`
- ensure each page wrapper injects the modern styles

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d1dc48ab483208a8fb2a5820e9b03