### PR TITLE
Refactor styles to use theme variables

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -7,7 +7,7 @@ primaryColor = "#00F0FF"
 backgroundColor = "#001E26"
 secondaryBackgroundColor = "#002B36"
 textColor = "#E0FFFF"
-font = "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+font = "'Inter', sans-serif"
 
 [server]
 # Switch to polling to avoid inotify limits

--- a/docs/codex_theme.md
+++ b/docs/codex_theme.md
@@ -24,7 +24,7 @@ primaryColor = "#00F0FF"
 backgroundColor = "#001E26"
 secondaryBackgroundColor = "#002B36"
 textColor = "#E0FFFF"
-font = "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+font = "'Inter', sans-serif"
 ```
 
 ### CSS Classes

--- a/frontend/profile_card.py
+++ b/frontend/profile_card.py
@@ -15,8 +15,8 @@ _CSS = """
 .pc-wrapper{
   display:flex;flex-direction:column;align-items:center;
   width:100%;max-width:360px;margin-inline:auto;
-  background:rgba(255,255,255,.05);
-  border:1px solid rgba(255,255,255,.12);
+  background:var(--card);
+  border:1px solid var(--card);
   backdrop-filter:blur(14px) saturate(160%);
   border-radius:1.2rem;overflow:hidden;padding-bottom:1rem;
   animation:fade-in .35s ease forwards;
@@ -24,10 +24,10 @@ _CSS = """
 @keyframes fade-in{from{opacity:0;transform:translateY(6px)}to{opacity:1}}
 
 .pc-banner{width:100%;height:84px;
-  background:linear-gradient(120deg,#0a84ff 0%,#00f0ff 100%);}
+  background:var(--accent);}
 .pc-avatar{width:88px;height:88px;border-radius:50%;
-  object-fit:cover;background:#eee;margin-top:-46px;
-  border:4px solid var(--card,#001E26);}
+  object-fit:cover;background:var(--bg);margin-top:-46px;
+  border:4px solid var(--card);}
 .pc-name{font-size:1.15rem;font-weight:600;margin:.45rem 0 .1rem}
 .pc-tag{font-size:.85rem;color:var(--text-muted,#7e9aaa);
   text-align:center;margin:0 .75rem .65rem}
@@ -37,10 +37,10 @@ _CSS = """
   text-align:center}
 .pc-actions{display:flex;gap:.6rem;flex-wrap:wrap;justify-content:center}
 .pc-btn{flex:1 1 120px;padding:.45rem .8rem;border:none;
-  border-radius:.65rem;background:rgba(255,255,255,.09);
-  color:#fff;font-size:.85rem;cursor:pointer;
+  border-radius:.65rem;background:var(--accent);
+  color:var(--bg);font-size:.85rem;cursor:pointer;
   transition:background .2s ease}
-.pc-btn:hover{background:rgba(255,255,255,.18)}
+.pc-btn:hover{background:var(--accent)}
 @media(max-width:400px){.pc-wrapper{max-width:100%}}
 </style>
 """

--- a/frontend/ui_layout.py
+++ b/frontend/ui_layout.py
@@ -66,7 +66,7 @@ DRAWER_CSS = """
 [data-testid='stSidebar']{background:var(--card);border-right:1px solid rgba(255,255,255,0.1);transition:transform 0.3s ease;z-index:1002;}
 [data-testid='stSidebar'].collapsed{transform:translateX(-100%);}
 @media(min-width:768px){[data-testid='stSidebar']{transform:none!important;}}
-#drawer_btn{display:none;background:none;border:none;color:#fff;font-size:1.3rem;cursor:pointer;}
+#drawer_btn{display:none;background:none;border:none;color:var(--accent);font-size:1.3rem;cursor:pointer;}
 @media(max-width:768px){#drawer_btn{display:block;}}
 </style>
 """
@@ -194,21 +194,21 @@ def render_top_bar() -> None:
   position:sticky;top:0;inset-inline:0;z-index:1001;
   display:flex;align-items:center;gap:.75rem;
   padding:.6rem 1rem;backdrop-filter:blur(10px);
-  background:rgba(18,18,18,.65);
+  background:var(--card);
 }
 @media(max-width:600px){.sn-topbar{flex-wrap:wrap}}
 .sn-topbar input[type='text']{
   flex:1;padding:.45rem .7rem;border-radius:8px;
-  border:1px solid rgba(255,255,255,.25);min-width:140px;
-  background:rgba(255,255,255,.90);font-size:.9rem;
+  border:1px solid var(--card);min-width:140px;
+  background:var(--bg);font-size:.9rem;
 }
-#drawer_btn{background:none;border:none;color:#fff;font-size:1.3rem;cursor:pointer;display:none}
+#drawer_btn{background:none;border:none;color:var(--accent);font-size:1.3rem;cursor:pointer;display:none}
 @media(max-width:768px){#drawer_btn{display:block}}
-.sn-bell{position:relative;background:none;border:none;font-size:1.3rem;color:#fff;cursor:pointer}
+.sn-bell{position:relative;background:none;border:none;font-size:1.3rem;color:var(--accent);cursor:pointer}
 .sn-bell::before{font-family:"Font Awesome 6 Free";font-weight:900;content:"\\f0f3"}
 .sn-bell[data-count]::after{
   content:attr(data-count);position:absolute;top:-.35rem;right:-.45rem;
-  background:#ff4757;color:#fff;border-radius:999px;padding:0 .33rem;
+  background:var(--accent);color:var(--bg);border-radius:999px;padding:0 .33rem;
   font-size:.62rem;line-height:1;
 }
 </style>
@@ -402,7 +402,7 @@ def show_preview_badge(text: str = "Preview") -> None:
     """Floating badge in the top-right corner."""
     st.markdown(
         f"<div style='position:fixed;top:1.1rem;right:1.1rem;"
-        f"background:#ffc107;color:#000;padding:.28rem .6rem;border-radius:6px;"
+        f"background:var(--accent);color:var(--bg);padding:.28rem .6rem;border-radius:6px;"
         f"box-shadow:0 2px 6px rgba(0,0,0,.15);z-index:999'>"
         f"<i class='fa-solid fa-triangle-exclamation'></i>&nbsp;{text}</div>",
         unsafe_allow_html=True,

--- a/modern_ui.py
+++ b/modern_ui.py
@@ -93,17 +93,17 @@ def render_modern_header() -> None:
     st.markdown(
         """
         <div style="
-            background: linear-gradient(135deg, rgba(24, 24, 24, 0.95), rgba(36, 36, 36, 0.95));
+            background: var(--card);
             backdrop-filter: blur(20px);
             padding: 1.5rem 2rem;
             margin: -2rem -3rem 3rem -3rem;
-            border-bottom: 1px solid rgba(74, 144, 226, 0.2);
+            border-bottom: 1px solid var(--accent);
             border-radius: 0 0 16px 16px;
         ">
             <div style="display: flex; align-items: center; justify-content: space-between;">
                 <div style="display: flex; align-items: center; gap: 1rem;">
                     <div style="
-                        background: linear-gradient(135deg, #4a90e2, #5ba0f2);
+                        background: var(--accent);
                         border-radius: 12px;
                         padding: 0.75rem;
                         display: flex;
@@ -113,19 +113,19 @@ def render_modern_header() -> None:
                         <span style="font-size: 1.5rem;">🚀</span>
                     </div>
                     <div>
-                        <h1 style="margin: 0; color: #ffffff; font-size: 1.75rem; font-weight: 700;">
+                        <h1 style="margin: 0; color: var(--text-muted); font-size: 1.75rem; font-weight: 700;">
                             superNova_2177
                         </h1>
-                        <p style="margin: 0; color: #888; font-size: 0.9rem;">Validation Analyzer</p>
+                        <p style="margin: 0; color: var(--text-muted); font-size: 0.9rem;">Validation Analyzer</p>
                     </div>
                 </div>
                 <div style="display: flex; gap: 1rem; align-items: center;">
                     <div style="
-                        background: rgba(74, 144, 226, 0.1);
-                        border: 1px solid rgba(74, 144, 226, 0.3);
+                        background: var(--bg);
+                        border: 1px solid var(--accent);
                         border-radius: 8px;
                         padding: 0.5rem 1rem;
-                        color: #4a90e2;
+                        color: var(--accent);
                         font-size: 0.85rem;
                         font-weight: 500;
                     ">
@@ -144,9 +144,9 @@ def render_validation_card() -> None:
     st.markdown(
         """
         <div style="
-            background: rgba(255, 255, 255, 0.03);
+            background: var(--card);
             backdrop-filter: blur(20px);
-            border: 1px solid rgba(255, 255, 255, 0.1);
+            border: 1px solid var(--card);
             border-radius: 16px;
             padding: 2rem;
             margin-bottom: 2rem;
@@ -174,9 +174,9 @@ def render_stats_section(stats: dict | None = None) -> None:
         .stats-card {{
             flex: 1 1 calc(25% - 1rem);
             min-width: 120px;
-            background: rgba(255, 255, 255, 0.03);
+            background: var(--card);
             backdrop-filter: blur(15px);
-            border: 1px solid rgba(255, 255, 255, 0.1);
+            border: 1px solid var(--card);
             border-radius: 12px;
             padding: 1.5rem;
             text-align: center;
@@ -192,7 +192,7 @@ def render_stats_section(stats: dict | None = None) -> None:
             margin-bottom: 0.25rem;
         }}
         .stats-label {{
-            color: #888;
+            color: var(--text-muted);
             font-size: calc(0.8rem + 0.2vw);
             font-weight: 500;
         }}

--- a/modern_ui_components.py
+++ b/modern_ui_components.py
@@ -97,7 +97,7 @@ SIDEBAR_STYLES = """
 }
 .sidebar-nav .nav-item.active {
     background: var(--accent);
-    color: #fff;
+    color: var(--bg);
 }
 </style>
 """
@@ -414,7 +414,7 @@ def render_stats_section(stats: dict) -> None:
             margin-bottom: 0.25rem;
         }}
         .stats-label {{
-            color: #888;
+            color: var(--text-muted);
             font-size: calc(0.8rem + 0.2vw);
             font-weight: 500;
         }}

--- a/streamlit_helpers.py
+++ b/streamlit_helpers.py
@@ -279,7 +279,7 @@ def render_post_card(post_data: dict[str, Any]) -> None:
             st.write(caption_text)
             getattr(st, "caption", st.write)(f"❤️ {likes}")
             getattr(st, "markdown", lambda *a, **k: None)(
-                "<div style='color:var(--text-color);font-size:1.2em;'>❤️ 🔁 💬</div>",
+                "<div style='color:var(--text-muted);font-size:1.2em;'>❤️ 🔁 💬</div>",
                 unsafe_allow_html=True,
             )
         else:
@@ -291,7 +291,7 @@ def render_post_card(post_data: dict[str, Any]) -> None:
             if username:
                 html_snippet += f"<div><strong>{html.escape(username)}</strong></div>"
             html_snippet += f"<p>{html.escape(text)}</p>"
-            html_snippet += f"<div style='color:var(--text-color);font-size:1.2em;'>❤️ {likes} 🔁 💬</div>"
+            html_snippet += f"<div style='color:var(--text-muted);font-size:1.2em;'>❤️ {likes} 🔁 💬</div>"
             html_snippet += "</div>"
             getattr(st, "markdown", lambda *a, **k: None)(html_snippet, unsafe_allow_html=True)
         return
@@ -314,7 +314,7 @@ def render_post_card(post_data: dict[str, Any]) -> None:
                 ui.element("div", reaction).classes("text-center text-lg")
             else:
                 getattr(st, "markdown", lambda *a, **k: None)(
-                    f"<div style='color:var(--text-color);font-size:1.2em;'>{reaction}</div>",
+                    f"<div style='color:var(--text-muted);font-size:1.2em;'>{reaction}</div>",
                     unsafe_allow_html=True,
                 )
     except Exception as exc:  # noqa: BLE001
@@ -339,7 +339,7 @@ def render_post_card(post_data: dict[str, Any]) -> None:
         write_fn(text)
         getattr(st, "caption", write_fn)(f"❤️ {likes}")
         getattr(st, "markdown", lambda *a, **k: None)(
-            "<div style='color:var(--text-color);font-size:1.2em;'>❤️ 🔁 💬</div>",
+            "<div style='color:var(--text-muted);font-size:1.2em;'>❤️ 🔁 💬</div>",
             unsafe_allow_html=True,
         )
 


### PR DESCRIPTION
## Summary
- use `'Inter', sans-serif` everywhere the font stack was defined
- swap hardcoded colors in `modern_ui.py` for CSS variables
- update the profile card stylesheet to use theme vars
- rely on variables in UI layout and components
- align helpers with `--text-muted` variable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d1dd2b078832093654ac594fefad2