### PR TITLE
Consolidate theme utilities

### DIFF
--- a/frontend/__init__.py
+++ b/frontend/__init__.py
@@ -1,11 +1,10 @@
 """Convenience exports for frontend utilities."""
 
-from .theme import apply_theme, set_theme, inject_modern_styles, get_accent_color
+from .theme import apply_theme, inject_modern_styles, get_accent_color
 from .assets import story_css, story_js, reaction_css, scroll_js
 
 __all__ = [
     "apply_theme",
-    "set_theme",
     "inject_modern_styles",
     "get_accent_color",
     "story_css",

--- a/frontend/theme.py
+++ b/frontend/theme.py
@@ -15,6 +15,7 @@ class ColorTheme:
     bg: str
     card: str
     accent: str
+    text: str
     text_muted: str
     radius: str = "1rem"
     transition: str = "0.4s ease"
@@ -25,6 +26,7 @@ class ColorTheme:
             f"--bg: {self.bg};",
             f"--card: {self.card};",
             f"--accent: {self.accent};",
+            f"--text: {self.text};",
             f"--text-muted: {self.text_muted};",
             f"--radius: {self.radius};",
             f"--transition: {self.transition};",
@@ -36,12 +38,14 @@ LIGHT_THEME = ColorTheme(
     bg="#F0F2F6",
     card="#FFFFFF",
     accent="#0077B5",        # LinkedIn-blue accent
+    text="#000000",
     text_muted="#666666",
 )
 DARK_THEME = ColorTheme(
     bg="#0A0F14",
     card="rgba(255,255,255,0.05)",
     accent="#00E5FF",        # Neon cyan
+    text="#FFFFFF",
     text_muted="#AAAAAA",
 )
 
@@ -75,6 +79,7 @@ def get_global_css(theme: bool | str = True) -> str:
 
 body {{
     background: var(--bg) !important;
+    color: var(--text);
     font-family: 'Inter', sans-serif;
     transition: background var(--transition);
 }}
@@ -165,19 +170,6 @@ def inject_modern_styles(theme: bool | str = True) -> None:
     st.session_state["_styles_injected"] = True
 
 
-def set_theme(name: str) -> None:
-    """Store ``name`` in session state and apply CSS once."""
-    mode = _resolve_mode(name)
-    if st.session_state.get("_theme") == mode and st.session_state.get("_styles_injected"):
-        return
-
-    st.session_state["_theme"] = mode
-
-    if st.session_state.get("_styles_injected"):
-        apply_theme(mode)
-    else:
-        inject_modern_styles(mode)
-
 
 def get_accent_color() -> str:
     """Return the accent color for the current theme."""
@@ -186,7 +178,6 @@ def get_accent_color() -> str:
 
 __all__ = [
     "apply_theme",
-    "set_theme",
     "inject_modern_styles",
     "get_accent_color",
 ]

--- a/social_tabs.py
+++ b/social_tabs.py
@@ -3,7 +3,7 @@
 # Legal & Ethical Safeguards
 import asyncio
 import streamlit as st
-from frontend.theme import set_theme
+from frontend.theme import apply_theme
 from streamlit_helpers import (
     alert,
     safe_container,
@@ -70,7 +70,7 @@ def _load_profile(username: str) -> tuple[dict, dict, dict]:
     return user, followers, following
 
 
-set_theme("light")
+apply_theme("light")
 
 
 

--- a/streamlit_helpers.py
+++ b/streamlit_helpers.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import html
 from contextlib import nullcontext
 from typing import Any, ContextManager, Literal
-from frontend.theme import set_theme
+from frontend.theme import apply_theme
 
 _FAKE_SESSION: dict[str, Any] = {}
 import inspect
@@ -481,7 +481,7 @@ def theme_selector(label: str = "Theme", *, key_suffix: str | None = None) -> st
     _safe_session_set(theme_key, chosen)
     _safe_session_set("theme",    chosen)          # keep global alias
 
-    set_theme(chosen)
+    apply_theme(chosen)
 
     try:                                           # Streamlit ≥1.29
         st.query_params["theme"] = chosen
@@ -511,7 +511,7 @@ def theme_toggle(label: str = "Dark Mode", *, key_suffix: str | None = None) -> 
     st.session_state[theme_key] = chosen
     st.session_state["theme"] = chosen
 
-    set_theme(chosen)
+    apply_theme(chosen)
 
     try:
         st.query_params["theme"] = chosen
@@ -607,7 +607,7 @@ __all__ = [
     "render_instagram_grid",
     "render_mock_feed",
     "sanitize_text",
-    "set_theme",
+    "apply_theme",
     "theme_selector",
     "theme_toggle",
     "get_active_user",

--- a/tests/test_ui_pages.py
+++ b/tests/test_ui_pages.py
@@ -86,7 +86,7 @@ def test_unknown_page_triggers_fallback(monkeypatch):
     monkeypatch.setattr(st, "query_params", {})
 
     for helper in [
-        "set_theme",
+        "apply_theme",
         "inject_modern_styles",
         "render_status_icon",
         "render_simulation_stubs",
@@ -159,7 +159,7 @@ def test_main_defaults_to_validation(monkeypatch):
 
 
     for helper in [
-        "set_theme",
+        "apply_theme",
         "inject_modern_styles",
         "render_status_icon",
         "render_simulation_stubs",

--- a/transcendental_resonance_frontend/pages/agents.py
+++ b/transcendental_resonance_frontend/pages/agents.py
@@ -3,7 +3,7 @@
 # Legal & Ethical Safeguards
 
 import streamlit as st
-from frontend.theme import set_theme
+from frontend.theme import apply_theme
 from modern_ui import inject_modern_styles
 
 from agent_ui import render_agent_insights_tab
@@ -11,7 +11,7 @@ from streamlit_helpers import theme_toggle
 
 __all__ = ["main", "render"]
 
-set_theme("light")
+apply_theme("light")
 inject_modern_styles()
 
 

--- a/transcendental_resonance_frontend/pages/chat.py
+++ b/transcendental_resonance_frontend/pages/chat.py
@@ -4,13 +4,13 @@
 """Chat page with text, video, and voice features."""
 
 import streamlit as st
-from frontend.theme import set_theme
+from frontend.theme import apply_theme
 from modern_ui import inject_modern_styles
 from streamlit_helpers import safe_container, header, theme_toggle
 from status_indicator import render_status_icon
 from chat_ui import render_chat_interface
 
-set_theme("light")
+apply_theme("light")
 inject_modern_styles()
 
 

--- a/transcendental_resonance_frontend/pages/feed.py
+++ b/transcendental_resonance_frontend/pages/feed.py
@@ -11,7 +11,7 @@ from typing import List, Dict, Any
 import random
 import streamlit as st
 
-from frontend.theme import set_theme
+from frontend.theme import apply_theme
 from modern_ui import inject_modern_styles
 from streamlit_helpers import theme_toggle, safe_container, sanitize_text
 
@@ -208,7 +208,7 @@ def _load_more_posts() -> None:
 # Page entrypoints
 # ──────────────────────────────────────────────────────────────────────────────
 
-set_theme("light")
+apply_theme("light")
 inject_modern_styles()
 
 

--- a/transcendental_resonance_frontend/pages/messages.py
+++ b/transcendental_resonance_frontend/pages/messages.py
@@ -6,12 +6,12 @@
 from __future__ import annotations
 
 import streamlit as st
-from frontend.theme import set_theme
+from frontend.theme import apply_theme
 from modern_ui import inject_modern_styles
 from streamlit_helpers import theme_toggle
 from transcendental_resonance_frontend.ui.chat_ui import render_chat_ui
 
-set_theme("light")
+apply_theme("light")
 inject_modern_styles()
 
 

--- a/transcendental_resonance_frontend/pages/messages_center.py
+++ b/transcendental_resonance_frontend/pages/messages_center.py
@@ -9,14 +9,14 @@ from __future__ import annotations
 
 import asyncio
 import streamlit as st
-from frontend.theme import set_theme
+from frontend.theme import apply_theme
 from modern_ui import inject_modern_styles
 from streamlit_helpers import safe_container, theme_toggle
 from status_indicator import render_status_icon
 from transcendental_resonance_frontend.src.utils import api
 
 # ─── Apply global styles ────────────────────────────────────────────────────────
-set_theme("light")
+apply_theme("light")
 inject_modern_styles()
 
 # ─── Dummy data ────────────────────────────────────────────────────────────────

--- a/transcendental_resonance_frontend/pages/profile.py
+++ b/transcendental_resonance_frontend/pages/profile.py
@@ -4,7 +4,7 @@
 """User identity hub with profile and activity overview."""
 
 import streamlit as st
-from frontend.theme import set_theme
+from frontend.theme import apply_theme
 from modern_ui import inject_modern_styles
 from streamlit_helpers import (
     safe_container,
@@ -80,7 +80,7 @@ def _fetch_social(username: str) -> tuple[dict, dict]:
         )
     return followers or {}, following or {}
 
-set_theme("light")
+apply_theme("light")
 inject_modern_styles()
 ensure_active_user()
 

--- a/transcendental_resonance_frontend/pages/resonance_music.py
+++ b/transcendental_resonance_frontend/pages/resonance_music.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 import requests
 import streamlit as st
-from frontend.theme import set_theme
+from frontend.theme import apply_theme
 from modern_ui import inject_modern_styles
 from streamlit_helpers import (
     alert,
@@ -27,7 +27,7 @@ from status_indicator import render_status_icon, check_backend # Ensure check_ba
 from transcendental_resonance_frontend.src.utils.api import get_resonance_summary, dispatch_route # Import get_resonance_summary and dispatch_route from utils.api
 
 
-set_theme("light")
+apply_theme("light")
 inject_modern_styles()
 
 # BACKEND_URL is defined in utils.api, but we keep it here for direct requests calls if needed

--- a/transcendental_resonance_frontend/pages/social.py
+++ b/transcendental_resonance_frontend/pages/social.py
@@ -4,14 +4,14 @@
 """Friends & Followers page."""
 
 import streamlit as st
-from frontend.theme import set_theme
+from frontend.theme import apply_theme
 from modern_ui import inject_modern_styles
 
 from social_tabs import render_social_tab
 from streamlit_helpers import safe_container, render_mock_feed, theme_toggle
 from feed_renderer import render_feed
 
-set_theme("light")
+apply_theme("light")
 inject_modern_styles()
 
 

--- a/transcendental_resonance_frontend/pages/validation.py
+++ b/transcendental_resonance_frontend/pages/validation.py
@@ -5,7 +5,7 @@
 
 import importlib
 import streamlit as st
-from frontend.theme import set_theme
+from frontend.theme import apply_theme
 from modern_ui import inject_modern_styles
 
 from streamlit_helpers import safe_container, theme_toggle
@@ -27,7 +27,7 @@ def _load_render_ui():
 render_validation_ui = _load_render_ui()
 
 # Inject modern global styles (safe when running in classic Streamlit)
-set_theme("light")
+apply_theme("light")
 inject_modern_styles()
 
 # --------------------------------------------------------------------

--- a/transcendental_resonance_frontend/pages/video_chat.py
+++ b/transcendental_resonance_frontend/pages/video_chat.py
@@ -6,7 +6,7 @@ import asyncio
 import json
 
 import streamlit as st
-from frontend.theme import set_theme
+from frontend.theme import apply_theme
 from modern_ui import inject_modern_styles
 
 
@@ -14,7 +14,7 @@ from ai_video_chat import create_session
 from video_chat_router import ConnectionManager
 from streamlit_helpers import safe_container, header, theme_toggle
 
-set_theme("light")
+apply_theme("light")
 inject_modern_styles()
 
 

--- a/transcendental_resonance_frontend/pages/voting.py
+++ b/transcendental_resonance_frontend/pages/voting.py
@@ -4,13 +4,13 @@
 """Governance and voting page."""
 
 import streamlit as st
-from frontend.theme import set_theme
+from frontend.theme import apply_theme
 from modern_ui import inject_modern_styles
 
 from voting_ui import render_voting_tab
 from streamlit_helpers import safe_container, theme_toggle
 
-set_theme("light")
+apply_theme("light")
 inject_modern_styles()
 
 

--- a/transcendental_resonance_frontend/src/utils/styles.py
+++ b/transcendental_resonance_frontend/src/utils/styles.py
@@ -1,7 +1,7 @@
 """Styling utilities for the Transcendental Resonance frontend."""
 
 from typing import Dict, Optional
-from frontend.theme import set_theme as _st_set_theme
+from frontend.theme import apply_theme as _st_set_theme
 
 try:
     from nicegui import ui  # type: ignore
@@ -123,7 +123,7 @@ def set_theme(name: str) -> None:
     """Switch the active theme and reapply global styles.
 
     This wrapper updates local theme tracking and delegates to
-    :func:`frontend.theme.set_theme` for CSS injection.
+    :func:`frontend.theme.apply_theme` for CSS injection.
     """
     global ACTIVE_THEME_NAME, ACTIVE_ACCENT
     ACTIVE_THEME_NAME = name if name in THEMES else "dark"

--- a/ui.py
+++ b/ui.py
@@ -324,7 +324,6 @@ from streamlit_helpers import (
     render_instagram_grid,
 )
 
-from frontend.theme import set_theme
 from frontend.theme import apply_theme
 
 
@@ -1497,7 +1496,7 @@ def main() -> None:
 
     # Simple light theme fallback
     try:
-        set_theme("light")
+        apply_theme("light")
     except Exception:  # pragma: no cover
         pass
 
@@ -1548,7 +1547,7 @@ def main() -> None:
         return
 
     try:
-        set_theme("light")
+        apply_theme("light")
 
 
         # Inject keyboard shortcuts for quick navigation
@@ -1605,7 +1604,7 @@ def main() -> None:
             return
 
         try:
-            set_theme(st.session_state.get("theme", "light"))
+            apply_theme(st.session_state.get("theme", "light"))
         except Exception as exc:
             st.warning(f"Theme load failed: {exc}")
 


### PR DESCRIPTION
## Summary
- consolidate theme helpers into a single `apply_theme`
- update all imports and calls to use `apply_theme`
- expose `apply_theme`, `inject_modern_styles` and `get_accent_color` from `frontend`
- ensure Inter is the default font and provide `--text` CSS variable

## Testing
- `pytest -k theme -q`
- `pytest tests/test_theme.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688d1dc384d4832083d964e1cdf6fb6e