### PR TITLE
Centralize font loading and color vars

### DIFF
--- a/frontend/profile_card.py
+++ b/frontend/profile_card.py
@@ -38,7 +38,7 @@ _CSS = """
 .pc-actions{display:flex;gap:.6rem;flex-wrap:wrap;justify-content:center}
 .pc-btn{flex:1 1 120px;padding:.45rem .8rem;border:none;
   border-radius:.65rem;background:rgba(255,255,255,.09);
-  color:#fff;font-size:.85rem;cursor:pointer;
+  color:var(--text);font-size:.85rem;cursor:pointer;
   transition:background .2s ease}
 .pc-btn:hover{background:rgba(255,255,255,.18)}
 @media(max-width:400px){.pc-wrapper{max-width:100%}}

--- a/frontend/theme.py
+++ b/frontend/theme.py
@@ -15,6 +15,7 @@ class ColorTheme:
     bg: str
     card: str
     accent: str
+    text: str
     text_muted: str
     radius: str = "1rem"
     transition: str = "0.4s ease"
@@ -25,6 +26,7 @@ class ColorTheme:
             f"--bg: {self.bg};",
             f"--card: {self.card};",
             f"--accent: {self.accent};",
+            f"--text: {self.text};",
             f"--text-muted: {self.text_muted};",
             f"--radius: {self.radius};",
             f"--transition: {self.transition};",
@@ -36,12 +38,14 @@ LIGHT_THEME = ColorTheme(
     bg="#F0F2F6",
     card="#FFFFFF",
     accent="#0077B5",        # LinkedIn-blue accent
+    text="#000000",
     text_muted="#666666",
 )
 DARK_THEME = ColorTheme(
     bg="#0A0F14",
     card="rgba(255,255,255,0.05)",
     accent="#00E5FF",        # Neon cyan
+    text="#FFFFFF",
     text_muted="#AAAAAA",
 )
 
@@ -68,14 +72,17 @@ def get_global_css(theme: bool | str = True) -> str:
     # resolve the theme into “light” or “dark”
     resolved = "dark" if theme is True else theme or "light"
     theme_obj = get_theme(resolved)
-    return f"""<style>
+    return f"""<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+<style>
 :root {{
     {theme_obj.css_vars()}
+    --font-family: 'Inter', sans-serif;
 }}
 
 body {{
     background: var(--bg) !important;
-    font-family: 'Inter', sans-serif;
+    color: var(--text);
+    font-family: var(--font-family);
     transition: background var(--transition);
 }}
 
@@ -150,7 +157,7 @@ def inject_modern_styles(theme: bool | str = True) -> None:
         transition: transform 0.2s ease;
     }
     .insta-btn {
-        background: linear-gradient(45deg, #F58529, #DD2A7B, #8134AF);
+        background: var(--accent);
     }
     .linkedin-btn {
         background: var(--accent);

--- a/frontend/ui_layout.py
+++ b/frontend/ui_layout.py
@@ -66,7 +66,7 @@ DRAWER_CSS = """
 [data-testid='stSidebar']{background:var(--card);border-right:1px solid rgba(255,255,255,0.1);transition:transform 0.3s ease;z-index:1002;}
 [data-testid='stSidebar'].collapsed{transform:translateX(-100%);}
 @media(min-width:768px){[data-testid='stSidebar']{transform:none!important;}}
-#drawer_btn{display:none;background:none;border:none;color:#fff;font-size:1.3rem;cursor:pointer;}
+#drawer_btn{display:none;background:none;border:none;color:var(--text);font-size:1.3rem;cursor:pointer;}
 @media(max-width:768px){#drawer_btn{display:block;}}
 </style>
 """
@@ -202,13 +202,13 @@ def render_top_bar() -> None:
   border:1px solid rgba(255,255,255,.25);min-width:140px;
   background:rgba(255,255,255,.90);font-size:.9rem;
 }
-#drawer_btn{background:none;border:none;color:#fff;font-size:1.3rem;cursor:pointer;display:none}
+#drawer_btn{background:none;border:none;color:var(--text);font-size:1.3rem;cursor:pointer;display:none}
 @media(max-width:768px){#drawer_btn{display:block}}
-.sn-bell{position:relative;background:none;border:none;font-size:1.3rem;color:#fff;cursor:pointer}
+.sn-bell{position:relative;background:none;border:none;font-size:1.3rem;color:var(--text);cursor:pointer}
 .sn-bell::before{font-family:"Font Awesome 6 Free";font-weight:900;content:"\\f0f3"}
 .sn-bell[data-count]::after{
   content:attr(data-count);position:absolute;top:-.35rem;right:-.45rem;
-  background:#ff4757;color:#fff;border-radius:999px;padding:0 .33rem;
+  background:var(--accent);color:var(--text);border-radius:999px;padding:0 .33rem;
   font-size:.62rem;line-height:1;
 }
 </style>
@@ -402,7 +402,7 @@ def show_preview_badge(text: str = "Preview") -> None:
     """Floating badge in the top-right corner."""
     st.markdown(
         f"<div style='position:fixed;top:1.1rem;right:1.1rem;"
-        f"background:#ffc107;color:#000;padding:.28rem .6rem;border-radius:6px;"
+        f"background:var(--accent);color:var(--text);padding:.28rem .6rem;border-radius:6px;"
         f"box-shadow:0 2px 6px rgba(0,0,0,.15);z-index:999'>"
         f"<i class='fa-solid fa-triangle-exclamation'></i>&nbsp;{text}</div>",
         unsafe_allow_html=True,

--- a/modern_ui.py
+++ b/modern_ui.py
@@ -40,15 +40,13 @@ def inject_modern_styles() -> None:
         return
 
     css = """
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <script type="module" src="/static/lucide-react.min.js"></script>
     <style>
     body, .stApp {
         background: var(--bg);
-        color: var(--text-muted);
-        font-family: 'Inter', sans-serif;
+        color: var(--text);
+        font-family: var(--font-family);
     }
     .card, .custom-container {
         background: var(--card);
@@ -97,13 +95,13 @@ def render_modern_header() -> None:
             backdrop-filter: blur(20px);
             padding: 1.5rem 2rem;
             margin: -2rem -3rem 3rem -3rem;
-            border-bottom: 1px solid rgba(74, 144, 226, 0.2);
+            border-bottom: 1px solid var(--accent);
             border-radius: 0 0 16px 16px;
         ">
             <div style="display: flex; align-items: center; justify-content: space-between;">
                 <div style="display: flex; align-items: center; gap: 1rem;">
                     <div style="
-                        background: linear-gradient(135deg, #4a90e2, #5ba0f2);
+                        background: var(--accent);
                         border-radius: 12px;
                         padding: 0.75rem;
                         display: flex;
@@ -113,19 +111,19 @@ def render_modern_header() -> None:
                         <span style="font-size: 1.5rem;">🚀</span>
                     </div>
                     <div>
-                        <h1 style="margin: 0; color: #ffffff; font-size: 1.75rem; font-weight: 700;">
+                        <h1 style="margin: 0; color: var(--text); font-size: 1.75rem; font-weight: 700;">
                             superNova_2177
                         </h1>
-                        <p style="margin: 0; color: #888; font-size: 0.9rem;">Validation Analyzer</p>
+                        <p style="margin: 0; color: var(--text-muted); font-size: 0.9rem;">Validation Analyzer</p>
                     </div>
                 </div>
                 <div style="display: flex; gap: 1rem; align-items: center;">
                     <div style="
-                        background: rgba(74, 144, 226, 0.1);
-                        border: 1px solid rgba(74, 144, 226, 0.3);
+                        background: var(--accent);
+                        border: 1px solid var(--accent);
                         border-radius: 8px;
                         padding: 0.5rem 1rem;
-                        color: #4a90e2;
+                        color: var(--accent);
                         font-size: 0.85rem;
                         font-weight: 500;
                     ">
@@ -192,7 +190,7 @@ def render_stats_section(stats: dict | None = None) -> None:
             margin-bottom: 0.25rem;
         }}
         .stats-label {{
-            color: #888;
+            color: var(--text-muted);
             font-size: calc(0.8rem + 0.2vw);
             font-weight: 500;
         }}

--- a/modern_ui_components.py
+++ b/modern_ui_components.py
@@ -95,10 +95,10 @@ SIDEBAR_STYLES = """
 .sidebar-nav .nav-item:hover {
     background: rgba(255, 255, 255, 0.05);
 }
-.sidebar-nav .nav-item.active {
-    background: var(--accent);
-    color: #fff;
-}
+    .sidebar-nav .nav-item.active {
+        background: var(--accent);
+        color: var(--text);
+    }
 </style>
 """
 
@@ -156,7 +156,6 @@ def render_modern_layout() -> None:
     inject_modern_styles()
     st.markdown(
         """
-        <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
         <style>
         .glass-card {
             background: rgba(255,255,255,0.3);
@@ -414,7 +413,7 @@ def render_stats_section(stats: dict) -> None:
             margin-bottom: 0.25rem;
         }}
         .stats-label {{
-            color: #888;
+            color: var(--text-muted);
             font-size: calc(0.8rem + 0.2vw);
             font-weight: 500;
         }}

--- a/streamlit_helpers.py
+++ b/streamlit_helpers.py
@@ -279,7 +279,7 @@ def render_post_card(post_data: dict[str, Any]) -> None:
             st.write(caption_text)
             getattr(st, "caption", st.write)(f"❤️ {likes}")
             getattr(st, "markdown", lambda *a, **k: None)(
-                "<div style='color:var(--text-color);font-size:1.2em;'>❤️ 🔁 💬</div>",
+                "<div style='color:var(--text);font-size:1.2em;'>❤️ 🔁 💬</div>",
                 unsafe_allow_html=True,
             )
         else:
@@ -291,7 +291,7 @@ def render_post_card(post_data: dict[str, Any]) -> None:
             if username:
                 html_snippet += f"<div><strong>{html.escape(username)}</strong></div>"
             html_snippet += f"<p>{html.escape(text)}</p>"
-            html_snippet += f"<div style='color:var(--text-color);font-size:1.2em;'>❤️ {likes} 🔁 💬</div>"
+            html_snippet += f"<div style='color:var(--text);font-size:1.2em;'>❤️ {likes} 🔁 💬</div>"
             html_snippet += "</div>"
             getattr(st, "markdown", lambda *a, **k: None)(html_snippet, unsafe_allow_html=True)
         return
@@ -314,7 +314,7 @@ def render_post_card(post_data: dict[str, Any]) -> None:
                 ui.element("div", reaction).classes("text-center text-lg")
             else:
                 getattr(st, "markdown", lambda *a, **k: None)(
-                    f"<div style='color:var(--text-color);font-size:1.2em;'>{reaction}</div>",
+                    f"<div style='color:var(--text);font-size:1.2em;'>{reaction}</div>",
                     unsafe_allow_html=True,
                 )
     except Exception as exc:  # noqa: BLE001
@@ -339,7 +339,7 @@ def render_post_card(post_data: dict[str, Any]) -> None:
         write_fn(text)
         getattr(st, "caption", write_fn)(f"❤️ {likes}")
         getattr(st, "markdown", lambda *a, **k: None)(
-            "<div style='color:var(--text-color);font-size:1.2em;'>❤️ 🔁 💬</div>",
+            "<div style='color:var(--text);font-size:1.2em;'>❤️ 🔁 💬</div>",
             unsafe_allow_html=True,
         )
 

--- a/transcendental_resonance_frontend/src/utils/styles.py
+++ b/transcendental_resonance_frontend/src/utils/styles.py
@@ -91,18 +91,14 @@ def apply_global_styles() -> None:
     theme = THEMES[ACTIVE_THEME_NAME].copy()
     theme["accent"] = ACTIVE_ACCENT
 
-    font_family = "'Inter', sans-serif"
-    font_link = "<link href=\"https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap\" rel=\"stylesheet\">"
+    font_family = "var(--font-family)"
+    font_link = ""
     if ACTIVE_THEME_NAME == "cyberpunk":
-        font_family = "'Orbitron', sans-serif"
-        font_link = (
-            "<link href=\"https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap\" rel=\"stylesheet\">"
-        )
+        font_family = "var(--font-family)"
+        font_link = ""
     elif ACTIVE_THEME_NAME == "codex":
-        font_family = "'Iosevka', monospace"
-        font_link = (
-            "<link href=\"https://fonts.googleapis.com/css2?family=Iosevka:wght@400;700&display=swap\" rel=\"stylesheet\">"
-        )
+        font_family = "var(--font-family)"
+        font_link = ""
 
     ui.add_head_html(
         f"""

--- a/transcendental_resonance_frontend/ui/profile_theme.css
+++ b/transcendental_resonance_frontend/ui/profile_theme.css
@@ -2,7 +2,7 @@
   max-width: 700px;
   margin: auto;
   padding: 1rem;
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-family);
 }
 .profile-header {}
 .profile-pic {


### PR DESCRIPTION
## Summary
- load Inter font via Google Fonts in theme CSS
- add `--font-family` and `--text` CSS vars
- replace inline fonts with `var(--font-family)`
- use global theme vars instead of hard-coded colors

## Testing
- `pip install --break-system-packages pytest pytest-asyncio`
- `pytest -q` *(fails: ImportError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_688d1dc635dc8320b7d2a85ddc2e445b