### PR TITLE
Use initialize_theme for unified theming

### DIFF
--- a/frontend/theme.py
+++ b/frontend/theme.py
@@ -186,6 +186,11 @@ def set_theme(name: str) -> None:
     inject_modern_styles(mode)
 
 
+def initialize_theme(name: bool | str = True) -> None:
+    """Initialize theme and styles in a single call."""
+    set_theme(name if isinstance(name, (str, bool)) else "light")
+
+
 
 def get_accent_color() -> str:
     """Return the accent color for the current theme."""
@@ -197,4 +202,5 @@ __all__ = [
     "set_theme",
     "inject_modern_styles",
     "get_accent_color",
+    "initialize_theme",
 ]

--- a/tests/test_ui_pages.py
+++ b/tests/test_ui_pages.py
@@ -86,8 +86,7 @@ def test_unknown_page_triggers_fallback(monkeypatch):
     monkeypatch.setattr(st, "query_params", {})
 
     for helper in [
-        "set_theme",
-        "inject_modern_styles",
+        "initialize_theme",
         "render_status_icon",
         "render_simulation_stubs",
         "render_stats_section",
@@ -159,8 +158,7 @@ def test_main_defaults_to_validation(monkeypatch):
 
 
     for helper in [
-        "set_theme",
-        "inject_modern_styles",
+        "initialize_theme",
         "render_status_icon",
         "render_simulation_stubs",
         "render_stats_section",

--- a/transcendental_resonance_frontend/pages/validation.py
+++ b/transcendental_resonance_frontend/pages/validation.py
@@ -5,7 +5,7 @@
 
 import importlib
 import streamlit as st
-from frontend.theme import set_theme
+from frontend.theme import initialize_theme
 from modern_ui import apply_modern_styles
 
 
@@ -28,7 +28,7 @@ def _load_render_ui():
 render_validation_ui = _load_render_ui()
 
 # Inject modern global styles (safe when running in classic Streamlit)
-set_theme("light")
+initialize_theme("light")
 apply_modern_styles()
 
 
@@ -46,9 +46,6 @@ def _page_decorator(func):
 @_page_decorator
 def main(main_container=None) -> None:
     """Render the validation UI inside a safe container."""
-    apply_theme("light")
-    inject_modern_styles()
-
     if main_container is None:
         main_container = st
     theme_toggle("Dark Mode", key_suffix="validation")

--- a/ui.py
+++ b/ui.py
@@ -324,8 +324,7 @@ from streamlit_helpers import (
     render_instagram_grid,
 )
 
-from frontend.theme import set_theme
-from frontend.theme import apply_theme, inject_modern_styles
+from frontend.theme import initialize_theme
 
 
 
@@ -490,13 +489,6 @@ def render_landing_page():
             if st.button("Run Validation", key="landing_run_validation"):
                 run_analysis([], layout="force")
         st.markdown("</div></div>", unsafe_allow_html=True)
-
-
-# Backward compatibility alias
-def inject_dark_theme() -> None:
-    """Legacy alias for inject_modern_styles()."""
-    inject_modern_styles()
-
 
 def load_page_with_fallback(choice: str, module_paths: list[str] | None = None) -> None:
     """Load a page via ``st.switch_page`` or fall back to importing the module with graceful handling."""
@@ -1481,12 +1473,6 @@ def main() -> None:
         # Older Streamlit builds (or re-runs) may raise – that’s OK.
         pass
 
-    # Simple light theme fallback
-    try:
-        set_theme("light")
-    except Exception:  # pragma: no cover
-        pass
-
     # Global CSS for cards / clean background
     st.markdown(
         """<style>
@@ -1534,8 +1520,6 @@ def main() -> None:
         return
 
     try:
-        set_theme("light")
-
 
         # Inject keyboard shortcuts for quick navigation
         st.markdown(
@@ -1558,11 +1542,6 @@ def main() -> None:
             """,
             unsafe_allow_html=True,
         )
-        try:
-            inject_modern_styles()
-        except Exception as exc:
-            logger.warning("CSS load failed: %s", exc)
-
         # Initialize session state
         defaults = {
             "session_start_ts": datetime.now(timezone.utc).isoformat(
@@ -1590,10 +1569,7 @@ def main() -> None:
                 st.rerun()
             return
 
-        try:
-            set_theme(st.session_state.get("theme", "light"))
-        except Exception as exc:
-            st.warning(f"Theme load failed: {exc}")
+        initialize_theme(st.session_state.get("theme", "light"))
 
         st.markdown(
             f"""


### PR DESCRIPTION
## Summary
- Replace legacy theme helpers in `ui.py` with new `initialize_theme` and call it once per session
- Add `initialize_theme` helper to `frontend.theme` and export it
- Update validation page and tests to use the new initializer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d65b6b4e083208c1a433c6157f68b