### PR TITLE
Use initialize_theme in theme tests

### DIFF
--- a/frontend/theme.py
+++ b/frontend/theme.py
@@ -23,33 +23,32 @@ class ColorTheme:
 
     def css_vars(self) -> str:
         """Return CSS variable declarations for this theme."""
-        return "\n    ".join([
-            f"--bg: {self.bg};",
-            f"--card: {self.card};",
-            f"--accent: {self.accent};",
-            f"--text: {self.text};",
-            f"--text-muted: {self.text_muted};",
-            f"--radius: {self.radius};",
-            f"--transition: {self.transition};",
-        ])
-
+        return "\n    ".join(
+            [
+                f"--bg: {self.bg};",
+                f"--card: {self.card};",
+                f"--accent: {self.accent};",
+                f"--text: {self.text};",
+                f"--text-muted: {self.text_muted};",
+                f"--radius: {self.radius};",
+                f"--transition: {self.transition};",
+            ]
+        )
 
 
 # Modern “light” and “dark” palettes
 LIGHT_THEME = ColorTheme(
     bg="#F0F2F6",
     card="#FFFFFF",
-    accent="#0077B5",        # LinkedIn-blue accent
+    accent="#0077B5",  # LinkedIn-blue accent
     text="#222222",
-
     text_muted="#666666",
 )
 DARK_THEME = ColorTheme(
     bg="#0A0F14",
     card="rgba(255,255,255,0.05)",
-    accent="#00E5FF",        # Neon cyan
+    accent="#00E5FF",  # Neon cyan
     text="#FFFFFF",
-
     text_muted="#AAAAAA",
 )
 
@@ -77,7 +76,9 @@ def get_global_css(theme: bool | str = True) -> str:
     resolved = "dark" if theme is True else theme or "light"
     theme_obj = get_theme(resolved)
     return f"""<link rel="preconnect" href="https://fonts.googleapis.com">
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+<link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap"
+    rel="stylesheet">
 <style>
 :root {{
     {theme_obj.css_vars()}
@@ -139,7 +140,9 @@ def inject_modern_styles(theme: bool | str = True) -> None:
 
     extra = """
     <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+    <link
+        href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap"
+        rel="stylesheet">
     <style>
     /* Glassmorphic cards */
     .glass-card {
@@ -186,6 +189,10 @@ def set_theme(name: str) -> None:
     inject_modern_styles(mode)
 
 
+def initialize_theme(mode: bool | str = True) -> None:
+    """Initialize the app theme and inject styles once."""
+    inject_modern_styles(mode)
+
 
 def get_accent_color() -> str:
     """Return the accent color for the current theme."""
@@ -197,4 +204,5 @@ __all__ = [
     "set_theme",
     "inject_modern_styles",
     "get_accent_color",
+    "initialize_theme",
 ]

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -10,7 +10,8 @@ root = Path(__file__).resolve().parents[1]
 if str(root) not in sys.path:
     sys.path.insert(0, str(root))
 
-import frontend.theme as theme
+import frontend.theme as theme  # noqa: E402
+
 
 def test_theme_application_and_idempotent_styles(monkeypatch):
     calls = []
@@ -21,16 +22,13 @@ def test_theme_application_and_idempotent_styles(monkeypatch):
     dummy_st = types.SimpleNamespace(markdown=dummy_markdown, session_state={})
     monkeypatch.setattr(theme, "st", dummy_st)
 
-    theme.apply_theme("light")
+    theme.initialize_theme("light")
     assert dummy_st.session_state["_theme"] == "light"
     assert theme.get_accent_color() == theme.LIGHT_THEME.accent
 
-    theme.apply_theme("dark")
+    theme.initialize_theme("dark")
     assert dummy_st.session_state["_theme"] == "dark"
     assert theme.get_accent_color() == theme.DARK_THEME.accent
-
-    theme.inject_modern_styles()
-    theme.inject_modern_styles()
 
     extra_css_calls = [c for c in calls if "Glassmorphic" in c]
     assert len(extra_css_calls) == 1


### PR DESCRIPTION
## Summary
- add initialize_theme helper to wrap style injection
- update theme tests to use initialize_theme and ensure idempotent CSS injection

## Testing
- `pre-commit run --files frontend/theme.py tests/test_theme.py`
- `pytest tests/test_theme.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688d65b5d45c83209cd6e77b7633ccc9