### PR TITLE
Handle missing session state and accent color

### DIFF
--- a/frontend/ui_layout.py
+++ b/frontend/ui_layout.py
@@ -453,9 +453,21 @@ def show_preview_badge(text: str = "Preview") -> None:
 
 def render_bottom_tab_bar(position: str = "fixed") -> None:
     """Bottom navigation bar for mobile screens."""
-    accent = theme.get_accent_color()
-    active = st.session_state.get("active_page", "home")
-    position = st.session_state.get("tab_bar_position", "bottom")
+    try:
+        accent = theme.get_accent_color()
+    except Exception:
+        accent = "#0077B5"
+
+    try:
+        active = st.session_state.get("active_page", "home")
+    except Exception:
+        active = "home"
+
+    try:
+        position = st.session_state.get("tab_bar_position", "bottom")
+    except Exception:
+        position = "bottom"
+
     st.markdown(
         BOTTOM_TAB_TEMPLATE.format(accent=accent, active=active, position=position),
         unsafe_allow_html=True,

--- a/modern_ui.py
+++ b/modern_ui.py
@@ -158,7 +158,10 @@ def render_validation_card() -> None:
 def render_stats_section(stats: dict | None = None) -> None:
     """Display quick stats using a responsive flexbox layout."""
 
-    accent = theme.get_accent_color()
+    try:
+        accent = theme.get_accent_color()
+    except Exception:
+        accent = "#0077B5"
 
     st.markdown(
         f"""

--- a/modern_ui_components.py
+++ b/modern_ui_components.py
@@ -389,8 +389,10 @@ def render_post_card(entry: dict) -> None:
 
 def render_stats_section(stats: dict) -> None:
     """Display quick stats using a responsive flexbox layout."""
-
-    accent = theme.get_accent_color()
+    try:
+        accent = theme.get_accent_color()
+    except Exception:
+        accent = "#0077B5"
 
     st.markdown(
         f"""


### PR DESCRIPTION
## Summary
- wrap accent color retrieval in try/except with a default color
- guard access to session state when determining active page and tab bar position

## Testing
- `pytest` *(fails: NameError: name 'apply_theme' is not defined, test_validation_page.py::test_validation_main_runs)*


------
https://chatgpt.com/codex/tasks/task_e_688d65b4e94c832083b6f4ab59ddbf8f