### PR TITLE
feat: centralize global style injection

### DIFF
--- a/frontend/__init__.py
+++ b/frontend/__init__.py
@@ -1,12 +1,19 @@
 """Convenience exports for frontend utilities."""
 
-from .theme import apply_theme, set_theme, inject_modern_styles, get_accent_color
+from .theme import (
+    apply_theme,
+    set_theme,
+    inject_modern_styles,
+    inject_global_styles,
+    get_accent_color,
+)
 from .assets import story_css, story_js, reaction_css, scroll_js
 
 __all__ = [
     "apply_theme",
     "set_theme",
     "inject_modern_styles",
+    "inject_global_styles",
     "get_accent_color",
     "story_css",
     "story_js",

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -10,7 +10,8 @@ root = Path(__file__).resolve().parents[1]
 if str(root) not in sys.path:
     sys.path.insert(0, str(root))
 
-import frontend.theme as theme
+import frontend.theme as theme  # noqa: E402
+
 
 def test_theme_application_and_idempotent_styles(monkeypatch):
     calls = []
@@ -21,16 +22,14 @@ def test_theme_application_and_idempotent_styles(monkeypatch):
     dummy_st = types.SimpleNamespace(markdown=dummy_markdown, session_state={})
     monkeypatch.setattr(theme, "st", dummy_st)
 
-    theme.apply_theme("light")
+    theme.inject_modern_styles("light")
     assert dummy_st.session_state["_theme"] == "light"
     assert theme.get_accent_color() == theme.LIGHT_THEME.accent
 
-    theme.apply_theme("dark")
+    # Second call switches theme but should not inject global styles again
+    theme.inject_modern_styles("dark")
     assert dummy_st.session_state["_theme"] == "dark"
     assert theme.get_accent_color() == theme.DARK_THEME.accent
 
-    theme.inject_modern_styles()
-    theme.inject_modern_styles()
-
-    extra_css_calls = [c for c in calls if "Glassmorphic" in c]
-    assert len(extra_css_calls) == 1
+    fa_calls = [c for c in calls if "font-awesome" in c.lower()]
+    assert len(fa_calls) == 1

--- a/tests/test_ui_pages.py
+++ b/tests/test_ui_pages.py
@@ -9,9 +9,10 @@ from pathlib import Path
 import sys
 
 import pytest
+
 pytest.importorskip("streamlit")
 pytestmark = pytest.mark.requires_streamlit
-import streamlit as st
+import streamlit as st  # noqa: E402
 
 # Ensure repository root is importable
 root = Path(__file__).resolve().parents[1]
@@ -21,6 +22,7 @@ if str(root) not in sys.path:
 # Provide a minimal stub for ``modern_ui`` to avoid syntax errors during import.
 stub_modern_ui = types.ModuleType("modern_ui")
 stub_modern_ui.inject_modern_styles = lambda *a, **k: None
+stub_modern_ui.apply_modern_styles = lambda *a, **k: None
 stub_modern_ui.render_stats_section = lambda *a, **k: None
 sys.modules.setdefault("modern_ui", stub_modern_ui)
 importlib.import_module("utils.paths")  # ensures namespace package is created
@@ -28,9 +30,8 @@ stub_page_registry = types.ModuleType("utils.page_registry")
 stub_page_registry.ensure_pages = lambda *a, **k: None
 sys.modules.setdefault("utils.page_registry", stub_page_registry)
 
-import frontend.ui_layout as ui_layout
-import modern_ui_components as mui
-import ui
+import modern_ui_components as mui  # noqa: E402
+import ui  # noqa: E402
 
 
 def test_unknown_page_triggers_fallback(monkeypatch):
@@ -38,8 +39,14 @@ def test_unknown_page_triggers_fallback(monkeypatch):
     importlib.reload(ui)
 
     fallback_called = {}
-    monkeypatch.setattr(ui, "_render_fallback", lambda choice: fallback_called.setdefault("choice", choice))
-    monkeypatch.setattr(ui, "load_page_with_fallback", lambda choice, paths: ui._render_fallback(choice))
+    monkeypatch.setattr(
+        ui,
+        "_render_fallback",
+        lambda choice: fallback_called.setdefault("choice", choice),
+    )
+    monkeypatch.setattr(
+        ui, "load_page_with_fallback", lambda choice, paths: ui._render_fallback(choice)
+    )
     monkeypatch.setattr(ui, "get_st_secrets", lambda: {})
     monkeypatch.setattr(mui, "render_modern_sidebar", lambda *a, **k: "Ghost")
     monkeypatch.setattr(ui, "render_modern_sidebar", lambda *a, **k: "Ghost")
@@ -47,12 +54,16 @@ def test_unknown_page_triggers_fallback(monkeypatch):
     class Dummy(contextlib.AbstractContextManager):
         def __enter__(self):
             return self
+
         def __exit__(self, *exc):
             return False
+
         def container(self):
             return Dummy()
+
         def expander(self, *a, **k):
             return Dummy()
+
         def tabs(self, labels):
             tab_calls.append(labels)
             return [Dummy() for _ in labels]
@@ -62,7 +73,9 @@ def test_unknown_page_triggers_fallback(monkeypatch):
     monkeypatch.setattr(st, "expander", lambda *a, **k: Dummy())
     monkeypatch.setattr(st, "container", lambda: Dummy())
     monkeypatch.setattr(st, "columns", lambda *a, **k: [Dummy(), Dummy(), Dummy()])
-    monkeypatch.setattr(st, "tabs", lambda labels: tab_calls.append(labels) or [Dummy() for _ in labels])
+    monkeypatch.setattr(
+        st, "tabs", lambda labels: tab_calls.append(labels) or [Dummy() for _ in labels]
+    )
     for fn in [
         "markdown",
         "info",
@@ -94,7 +107,9 @@ def test_unknown_page_triggers_fallback(monkeypatch):
     ]:
         monkeypatch.setattr(ui, helper, lambda *a, **k: None)
 
-    monkeypatch.setattr(ui, "render_api_key_ui", lambda *a, **k: {"model": "dummy", "api_key": ""})
+    monkeypatch.setattr(
+        ui, "render_api_key_ui", lambda *a, **k: {"model": "dummy", "api_key": ""}
+    )
 
     ui.main()
 
@@ -112,19 +127,28 @@ def test_main_defaults_to_validation(monkeypatch):
         lambda choice, paths: loaded.setdefault("choice", choice),
     )
     monkeypatch.setattr(ui, "get_st_secrets", lambda: {})
-    monkeypatch.setattr(mui, "render_modern_sidebar", lambda *a, **k: st.session_state.get("active_page"))
-    monkeypatch.setattr(ui, "render_modern_sidebar", lambda *a, **k: st.session_state.get("active_page"))
-
+    monkeypatch.setattr(
+        mui,
+        "render_modern_sidebar",
+        lambda *a, **k: st.session_state.get("active_page"),
+    )
+    monkeypatch.setattr(
+        ui, "render_modern_sidebar", lambda *a, **k: st.session_state.get("active_page")
+    )
 
     class Dummy(contextlib.AbstractContextManager):
         def __enter__(self):
             return self
+
         def __exit__(self, *exc):
             return False
+
         def container(self):
             return Dummy()
+
         def expander(self, *a, **k):
             return Dummy()
+
         def tabs(self, labels):
             return [Dummy() for _ in labels]
 
@@ -157,7 +181,6 @@ def test_main_defaults_to_validation(monkeypatch):
     params = {"page": "Unknown"}
     monkeypatch.setattr(st, "query_params", params)
 
-
     for helper in [
         "set_theme",
         "inject_modern_styles",
@@ -167,9 +190,15 @@ def test_main_defaults_to_validation(monkeypatch):
     ]:
         monkeypatch.setattr(ui, helper, lambda *a, **k: None)
 
-    monkeypatch.setattr(ui, "render_api_key_ui", lambda *a, **k: {"model": "dummy", "api_key": ""})
-    monkeypatch.setattr(mui, "render_modern_sidebar", lambda *a, **k: session.get("sidebar_nav"))
-    monkeypatch.setattr(ui, "render_modern_sidebar", lambda *a, **k: session.get("sidebar_nav"))
+    monkeypatch.setattr(
+        ui, "render_api_key_ui", lambda *a, **k: {"model": "dummy", "api_key": ""}
+    )
+    monkeypatch.setattr(
+        mui, "render_modern_sidebar", lambda *a, **k: session.get("sidebar_nav")
+    )
+    monkeypatch.setattr(
+        ui, "render_modern_sidebar", lambda *a, **k: session.get("sidebar_nav")
+    )
 
     ui.main()
 
@@ -201,13 +230,12 @@ def test_fallback_rendered_once(monkeypatch):
     assert called["count"] == 1
     assert "validation" in ui._fallback_rendered  # Use normalized slug form
 
+
 def test_render_stats_section_uses_flexbox(monkeypatch):
     """render_stats_section should output flexbox-based layout."""
     outputs = []
 
-    dummy_st = types.SimpleNamespace(
-        markdown=lambda html, **k: outputs.append(html)
-    )
+    dummy_st = types.SimpleNamespace(markdown=lambda html, **k: outputs.append(html))
 
     monkeypatch.setattr(mui, "st", dummy_st)
 
@@ -217,4 +245,3 @@ def test_render_stats_section_uses_flexbox(monkeypatch):
     combined = "\n".join(outputs)
     assert "stats-container" in combined
     assert "stats-card" in combined
-


### PR DESCRIPTION
## Summary
- add `inject_global_styles` to consolidate CSS variables, fonts and glassmorphic cards
- refactor theme helpers to delegate to `inject_global_styles`
- update tests for idempotent global style injection

## Testing
- `pre-commit run --files frontend/theme.py frontend/__init__.py tests/test_theme.py tests/test_ui_pages.py`
- `pytest tests/test_theme.py tests/test_ui_pages.py`


------
https://chatgpt.com/codex/tasks/task_e_688d6446f1fc832092a8ae9a8229fd01