### PR TITLE
refactor: reuse shared BOX_CSS

### DIFF
--- a/agent_ui.py
+++ b/agent_ui.py
@@ -4,7 +4,7 @@
 import json
 from pathlib import Path
 from datetime import datetime
-from typing import Any, cast
+from typing import cast
 
 import streamlit as st
 from streamlit_helpers import (
@@ -20,23 +20,8 @@ from voting_ui import (
     render_agent_ops_tab,
     render_logs_tab,
 )
-# Define BOX_CSS at the top of agent_ui.py or within the function if needed
-BOX_CSS = """
-<style>
-.tab-box {
-    padding: 1rem;
-    border-radius: 8px;
-    border: 1px solid #ddd;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.05);
-    margin-bottom: 1rem;
-    transition: box-shadow 0.2s ease, transform 0.2s ease;
-}
-.tab-box:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-}
-</style>
-"""
+from ui_utils import load_rfc_entries, summarize_text
+
 
 def render_agent_insights_tab(main_container=None) -> None:
     """Display diary, RFC summaries and internal notes."""
@@ -71,8 +56,11 @@ def render_agent_insights_tab(main_container=None) -> None:
             "Export Diary as Markdown",
             "\n".join(
                 [
-                    f"* {e['timestamp']}: {e.get('note', '')}" + (
-                        f" (RFCs: {', '.join(e['rfc_ids'])})" if e.get("rfc_ids") else ""
+                    f"* {e['timestamp']}: {e.get('note', '')}"
+                    + (
+                        f" (RFCs: {', '.join(e['rfc_ids'])})"
+                        if e.get("rfc_ids")
+                        else ""
                     )
                     for e in st.session_state.get("diary", [])
                 ]
@@ -95,7 +83,9 @@ def render_agent_insights_tab(main_container=None) -> None:
 
             rfc_entries, rfc_index = load_rfc_entries(rfc_dir)
 
-            diary_mentions: dict[str, list[int]] = {str(e["id"]): [] for e in rfc_entries}
+            diary_mentions: dict[str, list[int]] = {
+                str(e["id"]): [] for e in rfc_entries
+            }
             for i, entry in enumerate(st.session_state.get("diary", [])):
                 note_lower = entry.get("note", "").lower()
                 ids = {e.strip().lower() for e in entry.get("rfc_ids", []) if e}
@@ -155,12 +145,14 @@ def render_agent_insights_tab(main_container=None) -> None:
                 st.markdown(notes_content)
 
         if st.session_state.get("governance_view"):
-            tabs = st.tabs([
-                "Proposal Hub",
-                "Governance",
-                "Agent Ops",
-                "Logs",
-            ])
+            tabs = st.tabs(
+                [
+                    "Proposal Hub",
+                    "Governance",
+                    "Agent Ops",
+                    "Logs",
+                ]
+            )
             render_proposals_tab(main_container=tabs[0])
             render_governance_tab(main_container=tabs[1])
             render_agent_ops_tab(main_container=tabs[2])


### PR DESCRIPTION
## Summary
- remove local BOX_CSS definition from agent_ui
- rely on shared BOX_CSS from streamlit_helpers and import missing helpers

## Testing
- `pre-commit run --files agent_ui.py`
- `pytest` *(fails: NameError: name 'apply_theme' is not defined; assert 1 == 0)*

------
https://chatgpt.com/codex/tasks/task_e_688d6442f3708320b822440158fbfacb