### PR TITLE
Add RFC utilities import to agent UI

### DIFF
--- a/agent_ui.py
+++ b/agent_ui.py
@@ -14,6 +14,7 @@ from streamlit_helpers import (
     BOX_CSS,
     header,
 )
+from ui_utils import load_rfc_entries, summarize_text
 from voting_ui import (
     render_proposals_tab,
     render_governance_tab,


### PR DESCRIPTION
## Summary
- import `load_rfc_entries` and `summarize_text` from `ui_utils` in `agent_ui.py`

## Testing
- `python -m mypy --explicit-package-bases hypothesis_meta_evaluator.py causal_trigger.py introspection/introspection_pipeline.py`
- `pytest -q` *(fails: NameError: apply_theme not defined; test_validation_page_renders assertion error)*

------
https://chatgpt.com/codex/tasks/task_e_688d64462dfc83209a217af65efb95d1