### PR TITLE
refactor: consolidate theme and style application

### DIFF
--- a/transcendental_resonance.log
+++ b/transcendental_resonance.log
@@ -40,3 +40,51 @@ AttributeError: module 'bcrypt' has no attribute '__about__'
 2025-08-01 03:05:47,704 | WARNING | MainThread | Case-insensitive file collision for 'foo': Foo.py, foo.py (page_registry.py:83) | 감사합니다!
 2025-08-01 03:05:47,704 | WARNING | MainThread | Case-insensitive file collision for 'foo': Foo.py, foo.py (page_registry.py:83) | 감사합니다!
 2025-08-01 03:05:47,704 | WARNING | MainThread | Case-insensitive file collision for 'foo': Foo.py, foo.py (page_registry.py:83) | 감사합니다!
+2025-08-02 01:16:35,604 | WARNING | MainThread | (trapped) error reading bcrypt version (bcrypt.py:622) | 감사합니다!
+Traceback (most recent call last):
+  File "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/passlib/handlers/bcrypt.py", line 620, in _load_backend_mixin
+    version = _bcrypt.__about__.__version__
+              ^^^^^^^^^^^^^^^^^
+AttributeError: module 'bcrypt' has no attribute '__about__'
+2025-08-02 01:16:35,604 | WARNING | MainThread | (trapped) error reading bcrypt version (bcrypt.py:622) | 감사합니다!
+Traceback (most recent call last):
+  File "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/passlib/handlers/bcrypt.py", line 620, in _load_backend_mixin
+    version = _bcrypt.__about__.__version__
+              ^^^^^^^^^^^^^^^^^
+AttributeError: module 'bcrypt' has no attribute '__about__'
+2025-08-02 01:16:35,604 | WARNING | MainThread | (trapped) error reading bcrypt version (bcrypt.py:622) | 감사합니다!
+Traceback (most recent call last):
+  File "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/passlib/handlers/bcrypt.py", line 620, in _load_backend_mixin
+    version = _bcrypt.__about__.__version__
+              ^^^^^^^^^^^^^^^^^
+AttributeError: module 'bcrypt' has no attribute '__about__'
+2025-08-02 01:16:39,839 | WARNING | MainThread | Case-insensitive file collision for 'foo': Foo.py, foo.py (page_registry.py:83) | 감사합니다!
+2025-08-02 01:16:39,839 | WARNING | MainThread | Case-insensitive file collision for 'foo': Foo.py, foo.py (page_registry.py:83) | 감사합니다!
+2025-08-02 01:16:39,839 | WARNING | MainThread | Case-insensitive file collision for 'foo': Foo.py, foo.py (page_registry.py:83) | 감사합니다!
+2025-08-02 01:16:39,839 | WARNING | MainThread | Case-insensitive file collision for 'foo': Foo.py, foo.py (page_registry.py:83) | 감사합니다!
+2025-08-02 01:16:39,839 | WARNING | MainThread | Case-insensitive file collision for 'foo': Foo.py, foo.py (page_registry.py:83) | 감사합니다!
+2025-08-02 01:16:39,840 | INFO | MainThread | Removed duplicate page module Foo.py (page_registry.py:56) | 감사합니다!
+2025-08-02 01:16:39,840 | INFO | MainThread | Removed duplicate page module Foo.py (page_registry.py:56) | 감사합니다!
+2025-08-02 01:16:39,840 | INFO | MainThread | Removed duplicate page module Foo.py (page_registry.py:56) | 감사합니다!
+2025-08-02 01:16:39,840 | INFO | MainThread | Removed duplicate page module Foo.py (page_registry.py:56) | 감사합니다!
+2025-08-02 01:16:39,840 | INFO | MainThread | Removed duplicate page module Foo.py (page_registry.py:56) | 감사합니다!
+2025-08-02 01:16:39,842 | WARNING | MainThread | Case-insensitive file collision for 'foo': Foo.py, foo.py (page_registry.py:83) | 감사합니다!
+2025-08-02 01:16:39,842 | WARNING | MainThread | Case-insensitive file collision for 'foo': Foo.py, foo.py (page_registry.py:83) | 감사합니다!
+2025-08-02 01:16:39,842 | WARNING | MainThread | Case-insensitive file collision for 'foo': Foo.py, foo.py (page_registry.py:83) | 감사합니다!
+2025-08-02 01:16:39,842 | WARNING | MainThread | Case-insensitive file collision for 'foo': Foo.py, foo.py (page_registry.py:83) | 감사합니다!
+2025-08-02 01:16:39,842 | WARNING | MainThread | Case-insensitive file collision for 'foo': Foo.py, foo.py (page_registry.py:83) | 감사합니다!
+2025-08-02 01:16:39,845 | WARNING | MainThread | Case-insensitive file collision for 'foo': Foo.py, foo.py (page_registry.py:83) | 감사합니다!
+2025-08-02 01:16:39,845 | WARNING | MainThread | Case-insensitive file collision for 'foo': Foo.py, foo.py (page_registry.py:83) | 감사합니다!
+2025-08-02 01:16:39,845 | WARNING | MainThread | Case-insensitive file collision for 'foo': Foo.py, foo.py (page_registry.py:83) | 감사합니다!
+2025-08-02 01:16:39,845 | WARNING | MainThread | Case-insensitive file collision for 'foo': Foo.py, foo.py (page_registry.py:83) | 감사합니다!
+2025-08-02 01:16:39,845 | WARNING | MainThread | Case-insensitive file collision for 'foo': Foo.py, foo.py (page_registry.py:83) | 감사합니다!
+2025-08-02 01:16:39,845 | INFO | MainThread | Removed duplicate page module Foo.py (page_registry.py:56) | 감사합니다!
+2025-08-02 01:16:39,845 | INFO | MainThread | Removed duplicate page module Foo.py (page_registry.py:56) | 감사합니다!
+2025-08-02 01:16:39,845 | INFO | MainThread | Removed duplicate page module Foo.py (page_registry.py:56) | 감사합니다!
+2025-08-02 01:16:39,845 | INFO | MainThread | Removed duplicate page module Foo.py (page_registry.py:56) | 감사합니다!
+2025-08-02 01:16:39,845 | INFO | MainThread | Removed duplicate page module Foo.py (page_registry.py:56) | 감사합니다!
+2025-08-02 01:16:39,847 | WARNING | MainThread | Case-insensitive file collision for 'foo': Foo.py, foo.py (page_registry.py:83) | 감사합니다!
+2025-08-02 01:16:39,847 | WARNING | MainThread | Case-insensitive file collision for 'foo': Foo.py, foo.py (page_registry.py:83) | 감사합니다!
+2025-08-02 01:16:39,847 | WARNING | MainThread | Case-insensitive file collision for 'foo': Foo.py, foo.py (page_registry.py:83) | 감사합니다!
+2025-08-02 01:16:39,847 | WARNING | MainThread | Case-insensitive file collision for 'foo': Foo.py, foo.py (page_registry.py:83) | 감사합니다!
+2025-08-02 01:16:39,847 | WARNING | MainThread | Case-insensitive file collision for 'foo': Foo.py, foo.py (page_registry.py:83) | 감사합니다!

--- a/transcendental_resonance_frontend/pages/agents.py
+++ b/transcendental_resonance_frontend/pages/agents.py
@@ -3,17 +3,16 @@
 # Legal & Ethical Safeguards
 
 import streamlit as st
-from frontend.theme import set_theme
-from modern_ui import apply_modern_styles
+from frontend.theme import apply_theme
 
 
 from agent_ui import render_agent_insights_tab
-from streamlit_helpers import theme_toggle
+from streamlit_helpers import theme_toggle, inject_global_styles
 
 __all__ = ["main", "render"]
 
-set_theme("light")
-apply_modern_styles()
+apply_theme("light")
+inject_global_styles()
 
 
 
@@ -23,9 +22,6 @@ def main(main_container=None) -> None:
 
     If no main_container is provided, uses Streamlit root context.
     """
-    apply_theme("light")
-    inject_modern_styles()
-
     container = main_container if main_container is not None else st
     theme_toggle("Dark Mode", key_suffix="agents")
 

--- a/transcendental_resonance_frontend/pages/chat.py
+++ b/transcendental_resonance_frontend/pages/chat.py
@@ -4,22 +4,18 @@
 """Chat page with text, video, and voice features."""
 
 import streamlit as st
-from frontend.theme import set_theme
-from modern_ui import apply_modern_styles
+from frontend.theme import apply_theme
 
-from streamlit_helpers import safe_container, header, theme_toggle
+from streamlit_helpers import safe_container, header, theme_toggle, inject_global_styles
 from status_indicator import render_status_icon
 from chat_ui import render_chat_interface
 
-set_theme("light")
-apply_modern_styles()
+apply_theme("light")
+inject_global_styles()
 
 
 def main(main_container=None) -> None:
     """Render the chat page."""
-    apply_theme("light")
-    inject_modern_styles()
-
     if main_container is None:
         main_container = st
     page = "chat"

--- a/transcendental_resonance_frontend/pages/feed.py
+++ b/transcendental_resonance_frontend/pages/feed.py
@@ -11,13 +11,15 @@ from typing import List, Dict, Any
 import random
 import streamlit as st
 
-from frontend.theme import set_theme
-from modern_ui import apply_modern_styles
+from frontend.theme import apply_theme
 
-from streamlit_helpers import theme_toggle, safe_container, sanitize_text
+from streamlit_helpers import theme_toggle, safe_container, sanitize_text, inject_global_styles
 
 from modern_ui_components import st_javascript
 from frontend.assets import story_css, story_js, reaction_css, scroll_js
+
+apply_theme("light")
+inject_global_styles()
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Sample data models
@@ -209,10 +211,6 @@ def _load_more_posts() -> None:
 # Page entrypoints
 # ──────────────────────────────────────────────────────────────────────────────
 
-set_theme("light")
-apply_modern_styles()
-
-
 def _page_body() -> None:
     """Render the main feed inside the current container."""
     _init_state()
@@ -263,9 +261,6 @@ def _page_body() -> None:
 
 def main(main_container=None) -> None:
     """Render the feed inside ``main_container`` (or root Streamlit)."""
-    apply_theme("light")
-    inject_modern_styles()
-
     container = main_container or st
     with safe_container(container):
         _page_body()

--- a/transcendental_resonance_frontend/pages/messages.py
+++ b/transcendental_resonance_frontend/pages/messages.py
@@ -6,19 +6,16 @@
 from __future__ import annotations
 
 import streamlit as st
-from frontend.theme import set_theme
-from modern_ui import apply_modern_styles
-from streamlit_helpers import theme_toggle
+from frontend.theme import apply_theme
+from streamlit_helpers import theme_toggle, inject_global_styles
 from transcendental_resonance_frontend.ui.chat_ui import render_chat_ui
 
-set_theme("light")
-apply_modern_styles()
+apply_theme("light")
+inject_global_styles()
 
 
 def main(main_container=None) -> None:
     """Render the chat interface inside the given container (or the page itself)."""
-    apply_theme("light")
-    inject_modern_styles()
 
     theme_toggle("Dark Mode", key_suffix="messages")
     render_chat_ui(main_container)

--- a/transcendental_resonance_frontend/pages/messages_center.py
+++ b/transcendental_resonance_frontend/pages/messages_center.py
@@ -9,15 +9,14 @@ from __future__ import annotations
 
 import asyncio
 import streamlit as st
-from frontend.theme import set_theme
-from modern_ui import apply_modern_styles
-from streamlit_helpers import safe_container, theme_toggle
+from frontend.theme import apply_theme
+from streamlit_helpers import safe_container, theme_toggle, inject_global_styles
 from status_indicator import render_status_icon
 from transcendental_resonance_frontend.src.utils import api
 
 # ─── Apply global styles ────────────────────────────────────────────────────────
-set_theme("light")
-apply_modern_styles()
+apply_theme("light")
+inject_global_styles()
 
 # ─── Dummy data ────────────────────────────────────────────────────────────────
 DUMMY_CONVERSATIONS: dict[str, list[dict[str, str]]] = {
@@ -57,9 +56,6 @@ def send_message(target: str, text: str) -> None:
 
 # ─── Page Entrypoint ───────────────────────────────────────────────────────────
 def main(container: st.DeltaGenerator | None = None) -> None:
-    apply_theme("light")
-    inject_modern_styles()
-
     if container is None:
         container = st
 

--- a/transcendental_resonance_frontend/pages/profile.py
+++ b/transcendental_resonance_frontend/pages/profile.py
@@ -4,14 +4,14 @@
 """User identity hub with profile and activity overview."""
 
 import streamlit as st
-from frontend.theme import set_theme
-from modern_ui import apply_modern_styles
+from frontend.theme import apply_theme
 from streamlit_helpers import (
     safe_container,
     header,
     theme_toggle,
     get_active_user,
     ensure_active_user,
+    inject_global_styles,
 )
 from api_key_input import render_api_key_ui
 from social_tabs import _load_profile
@@ -80,8 +80,8 @@ def _fetch_social(username: str) -> tuple[dict, dict]:
         )
     return followers or {}, following or {}
 
-set_theme("light")
-apply_modern_styles()
+apply_theme("light")
+inject_global_styles()
 ensure_active_user()
 
 
@@ -114,8 +114,6 @@ def _render_profile(username: str) -> None:
 
 
 def main(main_container=None) -> None:
-    apply_theme("light")
-    inject_modern_styles()
 
     if main_container is None:
         main_container = st

--- a/transcendental_resonance_frontend/pages/resonance_music.py
+++ b/transcendental_resonance_frontend/pages/resonance_music.py
@@ -13,8 +13,7 @@ from pathlib import Path
 
 import requests
 import streamlit as st
-from frontend.theme import set_theme
-from modern_ui import apply_modern_styles
+from frontend.theme import apply_theme
 
 from streamlit_helpers import (
     alert,
@@ -22,14 +21,15 @@ from streamlit_helpers import (
     safe_container,
     header,
     theme_toggle,
+    inject_global_styles,
 )
 from streamlit_autorefresh import st_autorefresh
 from status_indicator import render_status_icon, check_backend # Ensure check_backend is imported
 from transcendental_resonance_frontend.src.utils.api import get_resonance_summary, dispatch_route # Import get_resonance_summary and dispatch_route from utils.api
 
 
-set_theme("light")
-apply_modern_styles()
+apply_theme("light")
+inject_global_styles()
 
 
 # BACKEND_URL is defined in utils.api, but we keep it here for direct requests calls if needed
@@ -75,9 +75,6 @@ def _run_async(coro):
 
 def main(main_container=None, status_container=None) -> None:
     """Render music generation and summary widgets."""
-
-    apply_theme("light")
-    inject_modern_styles()
 
     if main_container is None:
         main_container = st

--- a/transcendental_resonance_frontend/pages/social.py
+++ b/transcendental_resonance_frontend/pages/social.py
@@ -4,24 +4,20 @@
 """Friends & Followers page."""
 
 import streamlit as st
-from frontend.theme import set_theme
-from modern_ui import apply_modern_styles
+from frontend.theme import apply_theme
 
 
 from social_tabs import render_social_tab
-from streamlit_helpers import safe_container, render_mock_feed, theme_toggle
+from streamlit_helpers import safe_container, render_mock_feed, theme_toggle, inject_global_styles
 from feed_renderer import render_feed
 
-set_theme("light")
-apply_modern_styles()
+apply_theme("light")
+inject_global_styles()
 
 
 
 def main(main_container=None) -> None:
     """Render the social page content within ``main_container``."""
-    apply_theme("light")
-    inject_modern_styles()
-
     if main_container is None:
         main_container = st
     theme_toggle("Dark Mode", key_suffix="social")

--- a/transcendental_resonance_frontend/pages/validation.py
+++ b/transcendental_resonance_frontend/pages/validation.py
@@ -5,11 +5,10 @@
 
 import importlib
 import streamlit as st
-from frontend.theme import set_theme
-from modern_ui import apply_modern_styles
+from frontend.theme import apply_theme
 
 
-from streamlit_helpers import safe_container, theme_toggle
+from streamlit_helpers import safe_container, theme_toggle, inject_global_styles
 
 # --------------------------------------------------------------------
 # Dynamic loader with graceful degradation
@@ -27,9 +26,8 @@ def _load_render_ui():
 
 render_validation_ui = _load_render_ui()
 
-# Inject modern global styles (safe when running in classic Streamlit)
-set_theme("light")
-apply_modern_styles()
+apply_theme("light")
+inject_global_styles()
 
 
 # --------------------------------------------------------------------
@@ -46,8 +44,6 @@ def _page_decorator(func):
 @_page_decorator
 def main(main_container=None) -> None:
     """Render the validation UI inside a safe container."""
-    apply_theme("light")
-    inject_modern_styles()
 
     if main_container is None:
         main_container = st

--- a/transcendental_resonance_frontend/pages/video_chat.py
+++ b/transcendental_resonance_frontend/pages/video_chat.py
@@ -6,17 +6,16 @@ import asyncio
 import json
 
 import streamlit as st
-from frontend.theme import set_theme
-from modern_ui import apply_modern_styles
+from frontend.theme import apply_theme
 
 
 
 from ai_video_chat import create_session
 from video_chat_router import ConnectionManager
-from streamlit_helpers import safe_container, header, theme_toggle
+from streamlit_helpers import safe_container, header, theme_toggle, inject_global_styles
 
-set_theme("light")
-apply_modern_styles()
+apply_theme("light")
+inject_global_styles()
 
 
 def _run_async(coro):
@@ -36,8 +35,6 @@ manager = ConnectionManager()
 
 def main(main_container=None) -> None:
     """Render the simple video chat demo."""
-    apply_theme("light")
-    inject_modern_styles()
 
     container = main_container if main_container is not None else st
     theme_toggle("Dark Mode", key_suffix="video_chat")

--- a/transcendental_resonance_frontend/pages/voting.py
+++ b/transcendental_resonance_frontend/pages/voting.py
@@ -4,21 +4,18 @@
 """Governance and voting page."""
 
 import streamlit as st
-from frontend.theme import set_theme
-from modern_ui import apply_modern_styles
+from frontend.theme import apply_theme
 
 
 from voting_ui import render_voting_tab
-from streamlit_helpers import safe_container, theme_toggle
+from streamlit_helpers import safe_container, theme_toggle, inject_global_styles
 
-set_theme("light")
-apply_modern_styles()
+apply_theme("light")
+inject_global_styles()
 
 
 def main(main_container=None) -> None:
     """Render the Governance and Voting page inside ``main_container``."""
-    apply_theme("light")
-    inject_modern_styles()
 
     if main_container is None:
         main_container = st


### PR DESCRIPTION
## Summary
- streamline theme and style setup across Streamlit pages
- drop legacy `set_theme`/`inject_modern_styles` usage in favor of `apply_theme` and `inject_global_styles`
- remove obsolete `modern_ui` imports and ensure single initialization per page

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688d64497bf483208129a86e383b7844