### PR TITLE
Make bottom tab bar position configurable

### DIFF
--- a/frontend/ui_layout.py
+++ b/frontend/ui_layout.py
@@ -80,7 +80,7 @@ DRAWER_CSS = """
 BOTTOM_TAB_TEMPLATE = """
 <style>
 .sn-bottom-tabs{
-  position: fixed;
+  position: {position};
   bottom: 0;
   left: 0;
   right: 0;
@@ -105,7 +105,7 @@ BOTTOM_TAB_TEMPLATE = """
 }
 @media(min-width:768px){.sn-bottom-tabs{display:none!important;}}
 </style>
-<div class='sn-bottom-tabs {position}'>
+<div class='sn-bottom-tabs'>
   <a href='#' data-tag='home'><i class='fa-solid fa-house'></i></a>
   <a href='#' data-tag='video'><i class='fa-solid fa-video'></i></a>
   <a href='#' data-tag='network'><i class='fa-solid fa-user-group'></i></a>
@@ -452,12 +452,19 @@ def show_preview_badge(text: str = "Preview") -> None:
 
 
 def render_bottom_tab_bar(position: str = "fixed") -> None:
-    """Bottom navigation bar for mobile screens."""
+    """Bottom navigation bar for mobile screens.
+
+    Parameters
+    ----------
+    position : str
+        CSS ``position`` value for the tab bar (e.g., ``"fixed"`` or ``"static"``).
+    """
+
     accent = theme.get_accent_color()
     active = st.session_state.get("active_page", "home")
-    position = st.session_state.get("tab_bar_position", "bottom")
+    css_position = st.session_state.get("tab_bar_position", position)
     st.markdown(
-        BOTTOM_TAB_TEMPLATE.format(accent=accent, active=active, position=position),
+        BOTTOM_TAB_TEMPLATE.format(accent=accent, active=active, position=css_position),
         unsafe_allow_html=True,
     )
 


### PR DESCRIPTION
## Summary
- allow bottom tab bar CSS position to be set via template variable
- pass a valid CSS position value in `render_bottom_tab_bar`

## Testing
- `pre-commit run --files frontend/ui_layout.py`
- `pytest tests/test_modern_ui_components.py`
- `pytest` *(fails: NameError: name 'apply_theme' is not defined; assert 1 == 0)*


------
https://chatgpt.com/codex/tasks/task_e_688d650244508320aca88b1a3493e634