### PR TITLE
Add backend toggle for UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ pip install -r requirements.txt
 # python setup_env.py --launch-ui
 # or run manually with
 ./start.sh       # launches ui.py on port 8888
+# pass --real-backend or set USE_REAL_BACKEND=1 to sync with the backend
 streamlit run app.py  # launch the Streamlit server
 # or use the CLI directly
 
@@ -86,6 +87,7 @@ To launch the Streamlit UI:
 ```bash
 chmod +x start.sh
 ./start.sh  # launches ui.py
+# enable the real backend via ./start.sh --real-backend or USE_REAL_BACKEND=1
 streamlit run app.py  # same as above
 ```
 

--- a/docs/tasks/video_chat_translation_plan.md
+++ b/docs/tasks/video_chat_translation_plan.md
@@ -56,7 +56,7 @@ The module aims to provide video chat with live translation, lip-sync overlays, 
    ```
 4. Launch the Streamlit UI and open the **Video Chat** page:
    ```bash
-   streamlit run ui.py
+     USE_REAL_BACKEND=1 streamlit run ui.py
    ```
 5. Click **Start Session** to begin a call and choose the target language for
    live subtitles and voice.

--- a/docs/ui_backend_sync.md
+++ b/docs/ui_backend_sync.md
@@ -1,0 +1,24 @@
+<!--
+STRICTLY A SOCIAL MEDIA PLATFORM
+Intellectual Property & Artistic Inspiration
+Legal & Ethical Safeguards
+-->
+# UI Backend Sync Toggle
+
+`ui.py` now supports an optional connection to the real backend. By default,
+it uses local stubs to preserve existing behaviour.
+
+Enable the backend by setting an environment variable or passing a CLI flag:
+
+```bash
+USE_REAL_BACKEND=1 streamlit run ui.py
+# or
+streamlit run ui.py -- --real-backend
+# start script examples
+USE_REAL_BACKEND=1 ./start.sh
+./start.sh --real-backend
+```
+
+Call the `use_backend()` helper within `ui.py` to check whether the real
+backend is active. When enabled, the module imports functions from
+`superNova_2177`.

--- a/launch_ui.sh
+++ b/launch_ui.sh
@@ -2,5 +2,5 @@
 # STRICTLY A SOCIAL MEDIA PLATFORM
 # Intellectual Property & Artistic Inspiration
 # Legal & Ethical Safeguards
-streamlit run ui.py
+streamlit run ui.py -- "$@"
 

--- a/rfcs/001-gui-integration/README.md
+++ b/rfcs/001-gui-integration/README.md
@@ -11,4 +11,4 @@ Introduce a `ui.py` module built with Streamlit that exposes the existing `valid
 - Build a custom React or Django front‑end instead of Streamlit.
 
 ## Impact
-A lightweight GUI makes the validation pipeline more accessible and provides a starting point for future web-based features. Deployment can be as easy as running `streamlit run ui.py` on a server or container.
+A lightweight GUI makes the validation pipeline more accessible and provides a starting point for future web-based features. Deployment can be as easy as running `streamlit run ui.py` (use `-- --real-backend` or set `USE_REAL_BACKEND=1` to sync with the backend) on a server or container.

--- a/start.sh
+++ b/start.sh
@@ -15,8 +15,10 @@ fi
 # to override this value.
 PORT="${STREAMLIT_PORT:-${PORT:-8888}}"
 
-echo "🚀 Launching Streamlit UI: $UI_FILE on port $PORT"
-streamlit run "$UI_FILE" \
-  --server.headless true \
-  --server.address 0.0.0.0 \
-  --server.port "$PORT"
+  echo "🚀 Launching Streamlit UI: $UI_FILE on port $PORT"
+  # Pass through any additional args (e.g. --real-backend)
+  streamlit run "$UI_FILE" \
+    --server.headless true \
+    --server.address 0.0.0.0 \
+    --server.port "$PORT" \
+    -- "$@"

--- a/ui.py
+++ b/ui.py
@@ -9,9 +9,44 @@ import streamlit as st
 import importlib.util
 import numpy as np  # For random low stats
 import warnings
+import os
 
 # Suppress potential deprecation warnings
 warnings.filterwarnings("ignore", category=UserWarning)
+
+# ---------------------------------------------------------------------------
+# Backend toggle
+# ---------------------------------------------------------------------------
+_USE_REAL_BACKEND = False
+_backend_module = None
+
+
+def _init_backend_toggle() -> None:
+    """Initialize backend usage from env vars or CLI flags."""
+    global _USE_REAL_BACKEND, _backend_module
+
+    env_flag = os.getenv("USE_REAL_BACKEND", "0").lower() in {"1", "true", "yes"}
+    cli_flags = {"--real-backend", "--use-real-backend"}
+    cli_flag = any(flag in sys.argv for flag in cli_flags)
+    if cli_flag:
+        sys.argv = [arg for arg in sys.argv if arg not in cli_flags]
+
+    _USE_REAL_BACKEND = env_flag or cli_flag
+    if _USE_REAL_BACKEND:
+        try:
+            import superNova_2177 as _backend_module  # noqa: F401
+        except Exception as e:  # pragma: no cover - import failure path
+            warnings.warn(f"Real backend requested but not available: {e}")
+            _USE_REAL_BACKEND = False
+            _backend_module = None
+
+
+def use_backend() -> bool:
+    """Return True when the real backend should be used."""
+    return _USE_REAL_BACKEND
+
+
+_init_backend_toggle()
 
 # Path for Cloud/local
 sys.path.insert(0, str(Path(__file__).parent / "mount/src")) if Path(__file__).parent.joinpath("mount/src").exists() else sys.path.insert(0, str(Path(__file__).parent))


### PR DESCRIPTION
## Summary
- Allow the UI to toggle connection to the real backend through a `USE_REAL_BACKEND` env var or `--real-backend` CLI flag and expose `use_backend()` helper.
- Forward CLI args in launcher scripts and document the backend toggle with examples.

## Testing
- `pytest` *(fails: AttributeError and KeyError in UI-related tests)*

------
https://chatgpt.com/codex/tasks/task_e_689151a6fb5c8320abde106b5353b961