### PR TITLE
Add signup adapter and tests

### DIFF
--- a/signup_adapter.py
+++ b/signup_adapter.py
@@ -1,0 +1,41 @@
+import os
+from typing import Tuple
+
+OFFLINE_MODE = os.getenv("OFFLINE_MODE", "0") == "1"
+
+# simple in-memory store for stubbed mode
+_stub_users: list[dict] = []
+
+
+def register_user(username: str, email: str, password: str) -> Tuple[bool, str]:
+    """Register a user against the backend or an in-memory stub.
+
+    Returns a tuple ``(success, message)`` where ``success`` indicates whether
+    the registration succeeded. ``message`` contains either ``"ok"`` or a
+    human-readable error description.
+    """
+    if OFFLINE_MODE:
+        if any(u["username"] == username or u["email"] == email for u in _stub_users):
+            return False, "Username or email already exists"
+        _stub_users.append({"username": username, "email": email, "password": password})
+        return True, "ok"
+    else:
+        from fastapi import HTTPException
+        from superNova_2177 import HarmonizerCreate, SessionLocal, register_harmonizer
+
+        try:
+            with SessionLocal() as db:
+                user = HarmonizerCreate(username=username, email=email, password=password)
+                register_harmonizer(user, db)
+            return True, "ok"
+        except HTTPException as exc:  # duplicate or other HTTP errors
+            if exc.status_code == 400:
+                return False, exc.detail
+            return False, "Registration failed"
+        except Exception as exc:  # pragma: no cover - unexpected failures
+            return False, str(exc)
+
+
+def reset_stub() -> None:
+    """Clear stubbed users (testing helper)."""
+    _stub_users.clear()

--- a/tests/test_signup_adapter.py
+++ b/tests/test_signup_adapter.py
@@ -1,0 +1,47 @@
+import importlib
+from pathlib import Path
+import sys
+
+root = Path(__file__).resolve().parents[1]
+if str(root) not in sys.path:
+    sys.path.insert(0, str(root))
+
+
+def test_stub_signup(monkeypatch):
+    monkeypatch.setenv("OFFLINE_MODE", "1")
+    import signup_adapter
+    importlib.reload(signup_adapter)
+    signup_adapter.reset_stub()
+
+    ok, _ = signup_adapter.register_user("alice", "a@example.com", "password123")
+    assert ok
+    ok, msg = signup_adapter.register_user("alice", "b@example.com", "password123")
+    assert not ok and "exists" in msg.lower()
+    ok, msg = signup_adapter.register_user("bob", "a@example.com", "password123")
+    assert not ok and "exists" in msg.lower()
+
+
+def test_backend_signup(tmp_path, monkeypatch):
+    monkeypatch.setenv("OFFLINE_MODE", "0")
+    monkeypatch.setenv("DB_MODE", "central")
+    db_path = tmp_path / "test.db"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+    monkeypatch.setenv("SECRET_KEY", "testsecret")
+
+    import db_models
+    import superNova_2177
+    import signup_adapter
+
+    importlib.reload(db_models)
+    importlib.reload(superNova_2177)
+    superNova_2177.create_database()
+    superNova_2177.Base.metadata.drop_all(bind=superNova_2177.engine)
+    superNova_2177.Base.metadata.create_all(bind=superNova_2177.engine)
+    importlib.reload(signup_adapter)
+
+    ok, _ = signup_adapter.register_user("carol", "c@example.com", "password123")
+    assert ok
+    ok, msg = signup_adapter.register_user("carol", "d@example.com", "password123")
+    assert not ok and "exists" in msg.lower()
+    ok, msg = signup_adapter.register_user("dave", "c@example.com", "password123")
+    assert not ok and "exists" in msg.lower()

--- a/ui.py
+++ b/ui.py
@@ -9,6 +9,7 @@ import streamlit as st
 import importlib.util
 import numpy as np  # For random low stats
 import warnings
+from signup_adapter import register_user
 
 # Suppress potential deprecation warnings
 warnings.filterwarnings("ignore", category=UserWarning)
@@ -252,6 +253,20 @@ def main() -> None:
             st.session_state.current_page = "settings"
             st.rerun()
         theme_selector()
+
+        st.divider()
+        st.subheader("Sign up")
+        with st.form("signup_form"):
+            new_user = st.text_input("Username")
+            new_email = st.text_input("Email")
+            new_pass = st.text_input("Password", type="password")
+            submitted = st.form_submit_button("Create account")
+        if submitted:
+            ok, msg = register_user(new_user, new_email, new_pass)
+            if ok:
+                st.success("Account created")
+            else:
+                st.error(msg)
 
     # Main content area
     with st.container():


### PR DESCRIPTION
## Summary
- add signup sidebar form in `ui.py`
- implement signup adapter that handles offline mode or delegates to backend registration
- add unit tests covering stub and backend signup

## Testing
- `pytest tests/test_signup_adapter.py -q --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_e_689151b3ba288320a98fe012363b03e9