### PR TITLE
Add system status page with backend adapter

### DIFF
--- a/pages/system_status.py
+++ b/pages/system_status.py
@@ -1,0 +1,20 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+"""Wrapper exposing the system status page to Streamlit."""
+
+from __future__ import annotations
+
+from transcendental_resonance_frontend.pages import status_page as real_page
+
+
+def main() -> None:
+    real_page.main()
+
+
+def render() -> None:
+    real_page.main()
+
+
+if __name__ == "__main__":
+    main()

--- a/system_status_adapter.py
+++ b/system_status_adapter.py
@@ -1,0 +1,29 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+"""Adapter for retrieving system status metrics from the backend."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, Optional
+
+import requests
+
+BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:8000")
+OFFLINE_MODE = os.getenv("OFFLINE_MODE", "0") == "1"
+
+
+def get_status() -> Optional[Dict[str, Any]]:
+    """Fetch system status data from the backend API.
+
+    Returns ``None`` if offline mode is enabled or the request fails.
+    """
+    if OFFLINE_MODE:
+        return None
+    try:
+        resp = requests.get(f"{BACKEND_URL}/status", timeout=5)
+        resp.raise_for_status()
+        return resp.json()
+    except Exception:
+        return None

--- a/tests/test_system_status_page.py
+++ b/tests/test_system_status_page.py
@@ -1,0 +1,53 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("streamlit")
+pytestmark = pytest.mark.requires_streamlit
+
+root = Path(__file__).resolve().parents[1]
+if str(root) not in sys.path:
+    sys.path.insert(0, str(root))
+
+import transcendental_resonance_frontend.pages.status_page as status_page  # noqa: E402
+
+
+def test_status_page_placeholders_when_disabled(monkeypatch):
+    metrics = []
+    dummy_st = types.SimpleNamespace(
+        toggle=lambda *a, **k: False,
+        metric=lambda label, value: metrics.append((label, value)),
+        info=lambda *a, **k: None,
+    )
+    monkeypatch.setattr(status_page, "st", dummy_st)
+    status_page.main()
+    assert ("Harmonizers", "N/A") in metrics
+    assert ("VibeNodes", "N/A") in metrics
+    assert ("Entropy", "N/A") in metrics
+
+
+def test_status_page_shows_metrics(monkeypatch):
+    metrics = []
+    dummy_st = types.SimpleNamespace(
+        toggle=lambda *a, **k: True,
+        metric=lambda label, value: metrics.append((label, value)),
+        info=lambda *a, **k: None,
+    )
+    monkeypatch.setattr(status_page, "st", dummy_st)
+    sample = {
+        "metrics": {
+            "total_harmonizers": 3,
+            "total_vibenodes": 5,
+            "current_system_entropy": 0.42,
+        }
+    }
+    monkeypatch.setattr(status_page, "get_status", lambda: sample)
+    status_page.main()
+    assert ("Harmonizers", 3) in metrics
+    assert ("VibeNodes", 5) in metrics
+    assert ("Entropy", 0.42) in metrics


### PR DESCRIPTION
## Summary
- add adapter to fetch system status metrics from backend
- expose Streamlit system status page with backend toggle and placeholders
- cover both backend-enabled and disabled modes with tests

## Testing
- `pre-commit run --files system_status_adapter.py transcendental_resonance_frontend/pages/status_page.py pages/system_status.py tests/test_system_status_page.py`
- `pytest tests/test_system_status_page.py`
- `PYTHONPATH=. pytest tests/test_system_status_page.py tests/test_pages_unique.py` *(fails: ModuleNotFoundError: No module named 'utils.paths')*


------
https://chatgpt.com/codex/tasks/task_e_689151bf8fc883209386fa094f599d65