### PR TITLE
Add backend toggle for UI

### DIFF
--- a/docs/ui_backend_sync.md
+++ b/docs/ui_backend_sync.md
@@ -1,0 +1,42 @@
+# UI Backend Sync Toggle
+
+The Streamlit UI can connect to either a mock backend or the real service. By
+default the UI uses the mocked behavior. A toggle allows developers to enable
+integration with the real backend when desired.
+
+## Environment Variable
+
+Enable the real backend via an environment variable:
+
+```bash
+export USE_REAL_BACKEND=1
+streamlit run ui.py
+```
+
+Set the variable to `0` or omit it to keep the mock backend.
+
+## Command Line Flags
+
+The toggle can also be controlled with command line flags. CLI options override
+the environment variable.
+
+```bash
+# Enable the real backend
+streamlit run ui.py -- --use-backend
+
+# Explicitly disable it
+streamlit run ui.py -- --no-backend
+```
+
+## Checking in Code
+
+Use the helper to check the toggle inside your application logic:
+
+```python
+from ui import use_real_backend
+
+if use_real_backend():
+    connect_to_backend()
+else:
+    use_stub()
+```

--- a/tests/test_backend_toggle.py
+++ b/tests/test_backend_toggle.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+import pytest
+
+pytest.importorskip("streamlit")
+
+root = Path(__file__).resolve().parents[1]
+if str(root) not in sys.path:
+    sys.path.insert(0, str(root))
+
+import ui
+
+
+def test_default_false():
+    assert ui._determine_backend([], {}) is False
+
+
+def test_env_var(monkeypatch):
+    assert ui._determine_backend([], {"USE_REAL_BACKEND": "1"}) is True
+    assert ui._determine_backend([], {"USE_REAL_BACKEND": "0"}) is False
+
+
+def test_cli_flags_override_env():
+    assert ui._determine_backend(["--use-backend"], {}) is True
+    # CLI flag should override env var
+    assert ui._determine_backend(["--no-backend"], {"USE_REAL_BACKEND": "1"}) is False


### PR DESCRIPTION
## Summary
- add helper to toggle a real backend via env var or CLI flags
- document USE_REAL_BACKEND toggle with examples
- test parsing of toggle from CLI and environment

## Testing
- `pytest tests/test_backend_toggle.py -q`
- `pytest -q` *(fails: AttributeError: module 'ui' has no attribute 'build_pages', KeyError: '_theme', and others)*

------
https://chatgpt.com/codex/tasks/task_e_689151c30d448320988516ea859b9287