### PR TITLE
Add backend search adapter and UI integration

### DIFF
--- a/tests/test_ui_search.py
+++ b/tests/test_ui_search.py
@@ -1,0 +1,54 @@
+import types
+import sys
+from pathlib import Path
+
+import pytest
+
+root = Path(__file__).resolve().parents[1]
+if str(root) not in sys.path:
+    sys.path.insert(0, str(root))
+
+import ui_adapters
+import superNova_2177 as sn
+
+
+class DummySession:
+    def __enter__(self):
+        return "db"
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+
+def test_search_users_adapter_stub(monkeypatch):
+    monkeypatch.setattr(ui_adapters, "use_real_backend", lambda: False)
+    res = ui_adapters.search_users_adapter("al")
+    assert res == ui_adapters.DUMMY_USERS
+
+
+def test_search_users_adapter_real_backend(monkeypatch):
+    monkeypatch.setattr(ui_adapters, "use_real_backend", lambda: True)
+    monkeypatch.setattr(sn, "SessionLocal", lambda: DummySession())
+
+    def fake_search(q, db):
+        assert q == "al"
+        assert db == "db"
+        return [{"username": "alice"}, {"username": "albert"}]
+
+    monkeypatch.setattr(sn, "search_users", fake_search)
+    res = ui_adapters.search_users_adapter("al")
+    assert res == ["alice", "albert"]
+
+
+def test_search_users_adapter_failure(monkeypatch, caplog):
+    monkeypatch.setattr(ui_adapters, "use_real_backend", lambda: True)
+    monkeypatch.setattr(sn, "SessionLocal", lambda: DummySession())
+
+    def bad_search(q, db):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(sn, "search_users", bad_search)
+    with caplog.at_level("ERROR"):
+        res = ui_adapters.search_users_adapter("al")
+    assert res == [ui_adapters.ERROR_MESSAGE]
+    assert any("search_users_adapter failed" in r.message for r in caplog.records)

--- a/ui.py
+++ b/ui.py
@@ -12,6 +12,7 @@ import warnings
 
 # Suppress potential deprecation warnings
 warnings.filterwarnings("ignore", category=UserWarning)
+from ui_adapters import search_users_adapter
 
 # Path for Cloud/local
 sys.path.insert(0, str(Path(__file__).parent / "mount/src")) if Path(__file__).parent.joinpath("mount/src").exists() else sys.path.insert(0, str(Path(__file__).parent))
@@ -257,15 +258,12 @@ def main() -> None:
     with st.container():
         if st.session_state.search_bar:
             st.header(f"Searching for: \"{st.session_state.search_bar}\"")
-            st.info("This is where your database search results would appear. Connect this to your backend.")
-            st.write("---")
-            st.subheader("Example Post Result")
-            st.write("**User:** taha_gungor")
-            st.write("This is a sample post that matches the search query. #streamlit #search")
-            st.write("---")
-            st.subheader("Example Profile Result")
-            st.write("**Profile:** artist_dev")
-            st.write("Software developer and digital artist.")
+            usernames = search_users_adapter(st.session_state.search_bar)
+            if usernames:
+                for name in usernames:
+                    st.write(name)
+            else:
+                st.info("No users found.")
         else:
             load_page(st.session_state.current_page)
 

--- a/ui_adapters.py
+++ b/ui_adapters.py
@@ -1,0 +1,30 @@
+import os
+import logging
+from typing import List
+
+DUMMY_USERS: List[str] = ["taha_gungor", "artist_dev"]
+ERROR_MESSAGE = "Unable to fetch users"
+
+logger = logging.getLogger(__name__)
+
+def use_real_backend() -> bool:
+    """Return True if the real backend should be used."""
+    return os.getenv("USE_REAL_BACKEND", "").lower() in {"1", "true", "yes"}
+
+
+def search_users_adapter(query: str) -> List[str]:
+    """Search for users by ``query`` using real backend when available.
+
+    Falls back to a static dummy list when ``use_real_backend`` is ``False``.
+    On failure, logs the error and returns a friendly message.
+    """
+    if not use_real_backend():
+        return DUMMY_USERS
+    try:
+        import superNova_2177 as sn  # Local import to avoid heavy cost when unused
+        with sn.SessionLocal() as db:
+            results = sn.search_users(query, db)
+        return [r.get("username", "") for r in results]
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.exception("search_users_adapter failed: %s", exc)
+        return [ERROR_MESSAGE]


### PR DESCRIPTION
## Summary
- add `ui_adapters.search_users_adapter` to toggle between dummy and real backend search
- call adapter from `ui.py` to render usernames for search queries
- cover stub, real backend, and error cases in `tests/test_ui_search.py`

## Testing
- `pytest tests/test_ui_search.py`

------
https://chatgpt.com/codex/tasks/task_e_689151c4f59c8320921b77df69c9c582