### PR TITLE
Add follow adapter and UI follow button

### DIFF
--- a/tests/test_ui_follow.py
+++ b/tests/test_ui_follow.py
@@ -1,0 +1,45 @@
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+root = Path(__file__).resolve().parents[1]
+if str(root) not in sys.path:
+    sys.path.insert(0, str(root))
+
+import ui_adapters
+
+
+def test_follow_adapter_stub_toggle(monkeypatch):
+    # Force stub mode by disabling backend function
+    monkeypatch.setattr(ui_adapters, "toggle_follow", None)
+    ui_adapters._STUB_FOLLOWING.clear()
+
+    ok, msg = ui_adapters.follow_adapter("alice")
+    assert ok and msg == "Followed"
+
+    ok, msg = ui_adapters.follow_adapter("alice")
+    assert ok and msg == "Unfollowed"
+
+
+def test_follow_adapter_backend_success(monkeypatch):
+    async def fake_toggle(username: str):
+        return {"message": "Followed"}
+
+    monkeypatch.setattr(ui_adapters, "toggle_follow", fake_toggle)
+    ok, msg = ui_adapters.follow_adapter("bob")
+    assert ok and msg == "Followed"
+
+
+def test_follow_adapter_backend_error(monkeypatch, caplog):
+    async def bad_toggle(username: str):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ui_adapters, "toggle_follow", bad_toggle)
+    with caplog.at_level("ERROR"):
+        ok, msg = ui_adapters.follow_adapter("bob")
+    assert not ok
+    assert "boom" in msg
+    assert any("failed" in record.message.lower() for record in caplog.records)
+

--- a/ui.py
+++ b/ui.py
@@ -9,6 +9,7 @@ import streamlit as st
 import importlib.util
 import numpy as np  # For random low stats
 import warnings
+from ui_adapters import follow_adapter
 
 # Suppress potential deprecation warnings
 warnings.filterwarnings("ignore", category=UserWarning)
@@ -257,15 +258,22 @@ def main() -> None:
     with st.container():
         if st.session_state.search_bar:
             st.header(f"Searching for: \"{st.session_state.search_bar}\"")
-            st.info("This is where your database search results would appear. Connect this to your backend.")
+            st.info(
+                "This is where your database search results would appear. Connect this to your backend."
+            )
             st.write("---")
             st.subheader("Example Post Result")
             st.write("**User:** taha_gungor")
-            st.write("This is a sample post that matches the search query. #streamlit #search")
+            st.write(
+                "This is a sample post that matches the search query. #streamlit #search"
+            )
             st.write("---")
             st.subheader("Example Profile Result")
             st.write("**Profile:** artist_dev")
             st.write("Software developer and digital artist.")
+            if st.button("Follow/Unfollow", key="search_follow_artist_dev"):
+                success, msg = follow_adapter("artist_dev")
+                (st.success if success else st.error)(msg)
         else:
             load_page(st.session_state.current_page)
 

--- a/ui_adapters.py
+++ b/ui_adapters.py
@@ -1,0 +1,76 @@
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+"""Adapters bridging UI events to backend services.
+
+Currently provides :func:`follow_adapter` which mirrors the toggle style of
+search related adapters.  The function attempts to use the real backend via the
+``utils.api`` module but falls back to a lightweight in-memory stub when the
+backend is unavailable.  All outcomes are logged and a concise status message is
+returned for display in the UI.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Tuple, Dict, Any
+
+try:  # pragma: no cover - optional backend
+    from utils.api import toggle_follow  # type: ignore
+except Exception:  # pragma: no cover - backend not available
+    toggle_follow = None  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+# Simple in-memory follow set used when ``toggle_follow`` is unavailable.
+_STUB_FOLLOWING: set[str] = set()
+
+
+def _run_async(coro):
+    """Execute ``coro`` whether or not an event loop is running."""
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+    else:
+        if loop.is_running():
+            return asyncio.run_coroutine_threadsafe(coro, loop).result()
+        return loop.run_until_complete(coro)
+
+
+def follow_adapter(target_username: str) -> Tuple[bool, str]:
+    """Toggle following ``target_username``.
+
+    Returns a ``(success, message)`` tuple. Success is ``True`` when the follow
+    state was toggled either via the backend or the local stub. When the backend
+    is unavailable a lightweight in-memory toggle is used instead.
+    """
+
+    if not target_username:
+        logger.warning("follow_adapter called without a username")
+        return False, "No username provided"
+
+    if toggle_follow is None:
+        # Fallback stub path
+        if target_username in _STUB_FOLLOWING:
+            _STUB_FOLLOWING.remove(target_username)
+            message = "Unfollowed"
+        else:
+            _STUB_FOLLOWING.add(target_username)
+            message = "Followed"
+        logger.info("Stub follow toggle for %s: %s", target_username, message)
+        return True, message
+
+    try:
+        resp: Dict[str, Any] | None = _run_async(toggle_follow(target_username))
+        message = (resp or {}).get("message", "Updated")
+        logger.info("Follow toggle for %s succeeded: %s", target_username, message)
+        return True, message
+    except Exception as exc:  # pragma: no cover - runtime errors
+        logger.exception("Follow toggle failed for %s", target_username)
+        return False, f"Follow failed: {exc}"
+
+
+__all__ = ["follow_adapter"]
+


### PR DESCRIPTION
## Summary
- add `follow_adapter` to bridge UI follow actions to backend or stub, with logging
- show follow/unfollow button in profile search results using the adapter
- cover adapter behavior with unit tests for stub, backend, and error paths

## Testing
- `pytest tests/test_ui_follow.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689151c6330483209fe41141db872f19