### PR TITLE
Use top-level pages dir

### DIFF
--- a/frontend/ui_layout.py
+++ b/frontend/ui_layout.py
@@ -127,7 +127,7 @@ try:
     PAGES_DIR: Path = _paths.PAGES_DIR
 except Exception:  # pragma: no cover
     ROOT_DIR = Path(__file__).resolve().parents[1]
-    PAGES_DIR = ROOT_DIR / "transcendental_resonance_frontend" / "pages"
+    PAGES_DIR = ROOT_DIR / "pages"
 
 # optional pretty-sidebar package
 try:
@@ -490,7 +490,6 @@ def render_bottom_tab_bar(position: str = "fixed") -> None:
         )
     except Exception:
         return
-
 
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/modern_ui_components.py
+++ b/modern_ui_components.py
@@ -19,7 +19,7 @@ try:
     get_pages_dir = _paths.get_pages_dir
 except Exception:  # pragma: no cover – fallback for isolated execution
     ROOT_DIR = Path(__file__).resolve().parents[1]  # repo root
-    PAGES_DIR = ROOT_DIR / "transcendental_resonance_frontend" / "pages"
+    PAGES_DIR = ROOT_DIR / "pages"
 
     def get_pages_dir() -> Path:
         return PAGES_DIR
@@ -181,7 +181,6 @@ def render_modern_layout() -> None:
         """,
         unsafe_allow_html=True,
     )
-
 
 
 def render_modern_header(title: str) -> None:
@@ -393,7 +392,6 @@ def render_stats_section(stats: dict) -> None:
         accent = theme.get_accent_color()
     except Exception:
         accent = theme.LIGHT_THEME.accent  # Safe fallback to known value
-
 
     try:
         st.markdown(

--- a/transcendental_resonance_frontend/src/utils/page_registry.py
+++ b/transcendental_resonance_frontend/src/utils/page_registry.py
@@ -9,7 +9,6 @@ from pathlib import Path
 import logging
 import os
 import sys
-import streamlit as st
 from disclaimers import (
     STRICTLY_SOCIAL_MEDIA,
     INTELLECTUAL_PROPERTY_ARTISTIC_INSPIRATION,
@@ -18,7 +17,6 @@ from disclaimers import (
 
 logger = logging.getLogger(__name__)
 logger.propagate = False
-
 
 
 def clean_duplicate_pages(pages_dir: Path) -> list[str]:
@@ -103,11 +101,13 @@ def ensure_pages(pages: dict[str, str], pages_dir: Path) -> None:
             )
             logger.info("Created placeholder page module %s", file_path.name)
 
+
 try:
     from utils.paths import get_pages_dir as _get_pages_dir
 except Exception:  # pragma: no cover - fallback when utils.paths is missing
+
     def _get_pages_dir() -> Path:
-        return Path(__file__).resolve().parents[2] / "pages"
+        return Path(__file__).resolve().parents[3] / "pages"
 
 
 def get_pages_dir() -> Path:
@@ -116,4 +116,3 @@ def get_pages_dir() -> Path:
 
 
 __all__ = ["ensure_pages", "get_pages_dir", "clean_duplicate_pages"]
-

--- a/utils/paths.py
+++ b/utils/paths.py
@@ -11,7 +11,7 @@ from pathlib import Path
 ROOT_DIR = Path(__file__).resolve().parent.parent
 
 # Default directory where Streamlit pages are located
-PAGES_DIR = ROOT_DIR / "transcendental_resonance_frontend" / "pages"
+PAGES_DIR = ROOT_DIR / "pages"
 
 
 def get_pages_dir() -> Path:


### PR DESCRIPTION
## Summary
- point PAGES_DIR to repository `pages/`
- adjust fallback logic to use top-level pages directory
- align page registry with new path

## Testing
- `pre-commit run --files frontend/ui_layout.py modern_ui_components.py transcendental_resonance_frontend/src/utils/page_registry.py utils/paths.py`
- `pytest` *(fails: AttributeError: module 'ui' has no attribute 'PAGES', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68941c26e0c88320b12493ebe3d56faa