### PR TITLE
feat: add backend toggle and shared layout

### DIFF
--- a/streamlit_helpers.py
+++ b/streamlit_helpers.py
@@ -17,12 +17,15 @@ from frontend.theme import set_theme, inject_global_styles
 def sanitize_text(x: Any) -> str:
     return html.escape(str(x), quote=False) if x is not None else ""
 
+
 @contextmanager
 def safe_container(container=None):
     yield container or st
 
+
 def header(txt: str):
     st.markdown(f"<h2>{sanitize_text(txt)}</h2>", unsafe_allow_html=True)
+
 
 def alert(msg: str, type: Literal["info", "warning", "error"] = "info"):
     getattr(st, type, st.info)(msg)
@@ -40,11 +43,17 @@ def theme_toggle(label: str = "Dark mode", key_suffix: str = "default") -> str:
         st.rerun()
     return new
 
+
 def theme_selector(label: str = "Theme", key_suffix: str = "legacy") -> str:
     mapping = {"Light": "light", "Dark": "dark"}
     rev = {v: k for k, v in mapping.items()}
     cur = rev.get(st.session_state.get("theme", "light"), "Light")
-    choice = st.selectbox(label, list(mapping), index=list(mapping).index(cur), key=f"theme_sel_{key_suffix}")
+    choice = st.selectbox(
+        label,
+        list(mapping),
+        index=list(mapping).index(cur),
+        key=f"theme_sel_{key_suffix}",
+    )
     if mapping[choice] != st.session_state.get("theme", "light"):
         st.session_state["theme"] = mapping[choice]
         set_theme(mapping[choice])
@@ -52,21 +61,49 @@ def theme_selector(label: str = "Theme", key_suffix: str = "legacy") -> str:
     return mapping[choice]
 
 
+# Shared layout components
+def shared_header(title: str = "superNova_2177") -> None:
+    """Render a consistent application header."""
+    st.markdown(
+        f"<div class='app-header'><h1>{sanitize_text(title)}</h1></div>",
+        unsafe_allow_html=True,
+    )
+
+
+def shared_footer(text: str = "© 2024 superNova_2177") -> None:
+    """Render a consistent application footer."""
+    st.markdown(
+        (
+            "<div class='app-footer' "
+            "style='text-align:center; padding-top:1rem; color:#888;'>"
+            f"{sanitize_text(text)}</div>"
+        ),
+        unsafe_allow_html=True,
+    )
+
+
 # Legacy
 def get_active_user() -> str | None:
     return st.session_state.get("active_user")
 
+
 def ensure_active_user():
     st.session_state.setdefault("active_user", "guest")
+
 
 @contextmanager
 def centered_container(**kwargs):
     with st.container(**kwargs) as c:
-        st.markdown("<style>[data-testid='column']{margin-left:auto!important;margin-right:auto!important;}</style>", unsafe_allow_html=True)
+        st.markdown(
+            "<style>[data-testid='column']{margin-left:auto!important;margin-right:auto!important;}</style>",
+            unsafe_allow_html=True,
+        )
         yield c
+
 
 def render_post_card(*args, **kwargs):
     st.warning("Post card placeholder.")
+
 
 def render_instagram_grid(*args, **kwargs):
     st.info("Instagram grid placeholder.")
@@ -85,12 +122,22 @@ def _normalise_conversations_state():
                 upgraded[user] = {"messages": msgs, "preview": preview}
         st.session_state["conversations"] = upgraded
 
+
 _normalise_conversations_state()
 inject_global_styles()  # Early
 
 __all__ = [
-    "sanitize_text", "safe_container", "alert", "header",
-    "theme_toggle", "theme_selector", "get_active_user",
-    "centered_container", "render_post_card", "render_instagram_grid",
+    "sanitize_text",
+    "safe_container",
+    "alert",
+    "header",
+    "theme_toggle",
+    "theme_selector",
+    "get_active_user",
+    "centered_container",
+    "render_post_card",
+    "render_instagram_grid",
     "ensure_active_user",
+    "shared_header",
+    "shared_footer",
 ]

--- a/transcendental_resonance_frontend/src/quantum_futures.py
+++ b/transcendental_resonance_frontend/src/quantum_futures.py
@@ -13,8 +13,10 @@ from __future__ import annotations
 import random
 from typing import Any, Dict, List
 
+import streamlit as st
+
 from external_services.llm_client import LLMClient, get_speculative_futures
-from external_services.vision_client import VisionClient
+from external_services.vision_client import VisionClient, analyze_timeline
 
 # Satirical disclaimer appended to all speculative output
 DISCLAIMER = "This is a satirical simulation, not advice or prediction."
@@ -32,6 +34,7 @@ def _entropy_tag() -> float:
     return random.random()  # nosec B311
 
 
+@st.cache_data(show_spinner=False)
 async def generate_speculative_futures(
     node: Dict[str, Any], num_variants: int = 3
 ) -> List[Dict[str, str]]:
@@ -46,6 +49,7 @@ async def generate_speculative_futures(
     return futures
 
 
+@st.cache_data(show_spinner=False)
 async def generate_speculative_payload(description: str) -> List[Dict[str, str]]:
     """Return text, video, and vision analysis pairs with a disclaimer."""
 
@@ -69,6 +73,7 @@ async def generate_speculative_payload(description: str) -> List[Dict[str, str]]
             }
         )
     return results
+
 
 def quantum_video_stub(*_args, **_kwargs) -> None:
     """Placeholder for future WebGL/AI-video integration."""


### PR DESCRIPTION
## Summary
- add `shared_header` and `shared_footer` helpers for consistent layout
- expose sidebar toggle to switch between mock and real backend
- cache speculative futures generation to avoid repeated heavy calls

## Testing
- `pre-commit run --files streamlit_helpers.py ui.py transcendental_resonance_frontend/src/quantum_futures.py`
- `pytest` *(fails: FAILED tests/test_pages_unique.py::test_pages_labels_generated_from_slugs, FAILED tests/test_render_post_card.py::test_render_post_card_uses_ui_components, FAILED tests/test_render_post_card.py::test_render_post_card_plain_streamlit, FAILED tests/test_theme.py::test_theme_application_and_idempotent_styles, FAILED tests/test_ui_database.py::test_ensure_database_exists_creates_table_and_default_admin, FAILED tests/test_ui_database.py::test_safe_get_user_returns_none_on_connection_error, FAILED tests/test_ui_pages.py::test_unknown_page_triggers_fallback, FAILED tests/test_ui_pages.py::test_main_defaults_to_validation, FAILED tests/test_ui_pages.py::test_fallback_rendered_once, FAILED tests/test_ui_search.py::test_search_users_adapter_stub, FAILED tests/test_ui_search.py::test_search_users_adapter_real_backend, FAILED tests/test_ui_search.py::test_search_users_adapter_failure, FAILED tests/test_user_search.py::test_ui_adapter_backend_on, FAILED tests/test_user_search.py::test_ui_adapter_backend_off, FAILED transcendental_resonance_frontend/tests/test_offline_mode.py::test_generate_speculative_payload_offline, FAILED transcendental_resonance_frontend/tests/test_quantum_futures.py::test_generate_speculative_futures_length)*

------
https://chatgpt.com/codex/tasks/task_e_68941b6f2c7c832083194e53eb58c5ec